### PR TITLE
fix: .visually-hidden -> .d-none

### DIFF
--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -413,7 +413,7 @@ def format_snippet(text, trunc_words=25):
     full = keep_spacing(collapsebr(linebreaksbr(mark_safe(sanitize_fragment(text)))))
     snippet = truncatewords_html(full, trunc_words)
     if snippet != full:
-        return mark_safe('<div class="snippet">%s<button type="button" aria-label="Expand" class="btn btn-sm btn-primary show-all"><i class="bi bi-caret-down"></i></button></div><div class="visually-hidden full">%s</div>' % (snippet, full))
+        return mark_safe('<div class="snippet">%s<button type="button" aria-label="Expand" class="btn btn-sm btn-primary show-all"><i class="bi bi-caret-down"></i></button></div><div class="d-none full">%s</div>' % (snippet, full))
     return mark_safe(full)
 
 @register.simple_tag

--- a/ietf/static/js/complete-review.js
+++ b/ietf/static/js/complete-review.js
@@ -38,11 +38,11 @@ $(document)
             mailArchiveSearch.find(".search")
                 .prop("disabled", true);
             mailArchiveSearch.find(".error")
-                .addClass("visually-hidden");
+                .addClass("d-none");
             mailArchiveSearch.find(".retrieving")
-                .removeClass("visually-hidden");
+                .removeClass("d-none");
             mailArchiveSearch.find(".results")
-                .addClass("visually-hidden");
+                .addClass("d-none");
 
             retrievingData = $.ajax({
                     url: searchMailArchiveUrl,
@@ -58,7 +58,7 @@ $(document)
                     mailArchiveSearch.find(".search")
                         .prop("disabled", false);
                     mailArchiveSearch.find(".retrieving")
-                        .addClass("visually-hidden");
+                        .addClass("d-none");
 
                     var err = data.error;
                     if (!err && (!data.messages || !data.messages.length))
@@ -67,7 +67,7 @@ $(document)
                     var non_reply_row = null;
                     if (err) {
                         var errorDiv = mailArchiveSearch.find(".error");
-                        errorDiv.removeClass("visually-hidden");
+                        errorDiv.removeClass("d-none");
                         errorDiv.find(".content")
                             .text(err);
                         if (data.query && data.query_url && data.query_data_url) {
@@ -78,11 +78,11 @@ $(document)
                             errorDiv.find(".try-yourself .query-data-url")
                                 .prop("href", data.query_data_url);
                             errorDiv.find(".try-yourself")
-                                .removeClass("visually-hidden");
+                                .removeClass("d-none");
                         }
                     } else {
                         mailArchiveSearch.find(".results")
-                            .removeClass("visually-hidden");
+                            .removeClass("d-none");
 
                         var results = mailArchiveSearch.find(".results .list-group");
                         results.children()
@@ -119,10 +119,10 @@ $(document)
                     mailArchiveSearch.find(".search")
                         .prop("disabled", false);
                     mailArchiveSearch.find(".retrieving")
-                        .addClass("visually-hidden");
+                        .addClass("d-none");
 
                     var errorDiv = mailArchiveSearch.find(".error");
-                    errorDiv.removeClass("visually-hidden");
+                    errorDiv.removeClass("d-none");
                     errorDiv.find(".content")
                         .text("Error trying to retrieve data from mailing list archive.");
                 });

--- a/ietf/static/js/edit-meeting-timeslots-and-misc-sessions.js
+++ b/ietf/static/js/edit-meeting-timeslots-and-misc-sessions.js
@@ -47,7 +47,7 @@ jQuery(document)
             content.find(".selected")
                 .removeClass("selected");
 
-            schedulingPanel.addClass("visually-hidden");
+            schedulingPanel.addClass("d-none");
             schedulingPanel.find(".panel-content")
                 .children()
                 .remove();
@@ -109,7 +109,7 @@ jQuery(document)
                         .val(this.dataset.room);
                     schedulingPanel.find("[name=type]")
                         .trigger("change");
-                    schedulingPanel.removeClass("visually-hidden");
+                    schedulingPanel.removeClass("d-none");
                     schedulingPanel.find("[name=time]")
                         .trigger("focus");
                 });
@@ -147,8 +147,8 @@ jQuery(document)
                         schedulingPanel.find(".timeslot-form [name=type]")
                             .trigger("change");
                         schedulingPanel.find(".timeslot-form")
