### PR TITLE
chore: add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Files to be excluded from the docker build context
+
+/.git
+/.github
+/svn-history
+/data
+/tmp-*


### PR DESCRIPTION
Add dockerignore to speed up the docker build process by excluding the quite large `.git` directory.