### PR TITLE
fix: link 'Save' button with form on secr rooms template

### DIFF
--- a/ietf/secr/templates/includes/buttons_save.html
+++ b/ietf/secr/templates/includes/buttons_save.html
@@ -1,5 +1,0 @@
-<div class="button-group">
-    <ul>
-        <li><button type="submit" name="submit" value="Save">Save</button></li>
-    </ul>
-</div> <!-- button-group -->

--- a/ietf/secr/templates/meetings/rooms.html
+++ b/ietf/secr/templates/meetings/rooms.html
@@ -48,9 +48,18 @@
                 </form>
             </div>
         </div>
-
-            {% include "includes/buttons_save.html" %}
-
+        <div class="button-group">
+            <ul>
+                <li>
+                    <button type="submit"
+                            form="meetings-meta-rooms"
+                            name="submit"
+                            value="Save">
+                        Save
+                    </button>
+                </li>
+            </ul>
+        </div> <!-- button-group -->
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Restores ability to save rooms in the secr 'rooms' view.