### PR TITLE
fix: add missing slides + minutes tabs to session materials dialog #4274

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -107,11 +107,12 @@
                 span.badge.is-rescheduled(v-else-if='!isMobile && item.status === `resched`') Rescheduled
                 .agenda-table-cell-links-buttons(v-else-if='agendaStore.viewport < 1200 && item.links && item.links.length > 0')
                   n-dropdown(
+                    v-if='!agendaStore.colorPickerVisible'
                     trigger='click'
                     :options='item.links'
                     key-field='id'
                     :render-icon='renderLinkIcon'
-                    v-if='!agendaStore.colorPickerVisible'
+                    @select='goToSessionLink'
                     )
                     n-button(size='tiny')
                       i.bi.bi-three-dots
@@ -189,12 +190,17 @@ import {
   NCheckbox,
   NCheckboxGroup,
   NDropdown,
-  NPopover
+  NPopover,
+  useMessage
 } from 'naive-ui'
 
 import AgendaDetailsModal from './AgendaDetailsModal.vue'
 
 import { useAgendaStore } from './store'
+
+// MESSAGE PROVIDER
+
+const message = useMessage()
 
 // STORES
 
@@ -489,6 +495,14 @@ function toggleColorPicker () {
   agendaStore.$patch({
     colorPickerVisible: !agendaStore.colorPickerVisible
   })
+}
+
+function goToSessionLink (lnkKey, lnk) {
+  if (lnk.href) {
+    window.location.assign(lnk.href)
+  } else {
+    message.error('Missing link for this dropdown item.')
+  }
 }
 
 function showMaterials (eventId) {

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -29,6 +29,8 @@ urlpatterns = [
     url(r'^meeting/session/video/url$', meeting_views.api_set_session_video_url),
     # Meeting agenda + floorplan data
     url(r'^meeting/(?P<num>[A-Za-z0-9._+-]+)/agenda-data$', meeting_views.api_get_agenda_data),
+    # Meeting session materials
+    url(r'^meeting/session/(?P<session_id>[A-Za-z0-9._+-]+)/materials$', meeting_views.api_get_session_materials),
     # Let Meetecho trigger recording imports
     url(r'^notify/meeting/import_recordings/(?P<number>[a-z0-9-]+)/?$', meeting_views.api_import_recordings),
     # Let MeetEcho upload bluesheets

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -170,6 +170,7 @@ class MeetingTests(BaseMeetingTestCase):
         self.assertEqual(r.status_code, 200)  
 
         # Agenda API tests
+        # -> Meeting data
         r = self.client.get(urlreverse("ietf.meeting.views.api_get_agenda_data", kwargs=dict(num=meeting.number)))
         self.assertEqual(r.status_code, 200)  
         rjson = json.loads(r.content.decode("utf8"))
@@ -191,6 +192,24 @@ class MeetingTests(BaseMeetingTestCase):
                 "useHedgeDoc": True,
                 "schedule": rjson.get("schedule"), # Just expect the value to exist
                 "floors": []
+            }
+        )
+        # -> Session Materials
+        r = self.client.get(urlreverse("ietf.meeting.views.api_get_session_materials", kwargs=dict(session_id=session.id)))
+        self.assertEqual(r.status_code, 200)  
+        rjson = json.loads(r.content.decode("utf8"))
+        minutes = session.minutes()
+        self.assertJSONEqual(
+            r.content.decode("utf8"),
+            {
+                "url": session.agenda().get_href(),
+                "slides": rjson.get("slides"), # Just expect the value to exist
+                "minutes": {
+                    "id": minutes.id,
+                    "title": minutes.title,
+                    "url": minutes.get_href(),
+                    "ext": minutes.file_extension()
+                } if minutes is not None else None
             }
         )
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1687,7 +1687,6 @@ def agenda_extract_schedule (item):
         },
         "agenda": {
             "url": item.session.agenda().get_href()
-            # "slides": item.session.slides
         } if item.session.agenda() is not None else {
             "url": None
         },

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1639,9 +1639,26 @@ def api_get_agenda_data (request, num=None):
         "floors": list(map(agenda_extract_floorplan, floors))
     })
 
+def api_get_session_materials (request, session_id=None):
+    session = get_object_or_404(Session,pk=session_id)
+
+    minutes = session.minutes()
+
+    return JsonResponse({
+        "url": session.agenda().get_href(),
+        "slides": list(map(agenda_extract_slide, session.slides())),
+        "minutes": {
+            "id": minutes.id,
+            "title": minutes.title,
+            "url": minutes.get_href(),
+            "ext": minutes.file_extension()
+        } if minutes is not None else None
+    })
+
 def agenda_extract_schedule (item):
     return {
         "id": item.id,
+        "sessionId": item.session.id,
         "room": item.room_name,
         "location": {
             "short": item.timeslot.location.floorplan.short,
@@ -1670,6 +1687,7 @@ def agenda_extract_schedule (item):
         },
         "agenda": {
             "url": item.session.agenda().get_href()
+            # "slides": item.session.slides
         } if item.session.agenda() is not None else {
             "url": None
         },
@@ -1725,6 +1743,14 @@ def agenda_extract_recording (item):
         "name": item.name,
         "title": item.title,
         "url": item.external_url
+    }
+
+def agenda_extract_slide (item):
+    return {
+        "id": item.id,
+        "title": item.title,
+        "url": item.get_versionless_href(),
+        "ext": item.file_extension()
     }
 
 def agenda_csv(schedule, filtered_assignments):


### PR DESCRIPTION
Adds the missing **Slides** and **Minutes** tabs to the session materials dialog on the agenda-neue page.

<img width="763" alt="image" src="https://user-images.githubusercontent.com/15522395/180898269-e492cdcb-ef68-448f-b947-911077276d24.png">

Fixes #4274 