### PR TITLE
musing: Don't show a scrollbar for the righthand nav

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -176,7 +176,16 @@ table tbody.meta {
 #righthand-nav {
     height: 70vh;
     width: inherit;
+
+    -ms-overflow-style: none; // Hide scrollbar for IE and Edge and Firefox
+    scrollbar-width: none; // Hide scrollbar for Firefox
 }
+
+// Hide scrollbar for Chrome, Safari and Opera
+#righthand-nav::-webkit-scrollbar {
+    display: none;
+}
+
 
 // Add some padding when there are multiple buttons in a line than can wrap
 .buttonlist .btn {


### PR DESCRIPTION
This means that the scrollbars for the nav and the main content will no longer
overlap. But it also means the nav can't be directly scrolled anymore (just via
swiping, etc.)

I'm not sure this is a good tradeoff, but I think someone complained about the
overlap. FWIW, there doesn't seem to be a CSS way to move the scrollbars of the
nav to the left.