### PR TITLE
chore: run devcontainer as user vscode instead of root

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -96,11 +96,11 @@
             "label": "MariaDB",
             "onAutoForward": "silent"
         }
-    }
+    },
     
     // Use 'postCreateCommand' to run commands after the container is created.
     // "postCreateCommand": "sh /docker-init.sh",
     
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    // "remoteUser": "django"
+    "remoteUser": "vscode"
 }

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -114,11 +114,6 @@ ENV LC_ALL en_US.UTF-8
 ADD https://raw.githubusercontent.com/ietf-tools/idnits-mirror/main/idnits /usr/local/bin/
 RUN chmod +rx /usr/local/bin/idnits
 
-# Install current datatracker python dependencies
-COPY requirements.txt /tmp/pip-tmp/
-RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-    && rm -rf /tmp/pip-tmp
-
 # Turn off rsyslog kernel logging (doesn't work in Docker)
 RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 
@@ -136,5 +131,12 @@ RUN sed -i 's/\r$//' /docker-init.sh && \
 # Create workspace
 RUN mkdir -p /workspace
 WORKDIR /workspace
+
+USER vscode:vscode
+
+# Install current datatracker python dependencies
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install --user -r /tmp/pip-tmp/requirements.txt
+RUN sudo rm -rf /tmp/pip-tmp
 
 # ENTRYPOINT [ "/docker-init.sh" ]

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -2,11 +2,11 @@
 
 WORKSPACEDIR="/workspace"
 
-service rsyslog start
+sudo service rsyslog start
 
 # fix permissions for npm-related paths
 WORKSPACE_UID_GID=$(stat --format="%u:%g" "$WORKSPACEDIR")
-chown -R "$WORKSPACE_UID_GID" "$WORKSPACEDIR/.parcel-cache"
+sudo chown -R "$WORKSPACE_UID_GID" "$WORKSPACEDIR/.parcel-cache"
 
 # Build node packages that requrie native compilation
 echo "Compiling native node packages..."
@@ -71,7 +71,8 @@ fi
 
 # Run memcached
 
-/usr/bin/memcached -u root -d
+echo "Starting memcached..."
+/usr/bin/memcached -u vscode -d
 
 # Initial checks
 
@@ -99,6 +100,6 @@ if [ -z "$EDITOR_VSCODE" ]; then
         bash -c "$*"
         CODE=$?
     fi
-    service rsyslog stop
+    sudo service rsyslog stop
     exit $CODE
 fi


### PR DESCRIPTION
The dev container currently runs as root, which causes file ownership issues when using a linux host.

Docker for Mac and Windows automatically map root to the current user, but not on Linux where new files are created as root.

This PR makes the container run as `vscode` (the image default user). You can still use `sudo` if you need root access inside the container.