### PR TITLE
fix: Update timezone on the interim create page

### DIFF
--- a/ietf/static/js/meeting-interim-request.js
+++ b/ietf/static/js/meeting-interim-request.js
@@ -233,7 +233,7 @@ const interimRequest = (function() {
         },
 
         timezoneChange: function () {
-            var tzname = $(this).val();
+            const tzname = $(this).val();
             $("input[name$='-time']")
                 .trigger('blur');
             $("input[name$='-end_time']")

--- a/ietf/static/js/meeting-interim-request.js
+++ b/ietf/static/js/meeting-interim-request.js
@@ -185,6 +185,8 @@ const interimRequest = (function() {
                     .length > 0) {
                     $('#id_time_zone')
                         .val(tzname);
+                    $('#id_time_zone')
+                        .trigger('change');
                 }
             }
         },
@@ -231,10 +233,14 @@ const interimRequest = (function() {
         },
 
         timezoneChange: function () {
+            var tzname = $(this).val();
             $("input[name$='-time']")
                 .trigger('blur');
             $("input[name$='-end_time']")
                 .trigger('change');
+            $('input[type="text"][name*="time"]').next().each(function(){
+                this.innerText = "Time in the " + tzname + " time zone";
+            });
         },
 
         toggleLocation: function () {


### PR DESCRIPTION
The interim creation screen will set the timezone to the timezone of
the browser.  Unfortunately, the UI element was never refreshed, so
it remained on its loaded default, thus telling the user the wrong
value.

This change adds a timezone widget refresh to the end of the function that
loads the browser's local timezone into the timezone value.

This change also adds code to update the 'Local timezone' help text
for the start time and end time input bozes to
call out the selected timezone specifically.

(Finally, it adds a newline at the end of the file, since none was present previously)

Fixes #3898