### PR TITLE
fix: Always word-wrap person names in person_link links

### DIFF
--- a/ietf/templates/iesg/discusses.html
+++ b/ietf/templates/iesg/discusses.html
@@ -57,11 +57,11 @@
                            {% endif %}">
                     <td>{{ doc.displayname_with_link }}</td>
                     {% include "doc/search/status_columns.html" %}
-                    <td>{% person_link doc.ad nowrap=False %}</td>
+                    <td>{% person_link doc.ad %}</td>
                     <td>
                         {% for p in doc.blocking_positions %}
                             {% if p.is_old_pos %}<span class="text-muted">{% endif %}
-                            {% person_link p.balloter nowrap=False %}
+                            {% person_link p.balloter %}
                             ({% if p.discuss_time %}{{ p.discuss_time|timesince_days }} days ago{% endif %}
                             {% if doc.get_state_url != "rfc" and p.rev != doc.rev %}for -{{ p.rev }}{% endif %})
                             <br>

--- a/ietf/templates/iesg/past_documents.html
+++ b/ietf/templates/iesg/past_documents.html
@@ -46,11 +46,11 @@
                         </td>
                         <td>{{ doc.telechat }}</td>
                         {% include "doc/search/status_columns.html" %}
-                        <td>{% person_link doc.ad nowrap=False %}</td>
+                        <td>{% person_link doc.ad %}</td>
                         <td>
                             {% for p in doc.blocking_positions %}
                                 {% if p.is_old_pos %}<span class="text-muted">{% endif %}
-                                {% person_link p.balloter nowrap=False %}
+                                {% person_link p.balloter %}
                                 ({% if p.discuss_time %}{{ p.discuss_time|timesince_days }} days ago{% endif %}
                                 {% if doc.get_state_url != "rfc" and p.rev != doc.rev %}for -{{ p.rev }}{% endif %})
                                 <br>

--- a/ietf/templates/meeting/requests.html
+++ b/ietf/templates/meeting/requests.html
@@ -58,10 +58,10 @@
                             {% if session.requested_duration %}{{ session.requested_duration|stringformat:"s"|slice:"0:4" }}{% endif %}
                         </td>
                         <td>{{ session.attendees|default:"" }}</td>
-                        <td>{% person_link session.requested_by_person nowrap=False %}</td>
+                        <td>{% person_link session.requested_by_person %}</td>
                         <td>
                             {% if session.group.ad_role %}
-                                {% person_link session.group.ad_role.person nowrap=False %}
+                                {% person_link session.group.ad_role.person %}
                             {% endif %}
                         </td>
                         <td>

--- a/ietf/templates/person/person_link.html
+++ b/ietf/templates/person/person_link.html
@@ -1,5 +1,4 @@
-<span {% if class or nowrap %}class="{% if nowrap %}text-nowrap{% endif %}
-      {{ class }}"
+<span {% if class %}class=" {{ class }}"
       {% endif %}>{% if email or name %}<a {% if class %}class="text-reset"{% endif %}
            title="{% if title %}{{ title }}{% else %}Datatracker profile of {{ name }}.{% endif %}"
            {% if email %} href="{% url 'ietf.person.views.profile' email_or_name=email %}" {% else %} href="{% url 'ietf.person.views.profile' email_or_name=name %}" {% endif %}>{{ name }}</a>{% if email and with_email %} <a {% if class %}class="text-reset"{% endif %}

--- a/ietf/templates/person/person_link.html
+++ b/ietf/templates/person/person_link.html
@@ -1,4 +1,4 @@
-<span {% if class %}class=" {{ class }}"
+<span {% if class %}class="{{ class }}"
       {% endif %}>{% if email or name %}<a {% if class %}class="text-reset"{% endif %}
            title="{% if title %}{{ title }}{% else %}Datatracker profile of {{ name }}.{% endif %}"
            {% if email %} href="{% url 'ietf.person.views.profile' email_or_name=email %}" {% else %} href="{% url 'ietf.person.views.profile' email_or_name=name %}" {% endif %}>{{ name }}</a>{% if email and with_email %} <a {% if class %}class="text-reset"{% endif %}

--- a/ietf/templates/person/photo.html
+++ b/ietf/templates/person/photo.html
@@ -19,7 +19,7 @@
     {% if name or email %}</a>{% endif %}
     <div class="card-body">
         <p class="lead mb-1">
-            {% person_link person with_email=False nowrap=False %}
+            {% person_link person with_email=False %}
         </p>
         {% for role in groups %}
             <a title="{{ role.group.name }} {{ role.group.type | upper }}"


### PR DESCRIPTION
Defaulting to "text-nowrap" causes too many issues on narrow screens.