### PR TITLE
feat: only offer IAB/IESG members for bofreq responsible leadership

### DIFF
--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -2468,12 +2468,12 @@ class FieldTests(TestCase):
             decoded = json.loads(json_data)
         except json.JSONDecodeError as e:
             self.fail('data-pre contained invalid JSON data: %s' % str(e))
-        decoded_ids = list(decoded.keys())
-        self.assertCountEqual(decoded_ids, [str(doc.id) for doc in docs])
+        decoded_ids = [item['id'] for item in decoded]
+        self.assertEqual(decoded_ids, [doc.id for doc in docs])
         for doc in docs:
             self.assertEqual(
                 dict(id=doc.pk, selected=True, url=doc.get_absolute_url(), text=escape(uppercase_std_abbreviated_name(doc.name))),
-                decoded[str(doc.pk)],
+                decoded[decoded_ids.index(doc.pk)],
             )
 
 class MaterialsTests(TestCase):

--- a/ietf/doc/tests_bofreq.py
+++ b/ietf/doc/tests_bofreq.py
@@ -2,6 +2,7 @@
 
 import datetime
 import debug    # pyflakes:ignore
+import json
 import os
 
 from pathlib import Path
@@ -18,7 +19,9 @@ from ietf.group.factories import RoleFactory
 from ietf.doc.factories import BofreqFactory, NewRevisionDocEventFactory
 from ietf.doc.models import State, Document, DocAlias, NewRevisionDocEvent
 from ietf.doc.utils_bofreq import bofreq_editors, bofreq_responsible
+from ietf.ietfauth.utils import has_role
 from ietf.person.factories import PersonFactory
+from ietf.person.models import Person
 from ietf.utils.mail import outbox, empty_outbox
 from ietf.utils.test_utils import TestCase, reload_db_objects, unicontent, login_testing_unauthorized
 from ietf.utils.text import xslugify
@@ -270,6 +273,25 @@ This test section has some text.
         for p in bad_batch:
             self.assertIn(p.plain_name(), error_text)
 
+    def test_change_responsible_options(self):
+        """Only valid options should be offered for responsible leadership field"""
+        doc = BofreqFactory()
+        url = urlreverse('ietf.doc.views_bofreq.change_responsible', kwargs={'name': doc.name})
+        self.client.login(username='secretary', password='secretary+password')
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+        option_ids = [opt['id'] for opt in json.loads(q('#id_responsible').attr('data-pre'))]
+        ad_people = [p for p in Person.objects.all() if has_role(p.user, 'Area Director')]
+        iab_people = [p for p in Person.objects.all() if has_role(p.user, 'IAB')]
+        self.assertGreater(len(ad_people), 0, 'Need at least one AD')
+        self.assertGreater(len(iab_people), 0, 'Need at least one IAB member')
+        self.assertGreater(Person.objects.count(), len(ad_people) + len(iab_people),
+                           'Need at least one Person not an AD nor IAB member')
+        # Next line will fail if there's overlap between ad_people and iab_people. This is by design.
+        # If the test setup changes and overlap is expected, need to separately check that area directors
+        # and IAB members wind up in the options list.
+        self.assertCountEqual(option_ids, [p.pk for p in ad_people + iab_people])
 
     def test_submit(self):
         doc = BofreqFactory()

