### PR TITLE
fix: use same github issue URL on 500 error page as elsewhere

### DIFF
--- a/ietf/templates/500.html
+++ b/ietf/templates/500.html
@@ -19,7 +19,7 @@
     A failure report with details about what happened has been sent to the
     server administrators.  It would be helpful if you would create an issue
     providing additional information at 
-    <a href="https://github.com/ietf-tools/datatracker/issues">GitHub</a>, too.
+    <a href="https://github.com/ietf-tools/datatracker/issues/new/choose">GitHub</a>, too.
   </p>
 
 {% endblock %}


### PR DESCRIPTION
I believe this was overlooked on #3625