### PR TITLE
fix: Don't run `striptags` on event descriptions that are emailed

### DIFF
--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -456,13 +456,6 @@ def doc_edit_button(url_name, *args, **kwargs):
     return mark_safe('<a class="btn btn-primary btn-sm" href="%s">Edit</a>' % (urlreverse(url_name, args=args, kwargs=kwargs)))
 
 @register.filter
-def textify(text):
-    text = re.sub("</?b>", "*", text)
-    text = re.sub("</?i>", "/", text)
-    # There are probably additional conversions we should apply here
-    return text
-
-@register.filter
 def state(doc, slug):
     if slug == "stream": # convenient shorthand
         slug = "%s-stream-%s" % (doc.type_id, doc.stream_id)

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -456,6 +456,13 @@ def doc_edit_button(url_name, *args, **kwargs):
     return mark_safe('<a class="btn btn-primary btn-sm" href="%s">Edit</a>' % (urlreverse(url_name, args=args, kwargs=kwargs)))
 
 @register.filter
+def textify(text):
+    text = re.sub("</?b>", "*", text)
+    text = re.sub("</?i>", "/", text)
+    # There are probably additional conversions we should apply here
+    return text
+
+@register.filter
 def state(doc, slug):
     if slug == "stream": # convenient shorthand
         slug = "%s-stream-%s" % (doc.type_id, doc.stream_id)

--- a/ietf/templates/community/notification_email.txt
+++ b/ietf/templates/community/notification_email.txt
@@ -8,7 +8,7 @@ Document: {{ event.doc }},
 
 Change by {{ event.by }} on {{ event.time }}:
 
-{{ event.desc }}
+{{ event.desc|textify }}
 
 Best regards,
 

--- a/ietf/templates/community/notification_email.txt
+++ b/ietf/templates/community/notification_email.txt
@@ -8,7 +8,7 @@ Document: {{ event.doc }},
 
 Change by {{ event.by }} on {{ event.time }}:
 
-{{ event.desc|textify|striptags }}
+{{ event.desc }}
 
 Best regards,
 


### PR DESCRIPTION
Remove the `textify` filter, which is now unused.

Fixes #3600