### PR TITLE
fix: suppress profile link if user not linked to a Person

### DIFF
--- a/ietf/templates/base/menu_user.html
+++ b/ietf/templates/base/menu_user.html
@@ -45,12 +45,14 @@
                     Account info
                 </a>
             </li>
-            <li>
-                <a class="dropdown-item {% if flavor != 'top' %} text-wrap link-primary{% endif %}"
-                   href="{% url 'ietf.person.views.profile' email_or_name=user.person.name %}">
-                    Public profile page
-                </a>
-            </li>
+            {% if user and user.person %}
+                <li>
+                    <a class="dropdown-item {% if flavor != 'top' %} text-wrap link-primary{% endif %}"
+                       href="{% url 'ietf.person.views.profile' email_or_name=user.person.name %}">
+                        Public profile page
+                    </a>
+                </li>
+            {% endif %}
             <li>
                 <a class="dropdown-item {% if flavor != 'top' %} text-wrap link-primary{% endif %}"
                    href="{% url 'ietf.cookies.views.preferences' %}"


### PR DESCRIPTION
Suppress attempt to link to a person's profile when `user.person is None`.

This should prevent 500 errors when a `User` without an associated `Person` attempts to reset their password.

Related to (but not a replacement for!) #3568!