### PR TITLE
chore: fix missing devcontainer dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,7 @@
         "dbaeumer.vscode-eslint",
 		"eamodio.gitlens",
 		"editorconfig.editorconfig",
-		"johnsoncodehk.volar",
+		"vue.volar",
 		"mrmlnc.vscode-duplicate",
 		"ms-azuretools.vscode-docker",
 		"ms-python.python",

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -42,9 +42,11 @@ RUN groupmod --gid $USER_GID $USERNAME \
     && chown -R $USER_UID:$USER_GID /home/$USERNAME \
     || exit 0
 
+# Switch to local dev user
 USER dev:dev
 
 # Install current datatracker python dependencies
 COPY requirements.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install --user --no-warn-script-location -r /tmp/pip-tmp/requirements.txt
+RUN pip3 --disable-pip-version-check --no-cache-dir install --user --no-warn-script-location pylint pylint-common pylint-django
 RUN sudo rm -rf /tmp/pip-tmp

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -4,8 +4,9 @@ LABEL maintainer="IETF Tools Team <tools-discuss@ietf.org>"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update system packages
-RUN apt-get update
-RUN apt-get -qy upgrade
+RUN apt-get update \
+    && apt-get -qy upgrade \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1
 
 # Add Node.js Source
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
@@ -19,7 +20,6 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/d
 RUN apt-get update --fix-missing && apt-get install -qy \
 	apache2-utils \
 	apt-file \
-	apt-utils \
 	bash \
 	build-essential \
 	curl \


### PR DESCRIPTION
- add pylint, pylint-common, pylint-django
- install apt-utils before other packages to avoid warnings
- change volar extension to new id