### PR TITLE
musing: adding meeting buttons to group meetings page

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -771,6 +771,10 @@ def meetings(request, acronym=None, group_type=None):
         current_status__in=['sched','schedw','appr','canceled'],
     )
 
+    for s in sessions:
+        s.use_codimd = True if s.meeting.date>=settings.MEETING_USES_CODIMD_DATE else False
+
+
     future, in_progress, recent, past = group_sessions(sessions)
 
     can_edit = group.has_role(request.user,group.features.groupman_roles)
@@ -785,6 +789,7 @@ def meetings(request, acronym=None, group_type=None):
                      'past':past,
                      'can_edit':can_edit,
                      'can_always_edit':can_always_edit,
+                    'now': datetime.datetime.now(),
                   }))
 
 def chair_photos(request, group_type=None):

--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -139,7 +139,7 @@ def preprocess_assignments_for_agenda(assignments_queryset, meeting, extra_prefe
     parent_id_set = set()
     for a in assignments:
         if a.session and a.session.group:
-            a.session.historic_group = group_replacements.get(a.session.group_id)
+            #a.session.historic_group = group_replacements.get(a.session.group_id)
 
             if a.session.historic_group:
                 a.session.historic_group.historic_parent = None

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -47,7 +47,9 @@ from ietf.utils.validators import (
     validate_file_extension,
 )
 from ietf.utils.fields import MissingOkImageField
+from ietf.utils.history import find_history_replacements_active_at
 from ietf.utils.log import unreachable
+
 
 countries = list(pytz.country_names.items())
 countries.sort(key=lambda x: x[1])
@@ -1257,10 +1259,16 @@ class Session(models.Model):
             
         return self._agenda_file
 
+    @property
+    def historic_group(self):
+            group_replacements = find_history_replacements_active_at([self.group], datetime.datetime.combine(self.meeting.date, datetime.time()))
+            return group_replacements.get(self.group_id)
+
+
     def jabber_room_name(self):
         if self.type_id=='plenary':
             return 'plenary'
-        elif self.historic_group:
+        elif getattr(self,'historic_group',None):
             return self.historic_group.acronym
         else:
             return self.group.acronym

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2186,12 +2186,6 @@ def session_details(request, num, acronym):
     status_names = {n.slug: n.name for n in SessionStatusName.objects.all()}
     for session in sessions:
 
-        session.historic_group = None 
-        if session.group: 
-            session.historic_group = group_replacements.get(session.group_id) 
-            if session.historic_group: 
-                session.historic_group.historic_parent = None 
-
         session.type_counter = Counter()
         ss = session.timeslotassignments.filter(schedule__in=[meeting.schedule, meeting.schedule.base if meeting.schedule else None]).order_by('timeslot__time')
         if ss:

--- a/ietf/templates/group/meetings-row.html
+++ b/ietf/templates/group/meetings-row.html
@@ -57,7 +57,21 @@
                href="{% url 'ietf.meeting.views.session_details' num=s.meeting.number acronym=s.group.acronym %}">
                 Materials
             </a>
-            {% if can_always_edit or can_edit_materials %}
+            {{s}}
+            {% if not s.cancelled %}
+                <div class="regular float-end">
+                    {# see note in the included templates re: show_agenda parameter and required JS import #}
+                    {% if s.meeting.type.slug == 'interim' %}
+                        {% include "meeting/interim_session_buttons.html" with show_agenda=False show_empty=False session=s meeting=s.meeting use_codimd=s.use_codimd %}
+                    {% else %}
+                        {% with schedule=s.meeting.schedule %}
+                            {% include "meeting/session_buttons_include.html" with show_agenda=False item=s.official_timeslotassignment session=s meeting=s.meeting use_codimd=s.use_codimd %}
+                        {% endwith %}
+                    {% endif %}
+                </div>
+            {% endif %}
+  
+          {% if can_always_edit or can_edit_materials %}
                 <a class="btn btn-info btn-sm float-end"
                    href="{% url 'ietf.meeting.views.session_details' num=s.meeting.number acronym=s.group.acronym %}">
                     Edit Materials


### PR DESCRIPTION
This is not complete, and is likely not the way to go.

This quick exploration points again to the need to simplify the meeting agenda view helpers that currently glob a lot of state in unexpected ways onto the objects being passed in, refactoring what's really needed back to the objects that should be responsible (while keeping an eye out for any negative impacts on performance).