### PR TITLE
fix: Don't require a responsible AD to be identified for new status change

### DIFF
--- a/ietf/doc/views_status_change.py
+++ b/ietf/doc/views_status_change.py
@@ -465,7 +465,7 @@ class StartStatusChangeForm(forms.Form):
     document_name = forms.CharField(max_length=255, label="Document name", help_text="A descriptive name such as status-change-md2-to-historic is better than status-change-rfc1319.", required=True)
     title = forms.CharField(max_length=255, label="Title", required=True)
     ad = forms.ModelChoiceField(Person.objects.filter(role__name="ad", role__group__state="active",role__group__type='area').order_by('name'), 
-                                label="Shepherding AD", empty_label="(None)", required=True)
+                                label="Shepherding AD", empty_label="(None)", required=False)
     create_in_state = forms.ModelChoiceField(State.objects.filter(type="statchg", slug__in=("needshep", "adrev")), empty_label=None, required=False)
     notify = forms.CharField(max_length=255, label="Notice emails", help_text="Separate email addresses with commas.", required=False)
     telechat_date = forms.TypedChoiceField(coerce=lambda x: datetime.datetime.strptime(x, '%Y-%m-%d').date(), empty_value=None, required=False, widget=forms.Select(attrs={'onchange':'make_bold()'}))


### PR DESCRIPTION
Fixes #4159