### PR TITLE
test: fix permissions on files for html validation

### DIFF
--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -832,6 +832,7 @@ class IetfTestRunner(DiscoverRunner):
             try:
                 validation_results = json.load(stdout)
             except json.decoder.JSONDecodeError:
+                stdout.seek(0)
                 testcase.fail(stdout.read())
 
         errors = ""

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -51,7 +51,9 @@ import subprocess
 import tempfile
 import copy
 import factory.random
+
 from fnmatch import fnmatch
+from pathlib import Path
 
 from coverage.report import Reporter
 from coverage.results import Numbers
@@ -764,6 +766,7 @@ class IetfTestRunner(DiscoverRunner):
                 )
                 self.config_file[kind].write(json.dumps(config[kind]).encode())
                 self.config_file[kind].flush()
+                Path(self.config_file[kind].name).chmod(0o644)
 
         super(IetfTestRunner, self).setup_test_environment(**kwargs)
 
@@ -800,6 +803,7 @@ class IetfTestRunner(DiscoverRunner):
         testcase = TestCase()
         cwd = pathlib.Path.cwd()
         tmpdir = tempfile.TemporaryDirectory(prefix="html-validate-")
+        Path(tmpdir.name).chmod(0o655)
         for (name, content, fingerprint) in self.batches[kind]:
             path = pathlib.Path(tmpdir.name).joinpath(
                 hex(fingerprint)[2:],


### PR DESCRIPTION
The `html-validate` script is run via `npx`. When running as root, this causes the script to be executed as the owner of the working directory. Temp files/directories created as root are given perm 0600 and are thus not readable for the script. This fixes those permissions enough that it works in my environment.

Also rewinds stdout when printing the output that caused a JSON decode error. Without that, nothing is printed.