### PR TITLE
fix: Don't urlencode all resource URLs

### DIFF
--- a/ietf/templates/doc/document_bofreq.html
+++ b/ietf/templates/doc/document_bofreq.html
@@ -107,7 +107,7 @@
                             {% if resources %}
                                 {% for resource in resources|dictsort:"display_name" %}
                                     {% if resource.name.type.slug == 'url' or resource.name.type.slug == 'email' %}
-                                        <a href="{{ resource.value|urlencode }}" title="{{ resource.name.name }}">
+                                        <a href="{{ resource.value }}" title="{{ resource.name.name }}">
                                             {% firstof resource.display_name resource.name.name %}
                                         </a>
                                         <br>

--- a/ietf/templates/doc/document_draft.html
+++ b/ietf/templates/doc/document_draft.html
@@ -366,7 +366,7 @@
                             {% if resources or doc.group and doc.group.list_archive %}
                                 {% for resource in resources|dictsort:"display_name" %}
                                     {% if resource.name.type.slug == 'url' or resource.name.type.slug == 'email' %}
-                                        <a href="{{ resource.value|urlencode }}" title="{{ resource.name.name }}">
+                                        <a href="{{ resource.value }}" title="{{ resource.name.name }}">
                                             {% firstof resource.display_name resource.name.name %}
                                         </a>
                                         <br>

--- a/ietf/templates/group/group_about.html
+++ b/ietf/templates/group/group_about.html
@@ -150,7 +150,7 @@
                                 {% for resource in resources|dictsort:"display_name" %}
                                     {# Maybe make how a resource displays itself a method on the class so templates aren't doing this switching #}
                                     {% if resource.name.type.slug == 'url' or resource.name.type.slug == 'email' %}
-                                        <a href="{{ resource.value|urlencode }}" title="{{ resource.name.name }}">
+                                        <a href="{{ resource.value }}" title="{{ resource.name.name }}">
                                             {% firstof resource.display_name resource.name.name %}</a>{% else %}
                                         <span title="{{ resource.name.name }}">
                                             {% firstof resource.display_name resource.name.name %}: {{ resource.value|escape }}

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -177,6 +177,7 @@ def vnu_filter_message(msg, filter_db_issues, filter_test_issues):
     "True if the vnu message is a known false positive"
     if filter_db_issues and re.search(
         r"""^Forbidden\ code\ point\ U\+|
+             Illegal\ character\ in\ query:\ '\['|
             'href'\ on\ element\ 'a':\ Percentage\ \("%"\)\ is\ not\ followed|
             ^Saw\ U\+\d+\ in\ stream|
             ^Document\ uses\ the\ Unicode\ Private\ Use\ Area""",


### PR DESCRIPTION
While this does suppress errors, it breaks even valid URLs. Instead, just
suppress the validation error for those few cases in the database.

Fixes #3984