### PR TITLE
fix: add mailtrigger links

### DIFF
--- a/ietf/templates/mailtrigger/recipient.html
+++ b/ietf/templates/mailtrigger/recipient.html
@@ -22,7 +22,7 @@
                 {% for recipient in recipients %}
                     <tr>
                         <td>
-                            <span title="{{ recipient.desc }}">{{ recipient.slug }}</span>
+                            <a href="{% url 'ietf.mailtrigger.views.show_recipients' recipient.slug %}" title="{{ recipient.desc }}">{{ recipient.slug }}</a>
                         </td>
                         <td>
                             {% for mailtrigger in recipient.used_in_to.all %}

--- a/ietf/templates/mailtrigger/trigger.html
+++ b/ietf/templates/mailtrigger/trigger.html
@@ -20,7 +20,7 @@
             {% for mailtrigger in mailtriggers %}
                 <tr>
                     <td>
-                        <span title="{{ mailtrigger.desc }}">{{ mailtrigger.slug }}</span>
+                        <a href="{% url 'ietf.mailtrigger.views.show_triggers' mailtrigger.slug %}" title="{{ mailtrigger.desc }}">{{ mailtrigger.slug }}</a>
                     </td>
                     <td>
                         {% for recipient in mailtrigger.to.all %}


### PR DESCRIPTION
Replace text by link for a trigger when displayed.
Do the same for a recipient.

Fixes #3886