### PR TITLE
fix: Add `<pre>` to restore mailtrigger indentation

### DIFF
--- a/ietf/templates/mailtrigger/recipient.html
+++ b/ietf/templates/mailtrigger/recipient.html
@@ -39,12 +39,12 @@
                         </td>
                         <td>
                             {% if recipient.template %}
-                                <code>{{ recipient.template|escape|linebreaksbr }}</code>
+                                <code><pre>{{ recipient.template|escape }}</pre></code>
                             {% endif %}
                         </td>
                         <td>
                             {% if recipient.code %}
-                                <code>{{ recipient.code|escape|linebreaksbr }}</code>
+                                <code><pre>{{ recipient.code|escape }}</pre></code>
                             {% endif %}
                         </td>
                     </tr>

--- a/ietf/templates/mailtrigger/recipient.html
+++ b/ietf/templates/mailtrigger/recipient.html
@@ -39,12 +39,12 @@
                         </td>
                         <td>
                             {% if recipient.template %}
-                                <code><pre>{{ recipient.template|escape }}</pre></code>
+                                <pre><code>{{ recipient.template|escape }}</code></pre>
                             {% endif %}
                         </td>
                         <td>
                             {% if recipient.code %}
-                                <code><pre>{{ recipient.code|escape }}</pre></code>
+                                <pre><code>{{ recipient.code|escape }}</code></pre>
                             {% endif %}
                         </td>
                     </tr>


### PR DESCRIPTION
Fixes #4452