### PR TITLE
Fix: corrects the IESG evaluation record summary for approved docs

### DIFF
--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1216,6 +1216,7 @@ def document_ballot_content(request, doc, ballot_id, editable=True):
         else:
             position_groups.append(g)
 
+    iesg_state = doc.get_state("draft-iesg").slug
     if (ballot.ballot_type.slug == "irsg-approve"):
         summary = irsg_needed_ballot_positions(doc, [p for p in positions if not p.is_old_pos])
     else:
@@ -1241,6 +1242,7 @@ def document_ballot_content(request, doc, ballot_id, editable=True):
                                    deferred=deferred,
                                    summary=summary,
                                    all_ballots=all_ballots,
+                                   iesg_state=iesg_state,
                                    ),
                               request=request)
 

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1216,7 +1216,12 @@ def document_ballot_content(request, doc, ballot_id, editable=True):
         else:
             position_groups.append(g)
 
-    iesg_state = doc.get_state("draft-iesg").slug
+    iesg = doc.get_state("draft-iesg")
+    iesg_state = iesg.slug if iesg else None
+    #if (iesg):
+    #    iesg_state=iesg.slug
+    #else:
+    #    iesg_state=None
     if (ballot.ballot_type.slug == "irsg-approve"):
         summary = irsg_needed_ballot_positions(doc, [p for p in positions if not p.is_old_pos])
     else:

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1218,10 +1218,6 @@ def document_ballot_content(request, doc, ballot_id, editable=True):
 
     iesg = doc.get_state("draft-iesg")
     iesg_state = iesg.slug if iesg else None
-    #if (iesg):
-    #    iesg_state=iesg.slug
-    #else:
-    #    iesg_state=None
     if (ballot.ballot_type.slug == "irsg-approve"):
         summary = irsg_needed_ballot_positions(doc, [p for p in positions if not p.is_old_pos])
     else:

--- a/ietf/templates/doc/document_ballot_content.html
+++ b/ietf/templates/doc/document_ballot_content.html
@@ -39,7 +39,7 @@
                 </p>
             {% endif %}
         {% endif %}
-        {% if not ballot_open %}
+        {% if not ballot_open or iesg_state == "ann" or iesg_state == "approved" %}
             <p class="alert alert-warning my-3">
                 <b>Note:</b> This ballot was opened for revision {{ ballot.rev }} and is now closed.
             </p>


### PR DESCRIPTION
Fixes #3962.

This is done by extracting the IESG state (if applicable) and checking the state for approved (announced or not announced) documents. Documents in this state are made to works like documents in the "rfcqueue" or "pub" states, i.e., they list the status of the last ballot.