### PR TITLE
test: make tests run without root access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,9 @@ datatracker.sublime-workspace
 /share
 /static
 /testresult
+/.testresult
 /tmp
-/tmp-nomcom-public-keys-dir
+/tmp-*
 /trunk27
 /trunk36
 /trunk37

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -136,7 +136,7 @@ USER vscode:vscode
 
 # Install current datatracker python dependencies
 COPY requirements.txt /tmp/pip-tmp/
-RUN pip3 --disable-pip-version-check --no-cache-dir install --user -r /tmp/pip-tmp/requirements.txt
+RUN pip3 --disable-pip-version-check --no-cache-dir install --user --no-warn-script-location -r /tmp/pip-tmp/requirements.txt
 RUN sudo rm -rf /tmp/pip-tmp
 
 # ENTRYPOINT [ "/docker-init.sh" ]

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -422,8 +422,7 @@ def save_test_results(failures, test_labels):
     # Record the test result in a file, in order to be able to check the
     # results and avoid re-running tests if we've alread run them with OK
     # result after the latest code changes:
-    topdir = os.path.dirname(os.path.dirname(settings.BASE_DIR))
-    tfile = io.open(os.path.join(topdir,".testresult"), "a", encoding='utf-8')
+    tfile = io.open(".testresult", "a", encoding='utf-8')
     timestr = time.strftime("%Y-%m-%d %H:%M:%S")
     if failures:
         tfile.write("%s FAILED (failures=%s)\n" % (timestr, failures))
@@ -929,7 +928,7 @@ class IetfTestRunner(DiscoverRunner):
         testcase = TestCase()
         cwd = pathlib.Path.cwd()
         tmpdir = tempfile.TemporaryDirectory(prefix="html-validate-")
-        Path(tmpdir.name).chmod(0o655)
+        Path(tmpdir.name).chmod(0o777)
         for (name, content, fingerprint) in self.batches[kind]:
             path = pathlib.Path(tmpdir.name).joinpath(
                 hex(fingerprint)[2:],


### PR DESCRIPTION
Tests are currently failing inside the dev container due to python writing files to a directory with 0655 and asking html-validate to read them, resulting in permission denied errors.