--- a/ietf/doc/views_bofreq.py
+++ b/ietf/doc/views_bofreq.py
@@ -229,9 +229,9 @@ class ChangeResponsibleForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # The queryset here finds users for whom has_role(u, 'Area Director') or has_role(u, 'IAB') is True.
-        # It needs to match. Disable ajax requests because the SearchablePersonsField cannot enforce the
-        # queryset filter.
+        # The queryset in extra_prefetch finds users for whom has_role(u, 'Area Director') or
+        # has_role(u, 'IAB') is True. It needs to match the queries in the has_role() method.
+        # Disable ajax requests because the SearchablePersonsField cannot enforce the queryset filter.
         self.fields['responsible'] = SearchablePersonsField(
             required=False,
             extra_prefetch=Person.objects.filter(

--- a/ietf/liaisons/tests.py
+++ b/ietf/liaisons/tests.py
@@ -1014,7 +1014,7 @@ class LiaisonManagementTests(TestCase):
         self.assertEqual(q('#id_from_groups').find('option:selected').val(),reply_from_group_id)
         self.assertEqual(q('#id_to_groups').find('option:selected').val(),reply_to_group_id)
         pre = json.loads(q('#id_related_to').attr("data-pre"))
-        self.assertEqual(pre[str(liaison.pk)]['id'], liaison.pk)
+        self.assertEqual(pre[0]['id'], liaison.pk)
 
     def test_search(self):
         # Statement 1

--- a/ietf/person/fields.py
+++ b/ietf/person/fields.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 
 from typing import Type # pyflakes:ignore
 
+import unidecode
 from django import forms
 from django.core.validators import validate_email
 from django.db import models # pyflakes:ignore
@@ -92,7 +93,10 @@ class SearchablePersonsField(SearchableField):
         # via the extra_prefetch property.
         prefetch_set = set(model_instances) if model_instances else set()
         prefetch_set = prefetch_set.union(set(self.extra_prefetch))  # eliminate duplicates
-        return select2_id_name(sorted(prefetch_set, key=lambda p: p.ascii_name()))
+        return sorted(
+            select2_id_name(list(prefetch_set)),
+            key=lambda item: unidecode.unidecode(item['text']),
+        )
 
     def ajax_url(self):
         if self.disable_ajax:

--- a/ietf/person/fields.py
+++ b/ietf/person/fields.py
@@ -92,7 +92,7 @@ class SearchablePersonsField(SearchableField):
         # via the extra_prefetch property.
         prefetch_set = set(model_instances) if model_instances else set()
         prefetch_set = prefetch_set.union(set(self.extra_prefetch))  # eliminate duplicates
-        return select2_id_name(list(prefetch_set))
+        return select2_id_name(sorted(prefetch_set, key=lambda p: p.ascii_name()))
 
     def ajax_url(self):
         if self.disable_ajax:

--- a/ietf/static/js/select2.js
+++ b/ietf/static/js/select2.js
@@ -22,12 +22,19 @@ function prettify_tz(x) {
 // Copyright The IETF Trust 2015-2021, All Rights Reserved
 // JS for ietf.utils.fields.SearchableField subclasses
 window.setupSelect2Field = function (e) {
-    var url = e.data("select2-ajax-url");
-    var maxEntries = e.data("max-entries");
-    var result_key = e.data("result-key");
-    var options = e.data("pre");
-    for (var id in options) {
-        e.append(new Option(options[id].text, options[id].id, false, options[id].selected));
+    // Avoid using data attributes that match any of the search2 option attributes.
+    // These will override settings in the options object that we use below.
+    // (see https://select2.org/configuration/data-attributes)
+    // Note: e.data('k') returns undefined if there is no data-k attribute.
+    let url = e.data("select2-ajax-url");
+    let maxEntries = e.data("max-entries");
+    let minSearchLength = e.data("min-search-length");
+    let result_key = e.data("result-key");
+    let options = e.data("pre");
+    if (options) {
+        options.forEach(
+          opt => e.append(new Option(opt.text, opt.id, false, opt.selected))
+        );
     }
 
     template_modify = e.hasClass("tz-select") ? prettify_tz : undefined;
@@ -35,6 +42,7 @@ window.setupSelect2Field = function (e) {
     e.select2({
         multiple: maxEntries !== 1,
         maximumSelectionSize: maxEntries,
+        minimumInputLength: minSearchLength,
         templateResult: template_modify,
         templateSelection: template_modify,
         ajax: url ? {

--- a/ietf/static/js/select2.js
+++ b/ietf/static/js/select2.js
@@ -22,7 +22,7 @@ function prettify_tz(x) {
 // Copyright The IETF Trust 2015-2021, All Rights Reserved
 // JS for ietf.utils.fields.SearchableField subclasses
 window.setupSelect2Field = function (e) {
-    var url = e.data("ajax--url");
+    var url = e.data("select2-ajax-url");
     var maxEntries = e.data("max-entries");
     var result_key = e.data("result-key");
     var options = e.data("pre");

--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -61,7 +61,7 @@
                     <label aria-label="Document search">
                     <input class="form-control select2-field"
                            id="navbar-doc-search"
-                           data-ajax--url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='docalias' doc_type='draft' %}"
+                           data-select2-ajax-url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='docalias' doc_type='draft' %}"
                            type="text"
                            data-placeholder="Document search">
                    </label>

--- a/ietf/templates/doc/status_change/edit_related_rows.html
+++ b/ietf/templates/doc/status_change/edit_related_rows.html
@@ -5,7 +5,7 @@
 {% for rfc,choice_slug in form.relations.items %}
     <div class="input-group mb-3">
         <select class="form-control select2-field"
-                data-ajax--url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='document' doc_type='draft' %}"
+                data-select2-ajax-url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='document' doc_type='draft' %}"
                 data-max-entries="1"
                 data-width="resolve"
                 data-result-key="text"
@@ -39,7 +39,7 @@
             id="new_relation_row_rfc"
             aria-label="Enter new affected RFC"
             class="form-control select2-field"
-            data-ajax--url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='docalias' doc_type='draft' %}"
+            data-select2-ajax-url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='docalias' doc_type='draft' %}"
             data-result-key="text"
             data-max-entries="1"
             data-width="resolve"

--- a/ietf/utils/fields.py
+++ b/ietf/utils/fields.py
@@ -201,6 +201,7 @@ class SearchableField(forms.MultipleChoiceField):
     model = None  # type:Optional[Type[models.Model]]
 #    max_entries = None  # may be overridden in __init__
     max_entries = None # type: Optional[int] 
+    min_search_length = None # type: Optional[int]
     default_hint_text = 'Type a value to search'
     
     def __init__(self, hint_text=None, *args, **kwargs):
@@ -210,6 +211,8 @@ class SearchableField(forms.MultipleChoiceField):
         # not setting the parameter at all.
         if 'max_entries' in kwargs:
             self.max_entries = kwargs.pop('max_entries')
+        if 'min_search_length' in kwargs:
+            self.min_search_length = kwargs.pop('min_search_length')
 
         super(SearchableField, self).__init__(*args, **kwargs)
 
@@ -217,6 +220,8 @@ class SearchableField(forms.MultipleChoiceField):
         self.widget.attrs["data-placeholder"] = self.hint_text
         if self.max_entries is not None:
             self.widget.attrs["data-max-entries"] = self.max_entries
+        if self.min_search_length is not None:
+            self.widget.attrs["data-min-search-length"] = self.min_search_length
 
     def make_select2_data(self, model_instances):
         """Get select2 data items
@@ -281,9 +286,7 @@ class SearchableField(forms.MultipleChoiceField):
                 d["selected"] = any([v.pk == d["id"] for v in value])
             else:
                 d["selected"] = value.exists() and value.filter(pk__in=[d["id"]]).exists()
-        self.widget.attrs["data-pre"] = json.dumps({
-            d['id']: d for d in pre
-        })
+        self.widget.attrs["data-pre"] = json.dumps(list(pre))
 
         # doing this in the constructor is difficult because the URL
         # patterns may not have been fully constructed there yet

--- a/ietf/utils/fields.py
+++ b/ietf/utils/fields.py
@@ -287,7 +287,9 @@ class SearchableField(forms.MultipleChoiceField):
 
         # doing this in the constructor is difficult because the URL
         # patterns may not have been fully constructed there yet
-        self.widget.attrs["data-ajax--url"] = self.ajax_url()
+        ajax_url = self.ajax_url()
+        if ajax_url is not None:
+            self.widget.attrs["data-select2-ajax-url"] = ajax_url
 
         result = value
         return result


### PR DESCRIPTION
This filters the options available when selecting "responsible leaders" for a bofreq. Previously, the standard `SearchablePersonsField` was used to select one or more `Person` objects to be assigned. The form validation then rejected any choices that were neither IAB members nor Area Directors.

Fixing was not straightforward because the `SearchablePersonsField` dynamically searches the `Person` table using an ajax endpoint. This endpoint does not permit filtering using Django's queryset tools. To work around this, I've extended the `SearchableField` classes to support disabling ajax lookups. The fields already supported priming the options with "prefetch" data; this becomes the sole data source when ajax lookups are disabled. For the "responsible leaders" field, the area directors / IAB members are passed in as prefetch data. This does not add a large amount of data to the page - there are currently fewer than 30 options.

This pull request also adds the option to configure the "minSearchLength" for the fields - the minimum number of characters to enter before displaying matches. This retains its default of 2, but is set to 0 for the "responsible leaders" field. When the field is focused, the options are shown like a typical pull-down so that the user need not guess names to see what options are available.

Other changes include:
* rename the `data-ajax--url` attribute on search2 input elements (the select2 library overrides its javascript configuration with this attribute, so this avoids confusion)
* sort `SearchablePersonsField` prefetch options so they appear in a sensible order in the pulldown
* pass prefetch options to the javascript side as an array instead of a dict (needed to support the sorting)

Fixes #3711.