-                            .removeClass("visually-hidden");
-                        schedulingPanel.removeClass("visually-hidden");
+                            .removeClass("d-none");
+                        schedulingPanel.removeClass("d-none");
                     });
             });
 
@@ -161,31 +161,31 @@ jQuery(document)
             form.find("[name=group],[name=short],[name=\"agenda_note\"]")
                 .prop('disabled', false)
                 .closest(".mb-3")
-                .removeClass("visually-hidden");
+                .removeClass("d-none");
 
             if (this.value == "break") {
                 form.find("[name=short]")
                     .closest(".mb-3")
-                    .addClass("visually-hidden");
+                    .addClass("d-none");
             } else if (this.value == "plenary") {
                 let group = form.find("[name=group]");
                 group.val(group.data('ietf'));
             } else if (this.value == "regular") {
                 form.find("[name=short]")
                     .closest(".mb-3")
-                    .addClass("visually-hidden");
+                    .addClass("d-none");
             }
 
             if (this.value != "regular")
                 form.find("[name=\"agenda_note\"]")
                 .closest(".mb-3")
-                .addClass("visually-hidden");
+                .addClass("d-none");
 
             if (['break', 'reg', 'reserved', 'unavail', 'regular'].indexOf(this.value) != -1) {
                 let group = form.find("[name=group]");
                 group.prop('disabled', true);
                 group.closest(".mb-3")
-                    .addClass("visually-hidden");
+                    .addClass("d-none");
             }
         });
 

--- a/ietf/static/js/edit-milestones.js
+++ b/ietf/static/js/edit-milestones.js
@@ -21,7 +21,7 @@ $(document)
                 .addClass("changed");
             setSubmitButtonState();
             if (switch_date_use_form) {
-                switch_date_use_form.addClass("visually-hidden");
+                switch_date_use_form.addClass("d-none");
             }
         }
 
@@ -36,7 +36,7 @@ $(document)
             var action;
             var milestone_cnt = milestonesForm.find(".milestonerow")
                 .length;
-            var milestone_hidden_cnt = milestonesForm.find(".edit-milestone.visually-hidden")
+            var milestone_hidden_cnt = milestonesForm.find(".edit-milestone.d-none")
                 .length;
             var milestone_change_cnt = milestonesForm.find(".edit-milestone.changed")
                 .length;
@@ -53,9 +53,9 @@ $(document)
             var submit = milestonesForm.find("[type=submit]");
             submit.text(submit.data("label" + action));
             if (milestone_change_cnt + milestone_delete_cnt > 0 || action == "review") {
-                submit.removeClass("visually-hidden");
+                submit.removeClass("d-none");
             } else {
-                submit.addClass("visually-hidden");
+                submit.addClass("d-none");
             }
         }
 
@@ -63,8 +63,8 @@ $(document)
             .on("click", function () {
                 var row = $(this),
                     editRow = row.next(".edit-milestone");
-                row.addClass("visually-hidden");
-                editRow.removeClass("visually-hidden");
+                row.addClass("d-none");
+                editRow.removeClass("d-none");
 
                 editRow.find('input[name$="desc"]')
                     .trigger("focus");
@@ -79,8 +79,8 @@ $(document)
                             .next('.edit-milestone');
                         if (e.is(":visible") && !e.hasClass("changed")) {
                             $(this)
-                                .removeClass("visually-hidden");
-                            e.addClass("visually-hidden");
+                                .removeClass("d-none");
+                            e.addClass("d-none");
                         }
                     });
             });
@@ -127,7 +127,7 @@ $(document)
                     });
 
                 new_edit_milestone.removeClass("template");
-                new_edit_milestone.removeClass("visually-hidden");
+                new_edit_milestone.removeClass("d-none");
 
                 new_edit_milestone.find(".select2-field")
                     .each(function () {
@@ -151,12 +151,12 @@ $(document)
                 .find("[name$=resolved]");
             if (resolved) {
                 reason.closest(".row")
-                    .removeClass("visually-hidden");
+                    .removeClass("d-none");
                 if (!reason.val())
                     reason.val(reason.data("default"));
             } else {
                 reason.closest(".row")
-                    .addClass("visually-hidden");
+                    .addClass("d-none");
                 reason.val("");
             }
         }
@@ -223,7 +223,7 @@ $(document)
                     setSubmitButtonState();
                     setOrderControlValue();
                     if (switch_date_use_form) {
-                        switch_date_use_form.addClass("visually-hidden");
+                        switch_date_use_form.addClass("d-none");
                     }
                 }
             };

