### PR TITLE
htmlized_base: remove errant backslash

### DIFF
--- a/ietf/templates/doc/htmlized_base.html
+++ b/ietf/templates/doc/htmlized_base.html
@@ -125,7 +125,7 @@
 
             {% block morecss %}{% endblock %}
         </style>
-        {% block pagehead %}{% endblock %}\
+        {% block pagehead %}{% endblock %}
         {% include "base/icons.html" %}
     </head>
     <body {% block bodyAttrs %}{% endblock %}>


### PR DESCRIPTION
This removes the backslash from the top of pages like e.g.
https://datatracker.ietf.org/doc/html/rfc9110.