### PR TITLE
fix: dates alignment in group/review_requests

### DIFF
--- a/ietf/templates/group/review_requests.html
+++ b/ietf/templates/group/review_requests.html
@@ -22,10 +22,10 @@
             <tr>
                 <th scope="col" data-sort="request">Request</th>
                 <th scope="col" data-sort="type">Type</th>
-                <th scope="col" data-sort="req-date">Requested</th>
-                <th scope="col" data-sort="deadline-date">Deadline</th>
+                <th scope="col" data-sort="req">Requested</th>
+                <th scope="col" data-sort="deadline">Deadline</th>
                 <th scope="col" data-sort="state">Document state</th>
-                <th scope="col" data-sort="telechat-date">IESG Telechat</th>
+                <th scope="col" data-sort="telechat">IESG Telechat</th>
             </tr>
         </thead>
             <tbody>
@@ -71,11 +71,11 @@
                     <tr>
                         <th scope="col" data-sort="request">Request</th>
                         <th scope="col" data-sort="type">Type</th>
-                        <th scope="col" data-sort="req-date">Requested</th>
-                        <th scope="col" data-sort="deadline-date">Deadline</th>
+                        <th scope="col" data-sort="req">Requested</th>
+                        <th scope="col" data-sort="deadline">Deadline</th>
                         <th scope="col" data-sort="reviewer">Reviewer</th>
                         <th scope="col" data-sort="state">Document state</th>
-                        <th scope="col" data-sort="telechat-date">IESG Telechat</th>
+                        <th scope="col" data-sort="telechat">IESG Telechat</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -133,13 +133,13 @@
                     <th scope="col" data-sort="type">
                         Type
                     </th>
-                    <th scope="col" data-sort="req-date">
+                    <th scope="col" data-sort="req">
                         Requested
                     </th>
-                    <th scope="col" data-sort="deadline-date">
+                    <th scope="col" data-sort="deadline">
                         Deadline
                     </th>
-                    <th scope="col" data-sort="closed-date">
+                    <th scope="col" data-sort="closed">
                         Closed
                     </th>
                     <th scope="col" data-sort="state">
@@ -191,13 +191,13 @@
                         <th scope="col" data-sort="type">
                             Type
                         </th>
-                        <th scope="col" data-sort="assgn-date">
+                        <th scope="col" data-sort="assgn">
                             Assigned
                         </th>
-                        <th scope="col" data-sort="deadline-date">
+                        <th scope="col" data-sort="deadline">
                             Deadline
                         </th>
-                        <th scope="col" data-sort="closed-date">
+                        <th scope="col" data-sort="closed">
                             Closed
                         </th>
                         <th scope="col" data-sort="reviewer">


### PR DESCRIPTION
Remove "-date" from data-sort fields for all dates, so that all columns
are now much better aligned.

Note: did not find an opened issue related to this after a quick search.