### PR TITLE
fix: point to github releases in about page

### DIFF
--- a/ietf/templates/release/about.html
+++ b/ietf/templates/release/about.html
@@ -16,7 +16,7 @@
       The Datatracker is an open-source project, using <a href="https://github.com/ietf-tools/datatracker">GitHub</a>.
     </p>
     <p>
-      There are <a href="{% url 'releaseabout' %}">release notes</a> available since version 2.00.
+      There are <a href="https://github.com/ietf-tools/datatracker/releases">release notes</a> available since version 2.00.
     </p>
     <p>
         Below you'll find a brief history of the datatracker development, in terms of the big


### PR DESCRIPTION
The release notes link on the about page currently links to itself, instead of the github releases page.