### PR TITLE
Fix urlize ietf docs

### DIFF
--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -192,23 +192,15 @@ def urlize_ietf_docs(string, autoescape=None):
     """
     if autoescape and not isinstance(string, SafeData):
         string = escape(string)
-    patterns = [
-        (r"\b(draft-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
-        (r"\b(bofreq-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
-        (r"\b(conflict-review-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
-        (r"\b(status-change-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
-        (r"\b(charter-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
-        (r"\b(RFC\s*?)0{0,3}(\d+)\b", '<a href="/doc/rfc\\2/">\\1\\2</a>'),
-        (r"\b(BCP\s*?)0{0,3}(\d+)\b", '<a href="/doc/bcp\\2/">\\1\\2</a>'),
-        (r"\b(STD\s*?)0{0,3}(\d+)\b", '<a href="/doc/std\\2/">\\1\\2</a>'),
-        (r"\b(FYI\s*?)0{0,3}(\d+)\b", '<a href="/doc/fyi\\2/">\\1\\2</a>'),
-    ]
-
-    for pat, subst in patterns:
-        repl = re.sub(pat, subst, string, flags=re.IGNORECASE)
-        if repl != string:
-            string = repl
-            break
+    string = re.sub(r"(?<!>)\b(RFC\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/rfc\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(BCP\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/bcp\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(STD\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/std\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(FYI\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/fyi\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(draft-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(bofreq-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(conflict-review-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(status-change-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
+    string = re.sub(r"(?<!>)\b(charter-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
     return mark_safe(string)
 urlize_ietf_docs = stringfilter(urlize_ietf_docs)
 

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -192,15 +192,12 @@ def urlize_ietf_docs(string, autoescape=None):
     """
     if autoescape and not isinstance(string, SafeData):
         string = escape(string)
