### PR TITLE
chore: bring docker-compose to root level

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.202.5/containers/python-3
 {
     "name": "IETF Datatracker",
-    "dockerComposeFile": ["../docker/docker-compose.yml", "docker-compose.extend.yml"],
+    "dockerComposeFile": ["../docker-compose.yml", "docker-compose.extend.yml"],
     "service": "app",
     "workspaceFolder": "/root/src",
     "shutdownAction": "stopCompose",

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -6,7 +6,7 @@ services:
             EDITOR_VSCODE: 1
             DJANGO_SETTINGS_MODULE: settings_local_sqlitetest
         volumes:
-            - ..:/root/src
+            - .:/root/src
             - /root/src/node_modules
         # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
         network_mode: service:db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
     app:
         build:
-            context: ..
+            context: .
             dockerfile: docker/app.Dockerfile
             args:
                 # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6

--- a/docker/cleanall
+++ b/docker/cleanall
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+cd ..
 echo "Shutting down any instance still running and purge images..."
 docker-compose down -v --rmi all
 echo "Purging dangling images..."
 docker image prune
+cd docker
 echo "Done!"

--- a/docker/cleandb
+++ b/docker/cleandb
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 echo "Shutting down any instance still running..."
+cd ..
 docker-compose down -v
 echo "Rebuilding the DB image..."
 docker-compose pull db
 docker-compose build --no-cache db
+cd docker
 echo "Done!"

--- a/docker/docker-compose.extend.yml
+++ b/docker/docker-compose.extend.yml
@@ -5,7 +5,7 @@ services:
         ports:
             - '8000:8000'
         volumes:
-            - ..:/root/src
+            - .:/root/src
             - /root/src/node_modules
     db:
         ports:

--- a/docker/run
+++ b/docker/run
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-docker-compose -f docker-compose.yml -f docker-compose.extend.yml up -d
+cd ..
+docker-compose -f docker-compose.yml -f docker/docker-compose.extend.yml up -d
 docker-compose exec app /bin/sh /docker-init.sh
 docker-compose down
+cd docker


### PR DESCRIPTION
This moves docker-compose to the root of the project, enabling the resulting containers to be named after the parent directory, instead of "docker".

All scripts `cleanall`, `cleandb` and `run` have been updated. No apparent change for the user, they are still in the same location.