### PR TITLE
fix: avoid needlessly blocking import of session minutes

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -4170,7 +4170,7 @@ def import_session_minutes(request, session_id, num):
         # noinspection PyBroadException
         try:
             with open(current_minutes.get_file_name()) as f:
-                if import_contents == Note.preprocess_source(f.read()):
+                if import_contents == f.read():
                     contents_changed = False
                     messages.warning(request, 'This document is identical to the current revision, no need to import.')
         except Exception:

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -4167,7 +4167,6 @@ def import_session_minutes(request, session_id, num):
     current_minutes = session.minutes()
     contents_changed = True
     if current_minutes:
-        # noinspection PyBroadException
         try:
             with open(current_minutes.get_file_name()) as f:
                 if import_contents == f.read():

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -4167,13 +4167,14 @@ def import_session_minutes(request, session_id, num):
     current_minutes = session.minutes()
     contents_changed = True
     if current_minutes:
+        # noinspection PyBroadException
         try:
             with open(current_minutes.get_file_name()) as f:
                 if import_contents == Note.preprocess_source(f.read()):
                     contents_changed = False
                     messages.warning(request, 'This document is identical to the current revision, no need to import.')
-        except FileNotFoundError:
-            pass  # allow import if the file is missing
+        except Exception:
+            pass  # Do not let a failure here prevent minutes from being updated.
 
     return render(
         request,


### PR DESCRIPTION
Fixes #3558 and #3749