### PR TITLE
test: scroll swap timeslots button into view before clicking

### DIFF
--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -475,6 +475,14 @@ class EditMeetingScheduleTests(IetfSeleniumTestCase):
         # option to swap. If we used the first or last day, a fencepost error in
         # disabling options by date might be hidden.
         clicked_index = 1
+        # scroll so the button we want to click is just below the navbar, otherwise it may
+        # fall beneath the sessions panel
+        navbar = self.driver.find_element_by_class_name('navbar')
+        self.driver.execute_script(
+            'window.scrollBy({top: %s, behavior: "instant"})' % (
+                    future_swap_days_buttons[1].location['y'] - navbar.size['height']
+            )
+        )
         future_swap_days_buttons[clicked_index].click()
         try:
             modal = wait.until(


### PR DESCRIPTION
Fixes #3718