### PR TITLE
fix: allow shepherds for editorial stream documents. Fixes #4333

### DIFF
--- a/ietf/templates/doc/document_draft.html
+++ b/ietf/templates/doc/document_draft.html
@@ -529,7 +529,7 @@
                     </td>
                 </tr>
             {% endif %}
-            {% if doc.stream_id == 'ietf' or doc.stream_id == 'ise' or doc.stream_id == 'irtf' or doc.stream_id == 'editorial' %}
+            {% if doc.stream_id == 'ietf' or doc.stream_id == 'ise' or doc.stream_id == 'irtf' %}
                 <tr>
                     <td></td>
                     <th scope="row">

--- a/ietf/templates/doc/document_draft.html
+++ b/ietf/templates/doc/document_draft.html
@@ -529,7 +529,7 @@
                     </td>
                 </tr>
             {% endif %}
-            {% if doc.stream_id == 'ietf' or doc.stream_id == 'ise' or doc.stream_id == 'irtf' %}
+            {% if doc.stream_id == 'ietf' or doc.stream_id == 'ise' or doc.stream_id == 'irtf' or doc.stream_id == 'editorial' %}
                 <tr>
                     <td></td>
                     <th scope="row">


### PR DESCRIPTION
Testing the render of the document_main view (to see if the shepherd line shows up in this case, and that if you have permissions to change it, the edit button shows up, etc). is egregious, the effort is better deferred until the view has its front-end replaced with Vue.