### PR TITLE
fix: skip assets volume in cleandb script + add confirm prompt to cleanall

### DIFF
--- a/docker/cleanall
+++ b/docker/cleanall
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-cd ..
-echo "Shutting down any instance still running and purge images..."
-docker compose down -v --rmi all
-echo "Purging dangling images..."
-docker image prune
-cd docker
-echo "Done!"
+read -p "Stop and remove all containers, volumes and images for this project? [y/N] " -n 1 -r
+echo 
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    cd ..
+    echo "Shutting down any instance still running and purge images..."
+    docker compose down -v --rmi all
+    echo "Purging dangling images..."
+    docker image prune
+    cd docker
+    echo "Done!"
+fi

--- a/docker/cleanall
+++ b/docker/cleanall
@@ -7,8 +7,6 @@ then
     cd ..
     echo "Shutting down any instance still running and purge images..."
     docker compose down -v --rmi all
-    echo "Purging dangling images..."
-    docker image prune
     cd docker
     echo "Done!"
 fi

--- a/docker/cleandb
+++ b/docker/cleandb
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-echo "Shutting down any instance still running..."
 cd ..
-docker compose down -v
+echo "Shutting down any instance still running..."
+docker compose down
+echo "Removing DB volume..."
+PROJNAME=$(basename $PWD)
+docker volume rm -f "${PROJNAME}_mariadb-data"
 echo "Rebuilding the DB image..."
 docker compose pull db
 docker compose build --no-cache db


### PR DESCRIPTION
- Change the `cleandb` script to only remove the DB volume instead of all volumes.
- Add a confirm prompt to the `cleanall` script.