### PR TITLE
fix: Color the background of table rows for an AD based on their ballot

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -362,6 +362,29 @@ td.position-empty {
     border: none !important;
 }
 
+tr.position-moretime-row,
+tr.position-notready-row,
+tr.position-discuss-row,
+tr.position-block-row {
+    background-color: tint-color($color-discuss, 90%);
+}
+
+tr.position-yes-row {
+    background-color: tint-color($color-yes, 90%);
+}
+
+tr.position-noobj-row {
+    background-color: tint-color($color-noobj, 90%);
+}
+
+tr.position-abstain-row {
+    background-color: tint-color($color-abstain, 90%);
+}
+
+tr.position-recuse-row {
+    background-color: tint-color($color-recuse, 90%);
+}
+
 
 /* === Edit Meeting Schedule ====================================== */
 

--- a/ietf/templates/doc/search/search_result_row.html
+++ b/ietf/templates/doc/search/search_result_row.html
@@ -6,11 +6,7 @@
 {% load ballot_icon %}
 {% load person_filters %}
 {% load django_bootstrap5 %}
-<tr{% spaceless %}
-    {% if color_ad_position %} {% with doc|ballotposition:user as pos %} {% if pos %}class="position-{{ pos.slug }}-row"{% endif %}
-    {% endwith %}
-    {% endif %}
-    {% endspaceless %}>
+<tr {% if color_ad_position %}{% with doc|ballotposition:user as pos %}{% if pos %}class="position-{{ pos.slug }}-row"{% endif %}{% endwith %}{% endif %}>
     <td>
         {% if user.is_authenticated %}
             <a href="{% url "ietf.community.views.untrack_document" username=request.user.username name=doc.name %}"
@@ -154,10 +150,5 @@
                         {% email_person_link doc.shepherd title="Shepherd" class="small text-muted" %}
                     {% endif %}
                 </td>
-            {% endif %}
-            {% if color_ad_position %}
-                {% with doc|ballotposition:user as pos %}
-                    <td {% if pos %}class="changebar position-{{ pos.slug }}"{% endif %}></td>
-                {% endwith %}
             {% endif %}
         </tr>

--- a/ietf/templates/doc/search/search_results.html
+++ b/ietf/templates/doc/search/search_results.html
@@ -46,11 +46,7 @@
     <tbody>
         <tr class="table-info">
             <td></td>
-            {% if color_ad_position %}
-                <th scope="col" colspan="{{ meta.headers|length }}">
-            {% else %}
-                <th scope="col" colspan="{{ meta.headers|length|add:"-1" }}">
-            {% endif %}
+            <th scope="col" colspan="{{ meta.headers|length|add:"-1" }}">
             {{ doc_group.grouper|plural:doc_group.list }} ({{ doc_group.list|length }} {{"hit"|plural:doc_group.list }})
             </th>
         </tr>

--- a/ietf/templates/iesg/agenda_documents.html
+++ b/ietf/templates/iesg/agenda_documents.html
@@ -51,7 +51,6 @@
                                 <th scope="col" data-sort="status">Status</th>
                                 <th scope="col" class="d-none d-sm-table-cell" data-sort="ipr">IPR</th>
                                 <th scope="col" class="d-none d-sm-table-cell" data-sort="ad">AD/Shepherd</th>
-                                <th scope="col"></th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Instead of just adding a colored bar on the right-hand side. Fixes #3839.