### PR TITLE
chore: improve dev docker for offline + other fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "name": "IETF Datatracker",
     "dockerComposeFile": ["../docker-compose.yml", "docker-compose.extend.yml"],
     "service": "app",
-    "workspaceFolder": "/root/src",
+    "workspaceFolder": "/workspace",
     "shutdownAction": "stopCompose",
     "postCreateCommand": "/docker-init.sh",
     "containerEnv": {
@@ -69,7 +69,10 @@
 		"spmeesseman.vscode-taskexplorer",
 		"mtxr.sqltools",
 		"mtxr.sqltools-driver-mysql",
-		"mrmlnc.vscode-duplicate"
+		"mrmlnc.vscode-duplicate",
+		"eamodio.gitlens",
+		"oderwat.indent-rainbow",
+		"johnsoncodehk.volar"
 	],
     
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -6,7 +6,7 @@ services:
             EDITOR_VSCODE: 1
             DJANGO_SETTINGS_MODULE: settings_local_sqlitetest
         volumes:
-            - .:/root/src
-            - /root/src/node_modules
+            - .:/workspace
+            - /workspace/node_modules
         # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
         network_mode: service:db

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 save-exact = true
 save-prefix = ""
+fund = false
+loglevel = "warn"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
     "**/third_party/**",
     "**/vendor/**",
     "**/work/**",
-    "/root/src/bootstrap/nuget/MyGet.ps1"
+    "/workspace/bootstrap/nuget/MyGet.ps1"
   ],
   "taskExplorer.enableAnt": false,
   "taskExplorer.enableAppPublisher": false,

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -88,6 +88,8 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 ENV npm_config_loglevel warn
 # allow installing when the main user is root
 ENV npm_config_unsafe_perm true
+# disable NPM funding messages
+ENV npm_config_fund false
 
 # Set locale to en_US.UTF-8
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment && \
@@ -99,7 +101,7 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment && \
 ENV LC_ALL en_US.UTF-8
 
 # Install bower
-RUN npm install -g bower
+RUN npm install -g bower grunt-cli
 
 # Install idnits
 ADD https://raw.githubusercontent.com/ietf-tools/idnits-mirror/main/idnits /usr/local/bin/
@@ -116,10 +118,21 @@ RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 # Colorize the bash shell
 RUN sed -i 's/#force_color_prompt=/force_color_prompt=/' /root/.bashrc
 
+ADD https://raw.githubusercontent.com/eficode/wait-for/v2.1.3/wait-for /usr/local/bin/
+RUN chmod +rx /usr/local/bin/wait-for
+
 # Copy the startup file
 COPY docker/scripts/app-init.sh /docker-init.sh
 RUN sed -i 's/\r$//' /docker-init.sh && \
     chmod +x /docker-init.sh
 
-WORKDIR /root/src
+# Create workspace
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Install NPM modules
+COPY package.json package.json
+RUN npm install --no-audit
+RUN rm -f package.json package-lock.json
+
 # ENTRYPOINT [ "/docker-init.sh" ]

--- a/docker/docker-compose.extend.yml
+++ b/docker/docker-compose.extend.yml
@@ -5,8 +5,8 @@ services:
         ports:
             - '8000:8000'
         volumes:
-            - .:/root/src
-            - /root/src/node_modules
+            - .:/workspace
+            - /workspace/node_modules
     db:
         ports:
             - '3306'

--- a/docker/run
+++ b/docker/run
@@ -3,5 +3,5 @@
 cd ..
 docker-compose -f docker-compose.yml -f docker/docker-compose.extend.yml up -d
 docker-compose exec app /bin/sh /docker-init.sh
-docker-compose down
+docker-compose stop
 cd docker

--- a/docker/scripts/app-cypress.sh
+++ b/docker/scripts/app-cypress.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORKSPACEDIR="/root/src"
+WORKSPACEDIR="/workspace"
 
 pushd .
 cd $WORKSPACEDIR

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-WORKSPACEDIR="/root/src"
+WORKSPACEDIR="/workspace"
 
 service rsyslog start
 
 # Generate static assets
 
-npm install
+npm install --prefer-offline --no-audit
 echo "Building static assets... (this could take a minute or two)"
 cd bootstrap
-npm install -g grunt-cli
-npm install
+npm install -g grunt-cli --prefer-offline --no-audit
+npm install --prefer-offline --no-audit
 grunt dist
 cp -r dist/. ../ietf/static/ietf/bootstrap/
 cd ..
@@ -81,7 +81,7 @@ for sub in \
 	data/developers/www6/iesg/evaluation \
     data/developers/media/photo \
 	; do
-    dir="/root/src/$sub"
+    dir="/workspace/$sub"
     if [ ! -d "$dir"  ]; then
     	echo "Creating dir $dir"
 	    mkdir -p "$dir";
@@ -91,7 +91,7 @@ done
 # Wait for DB container
 if [ -n "$EDITOR_VSCODE" ]; then
     echo "Waiting for DB container to come online ..."
-    wget -qO- https://raw.githubusercontent.com/eficode/wait-for/v2.1.3/wait-for | sh -s -- localhost:3306 -- echo "DB ready"
+    /usr/local/bin/wait-for localhost:3306 -- echo "DB ready"
 fi
 
 # Initial checks

--- a/docker/scripts/app-win32-timezone-fix.sh
+++ b/docker/scripts/app-win32-timezone-fix.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORKSPACEDIR="/root/src"
+WORKSPACEDIR="/workspace"
 
 ICSFILES=$(/usr/bin/find $WORKSPACEDIR/vzic/zoneinfo/ -name '*.ics' -print)
 for ICSFILE in $ICSFILES


### PR DESCRIPTION
**Docker Changes**
- change docker-compose end behavior from `down` to `stop`
- set workspace directory to `/workspace` instead of `/root/src` to address issues mentioned by @jennifer-richards

**NPM Changes**
- pre-install npm modules during image build
- add `--prefer-offline` flag to npm install during container start
- disable the npm funding and auditing messages during init install

**VS Code Changes**
- make the `wait-for` script available offline instead of fetching it during vscode container start
- add gitlens, indent-rainbow and volar extensions to the default vscode config