### PR TITLE
Fix for reviewer table

### DIFF
--- a/ietf/templates/group/reviewer_overview.html
+++ b/ietf/templates/group/reviewer_overview.html
@@ -93,7 +93,7 @@
                                                     {{ assignment_to_closure_days }} day{{ assignment_to_closure_days|pluralize }}
                                                 {% endif %}
                                             </td>
-                                            <td>
+                                            <td class="text-nowrap">
                                                 {{ doc_name }}
                                                 {% if reviewed_rev %}-{{ reviewed_rev }}{% endif %}
                                             </td>


### PR DESCRIPTION
This fixes the reviewer list so that document name does not span multiple lines. Fixes issue #3680.