### PR TITLE
fix: persist timezone selection per meeting in agenda-neue

### DIFF
--- a/client/agenda/Agenda.vue
+++ b/client/agenda/Agenda.vue
@@ -59,6 +59,7 @@
             :options='timezones'
             placeholder='Select Time Zone'
             filterable
+            @update:value='() => { agendaStore.persistMeetingPreferences() }'
             )
 
       .alert.alert-warning.mt-3(v-if='agendaStore.isCurrentMeeting') #[strong Note:] IETF agendas are subject to change, up to and during a meeting.
@@ -260,6 +261,7 @@ function setTimezone (tz) {
       agendaStore.$patch({ timezone: tz })
       break
   }
+  agendaStore.persistMeetingPreferences()
 }
 
 function closeSearch () {

--- a/client/agenda/AgendaSettings.vue
+++ b/client/agenda/AgendaSettings.vue
@@ -52,6 +52,7 @@ n-drawer(v-model:show='isShown', placement='right', :width='panelWidth')
         :options='timezones'
         placeholder='Select Time Zone'
         filterable
+        @update:value='() => { agendaStore.persistMeetingPreferences() }'
         )
 
       n-divider(title-placement='left')
@@ -401,6 +402,7 @@ function setTimezone (tz) {
       agendaStore.$patch({ timezone: tz })
       break
   }
+  agendaStore.persistMeetingPreferences()
 }
 
 // MOUNTED

--- a/client/agenda/store.js
+++ b/client/agenda/store.js
@@ -144,7 +144,7 @@ export const useAgendaStore = defineStore('agenda', {
         const agendaData = await resp.json()
 
         // -> Switch to meeting timezone
-        this.timezone = agendaData.meeting.timezone
+        this.timezone = window.localStorage.getItem(`agenda.${agendaData.meeting.number}.timezone`) || agendaData.meeting.timezone
 
         // -> Load meeting data
         this.categories = agendaData.categories
@@ -178,6 +178,7 @@ export const useAgendaStore = defineStore('agenda', {
       }
       window.localStorage.setItem(`agenda.${this.meeting.number}.colorAssignments`, JSON.stringify(this.colorAssignments))
       window.localStorage.setItem(`agenda.${this.meeting.number}.pickedEvents`, JSON.stringify(this.pickedEvents))
+      window.localStorage.setItem(`agenda.${this.meeting.number}.timezone`, this.timezone)
     },
     findCurrentEventId () {
       const current = (this.nowDebugDiff ? DateTime.local().minus(this.nowDebugDiff) : DateTime.local()).setZone(this.timezone)


### PR DESCRIPTION
Persists the timezone selection per meeting.

Fixes #4271