### PR TITLE
fix: do not set `user` template var in ietfauth views

### DIFF
--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -37,7 +37,7 @@ from ietf.ietfauth.htpasswd import update_htpasswd_file
 from ietf.mailinglists.models import Subscribed
 from ietf.meeting.factories import MeetingFactory
 from ietf.nomcom.factories import NomComFactory
-from ietf.person.factories import PersonFactory, EmailFactory
+from ietf.person.factories import PersonFactory, EmailFactory, UserFactory
 from ietf.person.models import Person, Email, PersonalApiKey
 from ietf.review.factories import ReviewRequestFactory, ReviewAssignmentFactory
 from ietf.review.models import ReviewWish, UnavailablePeriod
@@ -433,10 +433,20 @@ class IetfAuthTests(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(len(outbox), 1)
 
-        # go to change password page
+        # goto change password page, logged in as someone else
         confirm_url = self.extract_confirm_url(outbox[-1])
+        other_user = UserFactory()
+        self.client.login(username=other_user.username, password=other_user.username + '+password')
+        r = self.client.get(confirm_url)
+        self.assertEqual(r.status_code, 403)
+
+        # sign out and go back to change password page
+        self.client.logout()
         r = self.client.get(confirm_url)
         self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+        self.assertNotIn(user.username, q('.nav').text(),
+                         'user should not appear signed in while resetting password')
 
         # password mismatch
         r = self.client.post(confirm_url, { 'password': 'secret', 'password_confirmation': 'nosecret' })

--- a/ietf/templates/registration/change_password.html
+++ b/ietf/templates/registration/change_password.html
@@ -24,6 +24,11 @@
         {% endif %}
     {% else %}
         <h1>Change password</h1>
+        {% if update_user and update_user != user %}
+            <div class="alert alert-info my-3">
+                This will change the password for user {{ update_user }}.
+            </div>
+        {% endif %}
         <form method="post" class="my-3">
             {% csrf_token %}
             {% bootstrap_form form %}


### PR DESCRIPTION
This prevents the reset password view from falsely indicating that the user is logged in, which fixes #3568. For the password reset, indicate the user who will be affected. In other cases, `user` was unnecessarily being set to `request.user` - this is done automatically.