### PR TITLE
fix: Remove stray space from end of href

### DIFF
--- a/ietf/templates/base/icons.html
+++ b/ietf/templates/base/icons.html
@@ -2,13 +2,13 @@
 {% load static %}
 <link rel="apple-touch-icon"
       sizes="180x180"
-      href="{% if server_mode and server_mode == 'production' %}{% static 'ietf/images/ietf-logo-nor-180.png' %}{% else %}{% static 'ietf/images/ietf-logo-nor-180-dev.png' %}{% endif %} ">
+      href="{% if server_mode and server_mode == 'production' %}{% static 'ietf/images/ietf-logo-nor-180.png' %}{% else %}{% static 'ietf/images/ietf-logo-nor-180-dev.png' %}{% endif %}">
 <link rel="icon"
       sizes="32x32"
-      href="{% if server_mode and server_mode == 'production' %}{% static 'ietf/images/ietf-logo-nor-32.png' %}{% else %}{% static 'ietf/images/ietf-logo-nor-32-dev.png' %}{% endif %} ">
+      href="{% if server_mode and server_mode == 'production' %}{% static 'ietf/images/ietf-logo-nor-32.png' %}{% else %}{% static 'ietf/images/ietf-logo-nor-32-dev.png' %}{% endif %}">
 <link rel="icon"
       sizes="16x16"
-      href="{% if server_mode and server_mode == 'production' %}{% static 'ietf/images/ietf-logo-nor-16.png' %}{% else %}{% static 'ietf/images/ietf-logo-nor-16-dev.png' %}{% endif %} ">
+      href="{% if server_mode and server_mode == 'production' %}{% static 'ietf/images/ietf-logo-nor-16.png' %}{% else %}{% static 'ietf/images/ietf-logo-nor-16-dev.png' %}{% endif %}">
 <link rel="manifest" href="/site.webmanifest">
 <link rel="mask-icon"
       href="{% static 'ietf/images/ietf-logo-nor-mask.svg' %}"

--- a/ietf/templates/group/group_about_rendertest.html
+++ b/ietf/templates/group/group_about_rendertest.html
@@ -11,7 +11,7 @@
     </div>
     <div class="row border-bottom text-center">
         <div class="col-md-6 border-end">&nbsp;</div>
-        <div class="col-md-6 "><input type="checkbox" class="form-check-input" name="widthconstraint"> Constrain width</input></div>
+        <div class="col-md-6"><input type="checkbox" class="form-check-input" name="widthconstraint"> Constrain width</input></div>
     </div>
     <div class="row">
         <div class="col-md-6 border-end">{{charter|linebreaks}}</div>

--- a/ietf/templates/meeting/interim_pending.html
+++ b/ietf/templates/meeting/interim_pending.html
@@ -31,7 +31,7 @@
                             <a class="interim-meeting-link"
                                href="{% url 'ietf.meeting.views.interim_request_details' number=meeting.number %}">
                                 {{ meeting.number }}
-                                {% if meeting.interim_meeting_cancelled %}<span class="badge rounded-pill bg-warning ms-1 ">Cancelled</span>{% endif %}
+                                {% if meeting.interim_meeting_cancelled %}<span class="badge rounded-pill bg-warning ms-1">Cancelled</span>{% endif %}
                             </a>
                         </td>
                         <td>

--- a/ietf/templates/meeting/proceedings/introduction.html
+++ b/ietf/templates/meeting/proceedings/introduction.html
@@ -2,7 +2,7 @@
 
 This renders the list of links below the title on the meeting proceedings page.
 {% endcomment %}
-<div class="proceedings-intro my-3 ">
+<div class="proceedings-intro my-3">
     <div class="proceedings-column">
         <div class="proceedings-row">
             <a href="{% url 'ietf.meeting.views.proceedings_overview' num=meeting.number %}">IETF Overview</a>


### PR DESCRIPTION
This caused the testcrawl to fail, because the new icons were a 404. Also
fix some similar stray spaces in some other tags.