### PR TITLE
feat: Render the document shepherd writeup templates at two new URLs

### DIFF
--- a/ietf/doc/tests_draft.py
+++ b/ietf/doc/tests_draft.py
@@ -1163,7 +1163,27 @@ class IndividualInfoFormsTests(TestCase):
         self.assertEqual(r.status_code, 302)
         doc = Document.objects.get(name=self.docname)
         self.assertEqual(comment_event, doc.latest_event(DocEvent, type="added_comment"))
-       
+
+    def test_doc_view_shepherd_writeup_templates(self):
+        url = urlreverse(
+            "ietf.doc.views_doc.document_shepherd_writeup_template",
+            kwargs=dict(type="group"),
+        )
+
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+        self.assertEqual(len(q('h1:contains("for Group Documents")')), 1)
+
+        url = urlreverse(
+            "ietf.doc.views_doc.document_shepherd_writeup_template",
+            kwargs=dict(type="individual"),
+        )
+
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+        self.assertEqual(len(q('h1:contains("for Individual Documents")')), 1)
 
     def test_doc_view_shepherd_writeup(self):
         url = urlreverse('ietf.doc.views_doc.document_shepherd_writeup',kwargs=dict(name=self.docname))

--- a/ietf/doc/urls.py
+++ b/ietf/doc/urls.py
@@ -60,7 +60,10 @@ urlpatterns = [
     url(r'^email-aliases/?$', views_doc.email_aliases),
     url(r'^downref/?$', views_downref.downref_registry),
     url(r'^downref/add/?$', views_downref.downref_registry_add),
-    url(r'^shepherdwriteup-template/(?P<type>\w+)/?$', views_doc.document_shepherd_writeup_template),
+    url(
+        r"^shepherdwriteup-template/(?P<type>\w+)/?$",
+        views_doc.document_shepherd_writeup_template,
+    ),
 
     url(r'^stats/newrevisiondocevent/?$', views_stats.chart_newrevisiondocevent),
     url(r'^stats/newrevisiondocevent/conf/?$', views_stats.chart_conf_newrevisiondocevent),

--- a/ietf/doc/urls.py
+++ b/ietf/doc/urls.py
@@ -60,7 +60,7 @@ urlpatterns = [
     url(r'^email-aliases/?$', views_doc.email_aliases),
     url(r'^downref/?$', views_downref.downref_registry),
     url(r'^downref/add/?$', views_downref.downref_registry_add),
-    url(r'^shepherdwriteuptemplate/(?P<type>(individual|group))/?$', views_doc.document_shepherd_writeup_template),
+    url(r'^shepherdwriteup-template/(?P<type>\w+)/?$', views_doc.document_shepherd_writeup_template),
 
     url(r'^stats/newrevisiondocevent/?$', views_stats.chart_newrevisiondocevent),
     url(r'^stats/newrevisiondocevent/conf/?$', views_stats.chart_conf_newrevisiondocevent),

--- a/ietf/doc/urls.py
+++ b/ietf/doc/urls.py
@@ -60,6 +60,8 @@ urlpatterns = [
     url(r'^email-aliases/?$', views_doc.email_aliases),
     url(r'^downref/?$', views_downref.downref_registry),
     url(r'^downref/add/?$', views_downref.downref_registry_add),
+    url(r'^shepherdwriteuptemplate/(?P<type>(individual|group))/?$', views_doc.document_shepherd_writeup_template),
+
     url(r'^stats/newrevisiondocevent/?$', views_stats.chart_newrevisiondocevent),
     url(r'^stats/newrevisiondocevent/conf/?$', views_stats.chart_conf_newrevisiondocevent),
     url(r'^stats/newrevisiondocevent/data/?$', views_stats.chart_data_newrevisiondocevent),

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1144,13 +1144,17 @@ def document_shepherd_writeup_template(request, type):
     writeup = markdown.markdown(
         render_to_string(
             "doc/shepherd_writeup.txt",
-            dict(type=type, stream="ietf", group="individ" if type == "individual" else "group"),
+            dict(stream="ietf", type="individ" if type == "individual" else "group"),
         )
     )
     return render(
         request,
         "doc/shepherd_writeup_template.html",
-        dict(writeup=writeup, type=type, stream="ietf", group="individ" if type == "individual" else "group"),
+        dict(
+            writeup=writeup,
+            stream="ietf",
+            type="individ" if type == "individual" else "group",
+        ),
     )
 
 

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1139,6 +1139,21 @@ def document_shepherd_writeup(request, name):
                                    ),
                               )
 
+
+def document_shepherd_writeup_template(request, type):
+    writeup = markdown.markdown(
+        render_to_string(
+            "doc/shepherd_writeup.txt",
+            dict(type=type),
+        )
+    )
+    return render(
+        request,
+        "doc/shepherd_writeup_template.html",
+        dict(writeup=writeup, type=type),
+    )
+
+
 def document_references(request, name):
     doc = get_object_or_404(Document,docalias__name=name)
     refs = doc.references()

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1144,13 +1144,13 @@ def document_shepherd_writeup_template(request, type):
     writeup = markdown.markdown(
         render_to_string(
             "doc/shepherd_writeup.txt",
-            dict(type=type),
+            dict(type=type, stream="ietf", group="individ" if type == "individual" else "group"),
         )
     )
     return render(
         request,
         "doc/shepherd_writeup_template.html",
-        dict(writeup=writeup, type=type),
+        dict(writeup=writeup, type=type, stream="ietf", group="individ" if type == "individual" else "group"),
     )
 
 

--- a/ietf/doc/views_draft.py
+++ b/ietf/doc/views_draft.py
@@ -982,7 +982,7 @@ def edit_shepherd_writeup(request, name):
 
         elif "reset_text" in request.POST:
 
-            init = { "content": render_to_string("doc/shepherd_writeup.txt",dict(doc=doc))}
+            init = { "content": render_to_string("doc/shepherd_writeup.txt",dict(doc=doc, stream=doc.stream.slug, group=doc.group.type.slug))}
             form = ShepherdWriteupUploadForm(initial=init)
 
         # Protect against handcrufted malicious posts
@@ -1000,7 +1000,7 @@ def edit_shepherd_writeup(request, name):
             init["content"] = previous_writeup.text
         else:
             init["content"] = render_to_string("doc/shepherd_writeup.txt",
-                                                dict(doc=doc),
+                                                dict(doc=doc, stream=doc.stream.slug, group=doc.group.type.slug),
                                               )
         form = ShepherdWriteupUploadForm(initial=init)
 

--- a/ietf/templates/doc/shepherd_writeup.txt
+++ b/ietf/templates/doc/shepherd_writeup.txt
@@ -1,4 +1,4 @@
-{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if not doc or doc.stream %}{% if not doc or doc.stream.slug == 'ietf' %}# Document Shepherd Write-Up{% if type == "group" %} for Group Documents{% elif type == "individual" %} for Individual Documents{% endif %}
+{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if stream %}{% if stream == 'ietf' %}# Document Shepherd Write-Up{% if type == "group" %} for Group Documents{% elif type == "individual" %} for Individual Documents{% endif %}
 
 *This version is dated 4 July 2022.*
 
@@ -13,7 +13,7 @@ Note that some numbered items contain multiple related questions; please be sure
 to answer all of them.
 
 ## Document History
-{% if not doc and type == 'individual' or doc.group.type.slug == 'individ' %}
+{% if type == 'individ' %}
 1. Was the document considered in any WG, and if so, why was it not adopted as a
    work item there?
 
@@ -139,5 +139,5 @@ to answer all of them.
 [15]: https://authors.ietf.org/en/content-guidelines-overview
 [16]: https://www.ietf.org/about/groups/iesg/statements/normative-informative-references/
 [17]: https://datatracker.ietf.org/doc/downref/
-{% else %}There is no default shepherd write-up template for the {{doc.stream}} stream.
+{% else %}There is no default shepherd write-up template for the {{stream}} stream.
 {% endif %}{% else %}There is no stream set for this document (thus, no default shepherd write-up template).{% endif %}

--- a/ietf/templates/doc/shepherd_writeup.txt
+++ b/ietf/templates/doc/shepherd_writeup.txt
@@ -1,4 +1,4 @@
-{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if doc.stream %}{% if doc.stream.slug == 'ietf' %}# Document Shepherd Write-Up
+{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if not doc or doc.stream %}{% if not doc or doc.stream.slug == 'ietf' %}# Document Shepherd Write-Up{% if type == "group" %} for Group Documents{% elif type == "individual" %} for Individual Documents{% endif %}
 
 *This version is dated 4 July 2022.*
 
@@ -13,7 +13,7 @@ Note that some numbered items contain multiple related questions; please be sure
 to answer all of them.
 
 ## Document History
-{% if doc.group.type.slug == 'individ' %}
+{% if not doc and type == 'individual' or doc.group.type.slug == 'individ' %}
 1. Was the document considered in any WG, and if so, why was it not adopted as a
    work item there?
 
@@ -37,7 +37,7 @@ to answer all of them.
    either in the document itself (as [RFC 7942][3] recommends) or elsewhere
    (where)?
 
-### Additional Reviews
+## Additional Reviews
 
 5. Do the contents of this document closely interact with technologies in other
    IETF working groups or external organizations, and would it therefore benefit
@@ -58,7 +58,7 @@ to answer all of them.
    final version of the document written in a formal language, such as XML code,
    BNF rules, MIB definitions, CBOR's CDDL, etc.
 
-### Document Shepherd Checks
+## Document Shepherd Checks
 
 9. Based on the shepherd's review of the document, is it their opinion that this
    document is needed, clearly written, complete, correctly designed, and ready

--- a/ietf/templates/doc/shepherd_writeup.txt
+++ b/ietf/templates/doc/shepherd_writeup.txt
@@ -1,5 +1,5 @@
-{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if stream %}{% if stream == 'ietf' %}# Document Shepherd Write-Up{% if type == "group" %} for Group Documents{% elif type == "individual" %} for Individual Documents{% endif %}
-
+{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if stream %}{% if stream == 'ietf' %}# Document Shepherd Write-Up{% if type != "individ" %} for Group Documents{% else %} for Individual Documents{% endif %}
+{{type}}
 *This version is dated 4 July 2022.*
 
 Thank you for your service as a document shepherd. Among the responsibilities is

--- a/ietf/templates/doc/shepherd_writeup.txt
+++ b/ietf/templates/doc/shepherd_writeup.txt
@@ -1,5 +1,5 @@
 {# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if stream %}{% if stream == 'ietf' %}# Document Shepherd Write-Up{% if type != "individ" %} for Group Documents{% else %} for Individual Documents{% endif %}
-{{type}}
+
 *This version is dated 4 July 2022.*
 
 Thank you for your service as a document shepherd. Among the responsibilities is

--- a/ietf/templates/doc/shepherd_writeup_template.html
+++ b/ietf/templates/doc/shepherd_writeup_template.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{# Copyright The IETF Trust 2015, All Rights Reserved #}
+{% load origin %}
+{% load ietf_filters %}
+{% load textfilters htmlfilters %}
+{% block title %}Document Shepherd Write-Up{% if type == "group" %} for Group Documents{% elif type == "individual" %} for Individual Documents{% endif %}{% endblock %}
+{% block content %}
+    {% origin %}
+    {{ writeup|urlize_ietf_docs|linkify }}
+{% endblock %}

--- a/ietf/utils/markdown.py
+++ b/ietf/utils/markdown.py
@@ -8,20 +8,17 @@ the datatracker.
 import markdown as python_markdown
 
 from django.utils.safestring import mark_safe
-from markdown.extensions.extra import ExtraExtension
 
 from ietf.doc.templatetags.ietf_filters import urlize_ietf_docs
-from ietf.utils.text import bleach_cleaner, bleach_linker
+from ietf.utils.text import bleach_linker
 
 
 def markdown(text):
     return mark_safe(
         bleach_linker.linkify(
             urlize_ietf_docs(
-                bleach_cleaner.clean(
-                    python_markdown.markdown(
-                        text, extensions=[ExtraExtension(), "nl2br"]
-                    )
+                python_markdown.markdown(
+                    text, extensions=["extra", "nl2br", "sane_lists", "toc"]
                 )
             )
         )

--- a/ietf/utils/markdown.py
+++ b/ietf/utils/markdown.py
@@ -10,15 +10,17 @@ import markdown as python_markdown
 from django.utils.safestring import mark_safe
 
 from ietf.doc.templatetags.ietf_filters import urlize_ietf_docs
-from ietf.utils.text import bleach_linker
+from ietf.utils.text import bleach_cleaner, bleach_linker
 
 
 def markdown(text):
     return mark_safe(
         bleach_linker.linkify(
             urlize_ietf_docs(
-                python_markdown.markdown(
-                    text, extensions=["extra", "nl2br", "sane_lists", "toc"]
+                bleach_cleaner.clean(
+                    python_markdown.markdown(
+                        text, extensions=["extra", "nl2br", "sane_lists", "toc"]
+                    )
                 )
             )
         )

--- a/ietf/utils/text.py
+++ b/ietf/utils/text.py
@@ -23,13 +23,35 @@ tlds_sorted = sorted(tlds.tld_set, key=len, reverse=True)
 protocols = copy.copy(bleach.sanitizer.ALLOWED_PROTOCOLS)
 protocols.append("ftp")  # we still have some ftp links
 protocols.append("xmpp")  # we still have some xmpp links
+
+tags = set(copy.copy(bleach.sanitizer.ALLOWED_TAGS)).union(
+    {
+        # fmt: off
+        'a', 'abbr', 'acronym', 'address', 'b', 'big',
+        'blockquote', 'body', 'br', 'caption', 'center', 'cite', 'code', 'col',
+        'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl', 'dt', 'em', 'font',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'hr', 'html', 'i', 'ins', 'kbd',
+        'li', 'ol', 'p', 'pre', 'q', 's', 'samp', 'small', 'span', 'strike', 'style',
+        'strong', 'sub', 'sup', 'table', 'title', 'tbody', 'td', 'tfoot', 'th', 'thead',
+        'tr', 'tt', 'u', 'ul', 'var'
+        # fmt: on
+    }
+)
+
+attributes = copy.copy(bleach.sanitizer.ALLOWED_ATTRIBUTES)
+attributes["ol"] = ["start"]
+
+bleach_cleaner = bleach.sanitizer.Cleaner(
+    tags=tags, attributes=attributes, protocols=protocols, strip=True
+)
+
 validate_url = URLValidator()
 
 
 def check_url_validity(attrs, new=False):
-    if (None, 'href') not in attrs:
+    if (None, "href") not in attrs:
         return None
-    url = attrs[(None, 'href')]
+    url = attrs[(None, "href")]
     try:
         if url.startswith("http"):
             validate_url(url)
@@ -41,21 +63,9 @@ def check_url_validity(attrs, new=False):
 bleach_linker = bleach.Linker(
     callbacks=[check_url_validity],
     url_re=bleach.linkifier.build_url_re(tlds=tlds_sorted, protocols=protocols),
-    email_re=bleach.linkifier.build_email_re(tlds=tlds_sorted), # type: ignore
-    parse_email=True
+    email_re=bleach.linkifier.build_email_re(tlds=tlds_sorted),  # type: ignore
+    parse_email=True,
 )
-
-tags = (
-    'a', 'abbr', 'acronym', 'address', 'b', 'big',
-    'blockquote', 'body', 'br', 'caption', 'center', 'cite', 'code', 'col',
-    'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl', 'dt', 'em', 'font',
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'hr', 'html', 'i', 'ins', 'kbd',
-    'li', 'ol', 'p', 'pre', 'q', 's', 'samp', 'small', 'span', 'strike', 'style',
-    'strong', 'sub', 'sup', 'table', 'title', 'tbody', 'td', 'tfoot', 'th', 'thead',
-    'tr', 'tt', 'u', 'ul', 'var'
-)
-
-bleach_cleaner = bleach.sanitizer.Cleaner(tags=tags, protocols=protocols, strip=True)
 
 
 @keep_lazy(str)

--- a/ietf/utils/text.py
+++ b/ietf/utils/text.py
@@ -39,6 +39,7 @@ tags = set(copy.copy(bleach.sanitizer.ALLOWED_TAGS)).union(
 )
 
 attributes = copy.copy(bleach.sanitizer.ALLOWED_ATTRIBUTES)
+attributes["*"] = ["id"]
 attributes["ol"] = ["start"]
 
 bleach_cleaner = bleach.sanitizer.Cleaner(


### PR DESCRIPTION
Those being `/doc/shepherdwriteup-template/group` and `/doc/shepherdwriteup-template/individual`.

CC @ghwood.