### PR TITLE
feat: shorten long agenda filter button labels

### DIFF
--- a/ietf/templates/meeting/agenda_filter.html
+++ b/ietf/templates/meeting/agenda_filter.html
@@ -69,9 +69,9 @@ Optional parameters:
                                                                     {% if button.toggled_by %}data-filter-keywords="{{ button.toggled_by|join:"," }}"{% endif %}
                                                                     data-filter-item="{{ button.keyword }}">
                                                                 {% if button.is_bof %}
-                                                                    <i>{{ button.label }}</i>
+                                                                    <i>{{ button.label|truncatewords:"3" }}</i>
                                                                 {% else %}
-                                                                    {{ button.label }}
+                                                                    {{ button.label|truncatewords:"3" }}
                                                                 {% endif %}
                                                             </button>
                                                         </div>


### PR DESCRIPTION
Sessions with long names lead to poor rendering of the agenda filter buttons on the 'customize the agenda view' page. This truncates those labels at 3 words.