### PR TITLE
fix(ui): import moment.js library with moment-timezone support in wrapper

### DIFF
--- a/ietf/static/js/moment-timezone-with-data-10-year-range.js
+++ b/ietf/static/js/moment-timezone-with-data-10-year-range.js
@@ -1,1 +1,0 @@
-import "moment-timezone/builds/moment-timezone-with-data-10-year-range";

--- a/ietf/static/js/moment.js
+++ b/ietf/static/js/moment.js
@@ -2,4 +2,4 @@
  * Moment.js are eliminated. When that happens, can import moment in the js files
  * that need it. */
 import moment from "moment-timezone/builds/moment-timezone-with-data-10-year-range";
-global.moment = moment;
+window.moment = moment;

--- a/ietf/static/js/moment.js
+++ b/ietf/static/js/moment.js
@@ -1,3 +1,5 @@
-const moment = require("moment");
-
+/* Add the moment object to the global scope - needed until inline scripts using
+ * Moment.js are eliminated. When that happens, can import moment in the js files
+ * that need it. */
+import moment from "moment-timezone/builds/moment-timezone-with-data-10-year-range";
 global.moment = moment;

--- a/ietf/static/js/timezone.js
+++ b/ietf/static/js/timezone.js
@@ -10,6 +10,7 @@
  */
 (function () {
     'use strict';
+
     // Callback for timezone change - called after current_timezone is updated
     let timezone_change_callback;
     let current_timezone;

--- a/ietf/templates/meeting/agenda.html
+++ b/ietf/templates/meeting/agenda.html
@@ -428,8 +428,6 @@
     </script>
     <script src="{% static 'ietf/js/moment.js' %}">
     </script>
-    <script src="{% static 'ietf/js/moment-timezone-with-data-10-year-range.js' %}">
-    </script>
     <script src="{% static 'ietf/js/timezone.js' %}">
     </script>
     <script src="{% static 'ietf/js/agenda_materials.js' %}">

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -25,7 +25,6 @@
 {% block title %}{{ schedule.name }}: IETF {{ meeting.number }} meeting agenda{% endblock %}
 {% block js %}
         <script src="{% static 'ietf/js/moment.js' %}"></script>
-        <script src="{% static 'ietf/js/moment-timezone-with-data-10-year-range.js' %}"></script>
         <script src="{% static 'ietf/js/edit-meeting-schedule.js' %}"></script>
     {% endblock %}
     {% block content %}

--- a/ietf/templates/meeting/upcoming.html
+++ b/ietf/templates/meeting/upcoming.html
@@ -112,7 +112,6 @@
     <script src="{% static 'ietf/js/list.js' %}"></script>
     <script src="{% static 'ietf/js/fullcalendar.js' %}"></script>
     <script src="{% static 'ietf/js/moment.js' %}"></script>
-    <script src="{% static 'ietf/js/moment-timezone-with-data-10-year-range.js' %}"></script>
     <script src="{% static 'ietf/js/agenda_filter.js' %}"></script>
     <script src="{% static 'ietf/js/agenda_materials.js' %}"></script>
     <script src="{% static 'ietf/js/timezone.js' %}"></script>

--- a/ietf/templates/meeting/week-view.html
+++ b/ietf/templates/meeting/week-view.html
@@ -12,7 +12,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="{% static 'ietf/js/agenda_filter.js' %}"></script>
         <script src="{% static 'ietf/js/moment.js' %}"></script>
-        <script src="{% static 'ietf/js/moment-timezone-with-data-10-year-range.js' %}"></script>
         <script src="{% static 'ietf/js/week-view.js' %}"></script>
         <script>
         var all_items = {{ items | safe }};

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         "ietf/static/js/manage-community-list.js",
         "ietf/static/js/manage-review-requests.js",
         "ietf/static/js/meeting-interim-request.js",
-        "ietf/static/js/moment-timezone-with-data-10-year-range.js",
         "ietf/static/js/moment.js",
         "ietf/static/js/password_strength.js",
         "ietf/static/js/review-stats.js",


### PR DESCRIPTION
Packaging changes broke the mechanism used to make moment.tz available to javascript code. This eliminates the separate moment.js and moment-timezone-with-data-10-year-range.js wrappers and instead imports the timezone-augmented version directly. This provides both the timezone support and the regular moment features.