-    string = re.sub(r"(?<!>)\b(RFC\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/rfc\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(BCP\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/bcp\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(STD\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/std\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(FYI\s*?)0{0,3}(\d+)\b", "<a href=\"/doc/fyi\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(draft-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(bofreq-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(conflict-review-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(status-change-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(?<!>)\b(charter-[-0-9a-zA-Z._+]+)\b", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
+    string = re.sub(
+        r"\b((RFC|BCP|STD|FYI|(?:draft-|bofreq-|conflict-review-|status-change-|charter-)[-\d\w.+]+)\s*0*(\d+))\b",
+        lambda x: f'<a href="/doc/{x[2].strip().lower()}{x[3]}/">{x[1]}</a>',
+        string,
+        flags=re.IGNORECASE | re.ASCII,
+    )
     return mark_safe(string)
 urlize_ietf_docs = stringfilter(urlize_ietf_docs)
 

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -193,15 +193,15 @@ def urlize_ietf_docs(string, autoescape=None):
     if autoescape and not isinstance(string, SafeData):
         string = escape(string)
     patterns = [
-        (r"(draft-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
-        (r"(bofreq-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
-        (r"(conflict-review-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
-        (r"(status-change-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
-        (r"(charter-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
-        (r"(RFC\s*?)0{0,3}(\d+)", '<a href="/doc/rfc\\2/">\\1\\2</a>'),
-        (r"(BCP\s*?)0{0,3}(\d+)", '<a href="/doc/bcp\\2/">\\1\\2</a>'),
-        (r"(STD\s*?)0{0,3}(\d+)", '<a href="/doc/std\\2/">\\1\\2</a>'),
-        (r"(FYI\s*?)0{0,3}(\d+)", '<a href="/doc/fyi\\2/">\\1\\2</a>'),
+        (r"\b(draft-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
+        (r"\b(bofreq-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
+        (r"\b(conflict-review-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
+        (r"\b(status-change-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
+        (r"\b(charter-[-0-9a-zA-Z._+]+)\b", '<a href="/doc/\\1/">\\1</a>'),
+        (r"\b(RFC\s*?)0{0,3}(\d+)\b", '<a href="/doc/rfc\\2/">\\1\\2</a>'),
+        (r"\b(BCP\s*?)0{0,3}(\d+)\b", '<a href="/doc/bcp\\2/">\\1\\2</a>'),
+        (r"\b(STD\s*?)0{0,3}(\d+)\b", '<a href="/doc/std\\2/">\\1\\2</a>'),
+        (r"\b(FYI\s*?)0{0,3}(\d+)\b", '<a href="/doc/fyi\\2/">\\1\\2</a>'),
     ]
 
     for pat, subst in patterns:

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -192,15 +192,24 @@ def urlize_ietf_docs(string, autoescape=None):
     """
     if autoescape and not isinstance(string, SafeData):
         string = escape(string)
-    string = re.sub(r"(RFC\s*?)0{0,3}(\d+)", "<a href=\"/doc/rfc\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(BCP\s*?)0{0,3}(\d+)", "<a href=\"/doc/bcp\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(STD\s*?)0{0,3}(\d+)", "<a href=\"/doc/std\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(FYI\s*?)0{0,3}(\d+)", "<a href=\"/doc/fyi\\2/\">\\1\\2</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(draft-[-0-9a-zA-Z._+]+)", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(bofreq-[-0-9a-zA-Z._+]+)", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(conflict-review-[-0-9a-zA-Z._+]+)", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(status-change-[-0-9a-zA-Z._+]+)", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
-    string = re.sub(r"(charter-[-0-9a-zA-Z._+]+)", "<a href=\"/doc/\\1/\">\\1</a>", string, flags=re.IGNORECASE)
+    patterns = [
+        (r"(draft-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
+        (r"(bofreq-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
+        (r"(conflict-review-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
+        (r"(status-change-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
+        (r"(charter-[-0-9a-zA-Z._+]+)", '<a href="/doc/\\1/">\\1</a>'),
+        (r"(RFC\s*?)0{0,3}(\d+)", '<a href="/doc/rfc\\2/">\\1\\2</a>'),
+        (r"(BCP\s*?)0{0,3}(\d+)", '<a href="/doc/bcp\\2/">\\1\\2</a>'),
+        (r"(STD\s*?)0{0,3}(\d+)", '<a href="/doc/std\\2/">\\1\\2</a>'),
+        (r"(FYI\s*?)0{0,3}(\d+)", '<a href="/doc/fyi\\2/">\\1\\2</a>'),
+    ]
+
+    for pat, subst in patterns:
+        repl = re.sub(pat, subst, string, flags=re.IGNORECASE)
+        print(repl, string)
+        if repl != string:
+            string = repl
+            break
     return mark_safe(string)
 urlize_ietf_docs = stringfilter(urlize_ietf_docs)
 

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -206,7 +206,6 @@ def urlize_ietf_docs(string, autoescape=None):
 
     for pat, subst in patterns:
         repl = re.sub(pat, subst, string, flags=re.IGNORECASE)
-        print(repl, string)
         if repl != string:
             string = repl
             break

--- a/ietf/doc/templatetags/tests_ietf_filters.py
+++ b/ietf/doc/templatetags/tests_ietf_filters.py
@@ -1,0 +1,27 @@
+from ietf.doc.templatetags.ietf_filters import urlize_ietf_docs
+from ietf.utils.test_utils import TestCase
+
+# TODO: most other filters need test cases, too
+
+
+class IetfFiltersTests(TestCase):
+    def test_urlize_ietf_docs(self):
+        cases = [
+            ("no change", "no change"),
+            ("bcp1", '<a href="/doc/bcp1/">bcp1</a>'),
+            ("Std 003", '<a href="/doc/std3/">Std 003</a>'),
+            (
+                "FYI02 changes Std 003",
+                '<a href="/doc/fyi2/">FYI02</a> changes <a href="/doc/std3/">Std 003</a>',
+            ),
+            ("rfc2119", '<a href="/doc/rfc2119/">rfc2119</a>'),
+            ("Rfc 02119", '<a href="/doc/rfc2119/">Rfc 02119</a>'),
+            ("draft-abc-123", '<a href="/doc/draft-abc-123/">draft-abc-123</a>'),
+            (
+                "draft-ietf-rfc9999-bis-01",
+                '<a href="/doc/draft-ietf-rfc9999-bis-01/">draft-ietf-rfc9999-bis-01</a>',
+            ),
+        ]
+
+        for input, output in cases:
+            self.assertEqual(urlize_ietf_docs(input), output)


### PR DESCRIPTION
The old code would first substitute the `rfx<nnnn>` part, and then again
on the full draft name. This now only ever applies one substitute,
and does longer ones first.