--- a/ietf/static/js/ietf.js
+++ b/ietf/static/js/ietf.js
@@ -277,7 +277,7 @@ $(document)
                             trigger.parent()
                                 .find(".track-untrack-doc")
                                 .tooltip("hide");
-                            trigger.addClass("visually-hidden");
+                            trigger.addClass("d-none");
 
                             var target_unhide = null;
                             if (trigger.hasClass('review-wish-add-remove-doc')) {
@@ -289,7 +289,7 @@ $(document)
                                 trigger.parent()
                                     .find(target_unhide)
                                     .not(trigger)
-                                    .removeClass("visually-hidden");
+                                    .removeClass("d-none");
                             }
                         }
                     }
@@ -327,8 +327,8 @@ $(document)
             .on("click", function () {
                 $(this)
                     .parents(".snippet")
-                    .addClass("visually-hidden")
+                    .addClass("d-none")
                     .siblings(".full")
-                    .removeClass("visually-hidden");
+                    .removeClass("d-none");
             });
     });

--- a/ietf/static/js/ipr-edit.js
+++ b/ietf/static/js/ipr-edit.js
@@ -6,13 +6,13 @@ $(document)
             .on("click", function () {
                 var template = form.find('.draft-row.template');
                 var el = template.clone(true)
-                    .removeClass("template visually-hidden");
+                    .removeClass("template d-none");
 
                 var totalField = $('#id_iprdocrel_set-TOTAL_FORMS');
                 var total = +totalField.val();
 
                 el.find("*[for*=iprdocrel], *[id*=iprdocrel], *[name*=iprdocrel]")
-                    .not(".visually-hidden")
+                    .not(".d-none")
                     .each(function () {
                         var x = $(this);
                         ["for", "id", "name"].forEach(function (at) {

--- a/ietf/static/js/list.js
+++ b/ietf/static/js/list.js
@@ -77,7 +77,7 @@ $(document)
                     .text()
                     .trim() == "") {
                     // console.log("No headers fields visible, hiding header row.");
-                    header_row.addClass("visually-hidden");
+                    header_row.addClass("d-none");
                 }
 
                 // HTML for the search widget
@@ -99,7 +99,7 @@ $(document)
                     .children("button.search-reset");
 
                 var pager = $.parseHTML(`
-                    <nav aria-label="Pagination control" class="visually-hidden">
+                    <nav aria-label="Pagination control" class="d-none">
                         <ul class="pagination d-flex flex-wrap text-center"></ul>
                     </nav>`);
 
@@ -170,7 +170,7 @@ $(document)
                         if (pagination) {
                             // console.log("Enabling pager.");
                             $(pager)
-                                .removeClass("visually-hidden");
+                                .removeClass("d-none");
                             pagination = {
                                 innerWindow: 5,
                                 left: 1,

--- a/ietf/static/js/meeting-interim-request.js
+++ b/ietf/static/js/meeting-interim-request.js
@@ -79,7 +79,7 @@ const interimRequest = (function() {
             totalField.val(total);
 
             template.before(el);
-            el.removeClass("template visually-hidden");
+            el.removeClass("template d-none");
 
             // copy field contents
             const first_session = $(".fieldset:first");
@@ -88,7 +88,7 @@ const interimRequest = (function() {
                     .val());
 
             $('.btn-delete')
-                .removeClass("visually-hidden");
+                .removeClass("d-none");
         },
 
         updateInfo: function () {
@@ -153,9 +153,9 @@ const interimRequest = (function() {
             const meeting_type = $('input[name="meeting_type"]:checked')
                 .val();
             if (meeting_type === 'single') {
-                interimRequest.addButton.addClass("visually-hidden");
+                interimRequest.addButton.addClass("d-none");
             } else {
-                interimRequest.addButton.removeClass("visually-hidden");
+                interimRequest.addButton.removeClass("d-none");
             }
         },
 
@@ -208,7 +208,7 @@ const interimRequest = (function() {
             totalField.val(total);
             if (total === 2) {
                 $(".btn-delete")
-                    .addClass("visually-hidden");
+                    .addClass("d-none");
             }
         },
 

--- a/ietf/static/js/password_strength.js
+++ b/ietf/static/js/password_strength.js
@@ -20,7 +20,7 @@
                 .closest("form");
             widget
                 .find(".hidden")
-                .addClass("visually-hidden")
+                .addClass("d-none")
                 .removeClass("hidden");
 
             widget
@@ -67,12 +67,12 @@
                             password_strength_bar.removeClass('bg-success')
                                 .addClass('bg-warning');
                             password_strength_info.find('.badge')
-                                .removeClass('visually-hidden');
+                                .removeClass('d-none');
                         } else {
                             password_strength_bar.removeClass('bg-warning')
                                 .addClass('bg-success');
                             password_strength_info.find('.badge')
-                                .addClass('visually-hidden');
+                                .addClass('d-none');
                         }
 
                         password_strength_bar.width(((result.score + 1) / 5) * 100 + '%')
@@ -80,17 +80,17 @@
                         // henrik@levkowetz.com -- this is the only changed line:
                         password_strength_info.find('.password_strength_time')
                             .html(result.crack_times_display.online_no_throttling_10_per_second);
-                        password_strength_info.removeClass('visually-hidden');
+                        password_strength_info.removeClass('d-none');
 
                         password_strength_offline_info.find('.password_strength_time')
                             .html(result.crack_times_display.offline_slow_hashing_1e4_per_second);
-                        password_strength_offline_info.removeClass('visually-hidden');
+                        password_strength_offline_info.removeClass('d-none');
                     } else {
                         password_strength_bar.removeClass('bg-success')
                             .addClass('bg-warning');
                         password_strength_bar.width('0%')
                             .attr('aria-valuenow', 0);
-                        password_strength_info.addClass('visually-hidden');
+                        password_strength_info.addClass('d-none');
                     }
                     self.match_passwords($(this));
                 });
@@ -157,18 +157,18 @@
                             $(confirm_field)
                                 .parent()
                                 .find('.password_strength_info')
-                                .addClass('visually-hidden');
+                                .addClass('d-none');
                         } else {
                             $(confirm_field)
                                 .parent()
                                 .find('.password_strength_info')
-                                .removeClass('visually-hidden');
+                                .removeClass('d-none');
                         }
                     } else {
                         $(confirm_field)
                             .parent()
                             .find('.password_strength_info')
-                            .addClass('visually-hidden');
+                            .addClass('d-none');
                     }
                 }
             });

--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -80,7 +80,7 @@
         <div class="pt-3 container-fluid">
             <div class="row">
                 {% if request.COOKIES.left_menu == "on" and not hide_menu %}
-                    <div class="col-1 d-none d-md-block bg-light py-3 lh-sm leftmenu small">
+                    <div class="d-none d-md-block bg-light py-3 leftmenu small">
                         <ul class="nav nav-pills flex-column">
                             {% include "base/menu.html" with flavor="left" %}
                         </ul>

--- a/ietf/templates/community/manage_list.html
+++ b/ietf/templates/community/manage_list.html
@@ -135,7 +135,7 @@
             </div>
             <button type="submit" class="btn btn-primary" name="action" value="add_rule">Add rule</button>
         </form>
-        <div class="empty-forms visually-hidden">
+        <div class="empty-forms d-none">
             {% for rule_type, f in empty_rule_forms.items %}
                 <div class="rule-type {{ rule_type }}">{% bootstrap_form f layout="horizontal" %}</div>
             {% endfor %}

--- a/ietf/templates/debug.html
+++ b/ietf/templates/debug.html
@@ -8,9 +8,9 @@
         {{ sql_queries|length }} queries ({{ sql_queries|timesum }}s)
         {% if sql_queries|length != 0 %}
             <a class="btn btn-primary btn-sm"
-               onclick="$('#debug-query-table').toggleClass('visually-hidden');">Show</a>
+               onclick="$('#debug-query-table').toggleClass('d-none');">Show</a>
         {% endif %}
-        <div id="debug-query-table" class="visually-hidden">
+        <div id="debug-query-table" class="d-none">
             <div class="text-start">
                 <table class="table table-sm tablesorter">
                     <thead>

--- a/ietf/templates/doc/review/complete_review.html
+++ b/ietf/templates/doc/review/complete_review.html
@@ -105,19 +105,19 @@
                                    value="{{ mail_archive_query_urls.query }}">
                             <button type="button" class="search btn btn-primary">Search</button>
                         </div>
-                        <div class="retrieving visually-hidden my-3">
+                        <div class="retrieving d-none my-3">
                             <div class="spinner-border spinner-border-sm" role="status"></div>
                             Searching...
                         </div>
-                        <div class="results visually-hidden my-3">
+                        <div class="results d-none my-3">
                             <p>
                                 Select one of the following messages to automatically pre-fill link and content:
                             </p>
                             <div class="list-group"></div>
                         </div>
-                        <div class="error alert alert-warning visually-hidden my-3">
+                        <div class="error alert alert-warning d-none my-3">
                             <span class="content">&nbsp;</span>
-                            <span class="visually-hidden try-yourself">
+                            <span class="d-none try-yourself">
                                 (searched for
                                 <a class="query-url" href="#">"<span class="query">&nbsp;</span>"</a>,
                                 corresponding

--- a/ietf/templates/doc/search/search_result_row.html
+++ b/ietf/templates/doc/search/search_result_row.html
@@ -14,13 +14,13 @@
     <td>
         {% if user.is_authenticated %}
             <a href="{% url "ietf.community.views.untrack_document" username=request.user.username name=doc.name %}"
-               class="track-untrack-doc {% if not doc.tracked_in_personal_community_list %}visually-hidden{% endif %}"
+               class="track-untrack-doc {% if not doc.tracked_in_personal_community_list %}d-none{% endif %}"
                aria-label="Remove from your personal ID list"
                title="Remove from your personal ID list">
                 <i class="bi bi-bookmark-check-fill"></i>
             </a>
             <a href="{% url "ietf.community.views.track_document" username=request.user.username name=doc.name %}"
-               class="track-untrack-doc {% if doc.tracked_in_personal_community_list %}visually-hidden{% endif %}"
+               class="track-untrack-doc {% if doc.tracked_in_personal_community_list %}d-none{% endif %}"
                aria-label="Add to your personal ID list"
                title="Add to your personal ID list">
                 <i class="bi bi-bookmark"></i>
@@ -28,13 +28,13 @@
             <br>
         {% endif %}
         {% if user.review_teams %}
-            <a class="review-wish-add-remove-doc ajax {% if not doc.has_review_wish %}visually-hidden{% endif %}"
+            <a class="review-wish-add-remove-doc ajax {% if not doc.has_review_wish %}d-none{% endif %}"
                href="{% url "ietf.doc.views_review.review_wishes_remove" name=doc.name %}?next={{ request.get_full_path|urlencode }}"
                aria-label="Remove from your review wishes for all teams"
                title="Remove from your review wishes for all teams">
                 <i class="bi bi-chat-left-heart-fill"></i>
             </a>
-            <a class="review-wish-add-remove-doc {% if user.review_teams|length_is:"1" %}ajax {% endif %} {% if doc.has_review_wish %}visually-hidden{% endif %}"
+            <a class="review-wish-add-remove-doc {% if user.review_teams|length_is:"1" %}ajax {% endif %} {% if doc.has_review_wish %}d-none{% endif %}"
                href="{% url "ietf.doc.views_review.review_wish_add" name=doc.name %}?next={{ request.get_full_path|urlencode }}"
                aria-label="Add to your review wishes"
                title="Add to your review wishes">

--- a/ietf/templates/group/active_dirs.html
+++ b/ietf/templates/group/active_dirs.html
@@ -30,7 +30,7 @@
                     <td class="text-center">
                         {% if group.type_id == 'review' %}
                             <i class="bi bi-check-lg text-success"></i>
-                            <span class="visually-hidden">yes</span>
+                            <span class="d-none">yes</span>
                         {% endif %}
                     </td>
                     <td>

--- a/ietf/templates/group/edit_milestones.html
+++ b/ietf/templates/group/edit_milestones.html
@@ -83,13 +83,13 @@
                             {% for d in form.docs_names %}<div class="doc">{{ d }}</div>{% endfor %}
                         </div>
                     </div>
-                    <div class="visually-hidden row edit-milestone{% if form.changed %} changed{% endif %}">
+                    <div class="d-none row edit-milestone{% if form.changed %} changed{% endif %}">
                         {% include "group/milestone_form.html" %}
                     </div>
                 </div>
             {% endfor %}
         </div>
-        <div id="extratemplatecontainer" class="visually-hidden">
+        <div id="extratemplatecontainer" class="d-none">
             <div class="row extratemplate">
                 <hr>
                 <div class="edit-milestone template">{% include "group/milestone_form.html" with form=empty_form %}</div>

--- a/ietf/templates/iesg/discusses.html
+++ b/ietf/templates/iesg/discusses.html
@@ -78,10 +78,10 @@
         $(".discuss").on("click", function () {
             var x = $(this).prev("input").val();
             if (x === "all") {
-                $("#doclist>tr").removeClass("visually-hidden");
+                $("#doclist>tr").removeClass("d-none");
             } else {
-                $("#doclist>tr." + x).removeClass("visually-hidden");
-                $("#doclist>tr:not(." + x + ")").addClass("visually-hidden");
+                $("#doclist>tr." + x).removeClass("d-none");
+                $("#doclist>tr:not(." + x + ")").addClass("d-none");
             }
         });
     </script>

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -131,7 +131,7 @@
             </p>
             {{ draft_formset.management_form }}
             {% for draft_form in draft_formset %}
-                <div class="row draft-row {% if forloop.last %}template visually-hidden{% endif %}">
+                <div class="row draft-row {% if forloop.last %}template d-none{% endif %}">
                     <label class="col-md-2 fw-bold" for="{{ draft_form.document.id_for_label }}">{{ draft_form.document.label }}</label>
                     <div class="col-md-6">
                         {{ draft_form.id }}
@@ -140,11 +140,11 @@
                     </div>
                     <div class="col-md-2">
                         {% bootstrap_field draft_form.revisions class="form-control" placeholder="Revisions, e.g., 04-07" show_help=False show_label=False %}
-                        <label class="visually-hidden" for="{{ draft_form.revisions.id_for_label }}">{{ draft_form.revisions.label }}</label>
+                        <label class="d-none" for="{{ draft_form.revisions.id_for_label }}">{{ draft_form.revisions.label }}</label>
                     </div>
                     <div class="col-md-2">
                         {% bootstrap_field draft_form.sections class="form-control" placeholder="Sections" show_help=False show_label=False %}
-                        <label class="visually-hidden" for="{{ draft_form.sections.id_for_label }}">{{ draft_form.sections.label }}</label>
+                        <label class="d-none" for="{{ draft_form.sections.id_for_label }}">{{ draft_form.sections.label }}</label>
                     </div>
                 </div>
             {% endfor %}
@@ -152,12 +152,12 @@
             {% for draft_form in draft_formset %}
                 <div class="row draft-row {% if forloop.last %}template{% endif %}">
                     <div class="col-md-2 fw-bold">{% bootstrap_label draft_form.document.label %}</div>
-                    <div class="col-md-6">{% bootstrap_field draft_form.document label_class="visually-hidden" show_help=False %}</div>
+                    <div class="col-md-6">{% bootstrap_field draft_form.document label_class="d-none" show_help=False %}</div>
                     <div class="col-md-2">
-                        {% bootstrap_field draft_form.revisions placeholder="Revisions, e.g., 04-07" label_class="visually-hidden" show_help=False %}
+                        {% bootstrap_field draft_form.revisions placeholder="Revisions, e.g., 04-07" label_class="d-none" show_help=False %}
                     </div>
                     <div class="col-md-2">
-                        {% bootstrap_field draft_form.sections placeholder="Sections" label_class="visually-hidden" show_help=False %}
+                        {% bootstrap_field draft_form.sections placeholder="Sections" label_class="d-none" show_help=False %}
                     </div>
                 </div>
             {% endfor %}

--- a/ietf/templates/meeting/agenda.html
+++ b/ietf/templates/meeting/agenda.html
@@ -88,7 +88,7 @@
             Download non-area events
         </a>
     </div>
-    <div id="weekview" class="visually-hidden mt-3">
+    <div id="weekview" class="d-none mt-3">
         <h2>
             Schedule
             {% if schedule.meeting.agenda_warning_note %}
@@ -138,7 +138,7 @@
                         {% if personalize %}
                             <td class="text-center">
                                 {% if item.session_keyword %}
-                                    <label class="visually-hidden"
+                                    <label class="d-none"
                                            aria-label="Select session"
                                            for="{{ item.session_keyword }}">
                                    </label>
@@ -221,7 +221,7 @@
                     {% if personalize %}
                         <td class="text-center">
                             {% if item.session_keyword %}
-                                <label class="visually-hidden"
+                                <label class="d-none"
                                        aria-label="Select session"
                                        for="{{ item.session_keyword }}">
                                </label>
@@ -377,22 +377,22 @@
         }
 
         function update_ical_links(filter_params) {
-            $(".ical-link").toggleClass("visually-hidden", !agenda_filter.filtering_is_enabled(filter_params));
+            $(".ical-link").toggleClass("d-none", !agenda_filter.filtering_is_enabled(filter_params));
         }
 
         function update_weekview(filter_params) {
             var weekview = $("#weekview");
             if (agenda_filter.filtering_is_enabled(filter_params)) {
-                weekview.removeClass("visually-hidden");
+                weekview.removeClass("d-none");
             } else {
-                weekview.addClass("visually-hidden");
+                weekview.addClass("d-none");
             }
             update_weekview_display();
         }
 
         function update_weekview_display() {
             var weekview = $("#weekview");
-            if (!weekview.hasClass('visually-hidden')) {
+            if (!weekview.hasClass('d-none')) {
                 var queryparams = window.location.search;
                 if (queryparams) {
                     queryparams += '&tz=' + encodeURIComponent(ietf_timezone.get_current_tz().toLowerCase());

--- a/ietf/templates/meeting/agenda_personalize_buttonlist.html
+++ b/ietf/templates/meeting/agenda_personalize_buttonlist.html
@@ -5,15 +5,15 @@ Required parameter: meeting - meeting being displayed
 {% endcomment %}
 {% load agenda_custom_tags %}
 <div class="mb-3 buttonlist">
-    <a class="btn btn-sm btn-outline-primary visually-hidden ical-link agenda-link filterable"
+    <a class="btn btn-sm btn-outline-primary d-none ical-link agenda-link filterable"
        href="{% webcal_url 'ietf.meeting.views.agenda_ical' num=meeting.number %}">
         Subscribe to personal agenda
     </a>
-    <a class="visually-hidden btn btn-sm btn-outline-primary ical-link agenda-link filterable"
+    <a class="d-none btn btn-sm btn-outline-primary ical-link agenda-link filterable"
        href="{% url "ietf.meeting.views.agenda_ical" num=meeting.number %}">
         Download .ics of personal agenda
     </a>
-    <a class="btn btn-sm btn-outline-primary visually-hidden ical-link agenda-link filterable"
+    <a class="btn btn-sm btn-outline-primary d-none ical-link agenda-link filterable"
        href="{% url 'ietf.meeting.views.agenda' num=meeting.number %}">
         View personal agenda
     </a>

--- a/ietf/templates/meeting/edit_meeting_timeslots_and_misc_sessions.html
+++ b/ietf/templates/meeting/edit_meeting_timeslots_and_misc_sessions.html
@@ -72,10 +72,10 @@
                 </div>
             {% endfor %}
         </div>
-        <div class="add-timeslot-template visually-hidden">
+        <div class="add-timeslot-template d-none">
             {% include "meeting/edit_timeslot_form.html" with timeslot_form_action='add' timeslot_form=empty_timeslot_form %}
         </div>
-        <div class="scheduling-panel {% if not edit_timeslot_form and not add_timeslot_form %}visually-hidden{% endif %}">
+        <div class="scheduling-panel {% if not edit_timeslot_form and not add_timeslot_form %}d-none{% endif %}">
             <i class="close bi bi-x float-end"></i>
             <div class="panel-content">
                 {% if edit_timeslot_form %}

--- a/ietf/templates/meeting/interim_request.html
+++ b/ietf/templates/meeting/interim_request.html
@@ -30,12 +30,12 @@
         {{ formset.management_form }}
         {% if formset.non_form_errors %}<div class="my-3 alert alert-danger">{{ formset.non_form_errors }}</div>{% endif %}
         {% for form in formset %}
-            <div class="fieldset{% if forloop.last %} template visually-hidden{% endif %}">
+            <div class="fieldset{% if forloop.last %} template d-none{% endif %}">
                 <hr class="my-4">
                 {% bootstrap_form form layout='horizontal' %}
                 <button name="id_session_set-{{ forloop.counter0 }}-delete-button"
                         type="button"
-                        class="btn btn-danger offset-md-2 visually-hidden btn-delete">
+                        class="btn btn-danger offset-md-2 d-none btn-delete">
                     Delete session
                 </button>
             </div>

--- a/ietf/templates/meeting/interim_request_edit.html
+++ b/ietf/templates/meeting/interim_request_edit.html
@@ -28,12 +28,12 @@
         {{ formset.management_form }}
         {% if formset.non_form_errors %}<div class="my-3 alert alert-danger">{{ formset.non_form_errors }}</div>{% endif %}
         {% for form in formset %}
-            <div class="fieldset{% if forloop.last %} template visually-hidden{% endif %}">
+            <div class="fieldset{% if forloop.last %} template d-none{% endif %}">
                 <hr class="my-4">
                 {% bootstrap_form form layout='horizontal' %}
                 <button name="id_session_set-{{ forloop.counter0 }}-delete-button"
                         type="button"
-                        class="btn btn-danger offset-md-2 visually-hidden btn-delete">
+                        class="btn btn-danger offset-md-2 d-none btn-delete">
                     Delete session
                 </button>
             </div>

--- a/ietf/templates/meeting/tz-display.html
+++ b/ietf/templates/meeting/tz-display.html
@@ -35,7 +35,7 @@ As long as id_suffix is different, should allow for as many copies of the widget
            value="UTC">
     <label class="btn btn-outline-primary" for="utc-timezone{{ suffix }}">UTC</label>
     {% if not minimal %}
-        <label aria-label="Select timezone" class="visually-hidden" for="timezone-select{{ id_suffix }}"></label>
+        <label aria-label="Select timezone" class="d-none" for="timezone-select{{ id_suffix }}"></label>
         <select id="timezone-select{{ suffix }}"
                 class="tz-select select2-field form-select border-primary"
                 data-max-entries="1" data-minimum-input-length="0">

--- a/ietf/templates/nomcom/private_index.html
+++ b/ietf/templates/nomcom/private_index.html
@@ -175,7 +175,7 @@
                     <tr>
                         {% if is_chair and nomcom.group.state_id == 'active' %}
                             <td>
-                                <label class="visually-hidden" aria-label="np.nominee.name" for="id-{{ np.id }}"></label>
+                                <label class="d-none" aria-label="np.nominee.name" for="id-{{ np.id }}"></label>
                                 <input class="batch-select form-check-input"
                                        type="checkbox"
                                        value="{{ np.id }}"

--- a/ietf/templates/nomcom/send_reminder_mail.html
+++ b/ietf/templates/nomcom/send_reminder_mail.html
@@ -42,7 +42,7 @@
                     {% for nominee in nominees %}
                         <tr>
                             <td>
-                                <label class="visually-hidden" aria-label="{{ nominee.name }}" for="id-{{ nominee.id }}"></label>
+                                <label class="d-none" aria-label="{{ nominee.name }}" for="id-{{ nominee.id }}"></label>
                                 <input type="checkbox"
                                        class="batch-select form-check-input"
                                        id="id-{{ nominee.id }}"

--- a/ietf/templates/nomcom/view_feedback_pending.html
+++ b/ietf/templates/nomcom/view_feedback_pending.html
@@ -107,7 +107,7 @@
                                 <td>{{ form.instance.time|date:"r" }}{{ form.id }}</td>
                                 {% for choice in form.type.field.choices %}
                                     <td class="text-center">
-                                        <label class="visually-hidden" aria-label="{{ choice.1 }}" for="{{ choice.1|slugify }}"></label>
+                                        <label class="d-none" aria-label="{{ choice.1 }}" for="{{ choice.1|slugify }}"></label>
                                         <input type="radio"
                                                class="form-check-input"
                                                name="{{ form.type.html_name }}"

--- a/ietf/templates/registration/change_password.html
+++ b/ietf/templates/registration/change_password.html
@@ -49,7 +49,7 @@
 
             Calculating offline attack time if password hashes should leak is left
             as an exercise for the reader.
-            <span class="password_strength_offline_info visually-hidden">
+            <span class="password_strength_offline_info d-none">
                 As a guideline, if we assume offline hashing using the current hasher
                 at a speed of 10<sup>4</sup> attempts per second, this password would
                 take <em class="password_strength_time"></em> to crack.

--- a/ietf/templates/stats/review_stats.html
+++ b/ietf/templates/stats/review_stats.html
@@ -51,7 +51,7 @@
             <label id="reqtime" class="fw-bold col-sm-2 col-form-label">Request time:</label>
             <div class="col-sm-10">
                 <div class="input-group">
-                    <label class="visually-hidden" for="from" aria-label="Request time, from"></label>
+                    <label class="d-none" for="from" aria-label="Request time, from"></label>
                     <input class="form-control"
                            type="text"
                            name="from"
@@ -64,7 +64,7 @@
                            data-date-end-date="{{ today.isoformat }}"
                            data-date-start-view="months">
                     <span class="input-group-text" id="basic-addon2">&mdash;</span>
-                    <label class="visually-hidden" for="to" aria-label="Request time, to"></label>
+                    <label class="d-none" for="to" aria-label="Request time, to"></label>
                     <input class="form-control"
                            type="text"
                            name="to"


### PR DESCRIPTION
In bs5, `.visually-hidden` is the equivalent of bs3's `.sr-only`, i.e., it's
still shown on screen readers, which is not what we want. Use `.d-none` instead,
which is the equivalent of bs3's `.hidden`.