### PR TITLE
fix: escape the ballot comments

### DIFF
--- a/ietf/templates/doc/document_ballot_content.html
+++ b/ietf/templates/doc/document_ballot_content.html
@@ -122,7 +122,7 @@
                                 </div>
                             </div>
                             <div class="card-body">
-                                <pre class="ballot pasted">{{ p.discuss|urlize_ietf_docs|linkify }}</pre>
+                                <pre class="ballot pasted">{{ p.discuss|escape|urlize_ietf_docs|linkify }}</pre>
                             </div>
                         </div>
                     {% endif %}
@@ -148,7 +148,7 @@
                                 </div>
                             </div>
                             <div class="card-body">
-                                <pre class="ballot pasted">{{ p.comment|urlize_ietf_docs|linkify }}</pre>
+                                <pre class="ballot pasted">{{ p.comment|escape|urlize_ietf_docs|linkify }}</pre>
                             </div>
                         </div>
                     {% endif %}
@@ -199,11 +199,11 @@
                         </div>
                         {% if p.pos.blocking and p.discuss %}
                             <div class="card-body">
-                                <pre class="ballot pasted">{{ p.discuss|urlize_ietf_docs|linkify }}</pre>
+                                <pre class="ballot pasted">{{ p.discuss|escape|urlize_ietf_docs|linkify }}</pre>
                             </div>
                         {% else %}
                             <div class="card-body">
-                                <pre class="ballot pasted">{{ p.comment|urlize_ietf_docs|linkify }}</pre>
+                                <pre class="ballot pasted">{{ p.comment|escape|urlize_ietf_docs|linkify }}</pre>
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
I wonder if other fields that have class `pasted` would need to be escaped, too?