### PR TITLE
fix: Fix include of bootstrap-icons

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -56,6 +56,11 @@ $popover-max-width: 100%;
 // Utilities
 @import "bootstrap/scss/utilities/api";
 
+// Make the bootstrap icons available.
+$bootstrap-icons-font-src: url("npm:bootstrap-icons/font/fonts/bootstrap-icons.woff2") format("woff2"),
+url("npm:bootstrap-icons/font/fonts/bootstrap-icons.woff") format("woff");
+@import "bootstrap-icons/font/bootstrap-icons";
+
 // Leave room for fixed-top navbar...
 body {
     padding-top: 60px;

--- a/ietf/static/js/ietf.js
+++ b/ietf/static/js/ietf.js
@@ -16,9 +16,6 @@ import "bootstrap/js/dist/tooltip";
 
 import jquery from "jquery";
 
-// Make the bootstrap icons available. Yes, we require CSS in JS, parcel wants this.
-require("bootstrap-icons/font/bootstrap-icons.css");
-
 window.$ = window.jQuery = jquery;
 if (!process.env.BUILD_DEPLOY) {
     // get warnings for using deprecated jquery features


### PR DESCRIPTION
This got broken in #4035, which included some things it wasn't meant to.