### PR TITLE
fix: Make AD position colors more noticeable

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -368,23 +368,23 @@ tr.position-moretime-row,
 tr.position-notready-row,
 tr.position-discuss-row,
 tr.position-block-row {
-    background-color: tint-color($color-discuss, 90%);
+    background-color: tint-color($color-discuss, 85%);
 }
 
 tr.position-yes-row {
-    background-color: tint-color($color-yes, 90%);
+    background-color: tint-color($color-yes, 85%);
 }
 
 tr.position-noobj-row {
-    background-color: tint-color($color-noobj, 90%);
+    background-color: tint-color($color-noobj, 50%);
 }
 
 tr.position-abstain-row {
-    background-color: tint-color($color-abstain, 90%);
+    background-color: tint-color($color-abstain, 85%);
 }
 
 tr.position-recuse-row {
-    background-color: tint-color($color-recuse, 90%);
+    background-color: tint-color($color-recuse, 85%);
 }
 
 

--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -372,7 +372,7 @@ tr.position-block-row {
 }
 
 tr.position-yes-row {
-    background-color: tint-color($color-yes, 85%);
+    background-color: tint-color($color-yes, 75%);
 }
 
 tr.position-noobj-row {

--- a/ietf/templates/iesg/agenda_documents.html
+++ b/ietf/templates/iesg/agenda_documents.html
@@ -42,7 +42,7 @@
                     {% if num|sectionlevel == 3 %}<h5 class="mt-3">{{ num }} {{ section.title|safe }}</h5>{% endif %}
                 {% endif %}
                 {% if "docs" in section and section.docs %}
-                    <table class="table table-sm table-striped tablesorter">
+                    <table class="table table-sm tablesorter">
                         <thead>
                             <tr>
                                 <th scope="col"></th>

--- a/ietf/templates/iesg/agenda_documents.html
+++ b/ietf/templates/iesg/agenda_documents.html
@@ -42,7 +42,7 @@
                     {% if num|sectionlevel == 3 %}<h5 class="mt-3">{{ num }} {{ section.title|safe }}</h5>{% endif %}
                 {% endif %}
                 {% if "docs" in section and section.docs %}
-                    <table class="table table-sm tablesorter">
+                    <table class="table table-sm {% if not user|has_role:'Area Director' %}table-striped{% endif %} tablesorter">
                         <thead>
                             <tr>
                                 <th scope="col"></th>


### PR DESCRIPTION
Also remove the striping of the table, which makes it easier to notice which
documents are missing a ballot.

Fixes #4008.