### PR TITLE
fix: refactor/correct calculation of week-view event start/end times

### DIFF
--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -622,30 +622,29 @@ class TimeSlot(models.Model):
             return self.tz().tzname(self.time)
         else:
             return ""
+
     def utc_start_time(self):
         if self.tz():
             local_start_time = self.tz().localize(self.time)
             return local_start_time.astimezone(pytz.utc)
         else:
             return None
+
     def utc_end_time(self):
-        if self.tz():
-            local_end_time = self.tz().localize(self.end_time())
-            return local_end_time.astimezone(pytz.utc)
-        else:
-            return None
+        utc_start = self.utc_start_time()
+        # Add duration after converting start time, otherwise errors creep in around DST change
+        return None if utc_start is None else utc_start + self.duration
+
     def local_start_time(self):
         if self.tz():
-            local_start_time = self.tz().localize(self.time)
-            return local_start_time
+            return self.tz().localize(self.time)
         else:
             return None
+
     def local_end_time(self):
-        if self.tz():
-            local_end_time = self.tz().localize(self.end_time())
-            return local_end_time
-        else:
-            return None
+        local_start = self.local_start_time()
+        # Add duration after converting start time, otherwise errors creep in around DST change
+        return None if local_start is None else local_start + self.duration
 
     @property
     def js_identifier(self):


### PR DESCRIPTION
Around DST switchover dates, the agenda week-view display had some errors in its timestamp calculations. These led to sessions ending at timestamps earlier than when they started. This straightens that out and refactors the code for clarity.

There were also similar bugs in the `TimeSlot` local and utc start/end time helper functions. These are fixed as well.