### PR TITLE
ci: chown npm-related paths to owner of /workspace in app container

### DIFF
--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -4,6 +4,10 @@ WORKSPACEDIR="/workspace"
 
 service rsyslog start
 
+# fix permissions for npm-related paths
+WORKSPACE_UID_GID=$(stat --format="%u:%g" "$WORKSPACEDIR")
+chown -R "$WORKSPACE_UID_GID" "$WORKSPACEDIR/node_modules" "$WORKSPACEDIR/.parcel-cache"
+
 # Generate static assets
 
 npm install --prefer-offline --no-audit


### PR DESCRIPTION
Intended to fix #3751