### PR TITLE
fix: remove overflow-hidden from div#content

### DIFF
--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -84,7 +84,7 @@
                         </ul>
                     </div>
                 {% endif %}
-                <div class="col overflow-hidden mx-lg-3 ietf-auto-nav" id="content">
+                <div class="col mx-lg-3 ietf-auto-nav" id="content">
                     <noscript>
                         <div class="alert alert-danger alert-ignore my-3">
                             <b>Javascript disabled?</b> Like other modern websites, the IETF Datatracker relies on Javascript.


### PR DESCRIPTION
Allows position="sticky" items to attach to the viewport instead of the #content element.

Fixes #3666