### PR TITLE
fix: return same bibxml for versioned and versionless references

### DIFF
--- a/ietf/doc/management/commands/generate_draft_bibxml_files.py
+++ b/ietf/doc/management/commands/generate_draft_bibxml_files.py
@@ -10,11 +10,11 @@ import sys
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.template.loader import render_to_string
 
 import debug                            # pyflakes:ignore
 
 from ietf.doc.models import NewRevisionDocEvent
+from ietf.doc.utils import bibxml_for_draft
 
 DEFAULT_DAYS = 7
 
@@ -76,21 +76,8 @@ class Command(BaseCommand):
             self.mutter('%s %s' % (e.time, e.doc.name))
             try:
                 doc = e.doc
-                if e.rev != doc.rev:
-                    for h in doc.history_set.order_by("-time"):
-                        if e.rev == h.rev:
-                            doc = h
-                            break
-                doc.date = e.time.date()
-                ref_text = '%s' % render_to_string('doc/bibxml.xml', {'name':doc.name, 'doc': doc, 'doc_bibtype':'I-D'})
-                # if e.rev == e.doc.rev:
-                #     for name in (doc.name, doc.name[6:]):
-                #         ref_file_name = os.path.join(bibxmldir, 'reference.I-D.%s.xml' % (name, ))
-                #         self.write(ref_file_name, ref_text)
-                # for name in (doc.name, doc.name[6:]):
-                #     ref_rev_file_name = os.path.join(bibxmldir, 'reference.I-D.%s-%s.xml' % (name, doc.rev))
-                #     self.write(ref_rev_file_name, ref_text)
-                ref_rev_file_name = os.path.join(bibxmldir, 'reference.I-D.%s-%s.xml' % (doc.name, doc.rev))
-                self.write(ref_rev_file_name, ref_text)
+                bibxml = bibxml_for_draft(doc, e.rev)
+                ref_rev_file_name = os.path.join(bibxmldir, 'reference.I-D.%s-%s.xml' % (doc.name, e.rev))
+                self.write(ref_rev_file_name, bibxml)
             except Exception as ee:
                 sys.stderr.write('\n%s-%s: %s\n' % (doc.name, doc.rev, ee))

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -17,6 +17,7 @@ from urllib.parse import quote
 from django.conf import settings
 from django.contrib import messages
 from django.forms import ValidationError
+from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.html import escape
 from django.urls import reverse as urlreverse
@@ -1317,3 +1318,33 @@ def fuzzy_find_documents(name, rev=None):
 
     FoundDocuments = namedtuple('FoundDocuments', 'documents matched_name matched_rev')
     return FoundDocuments(docs, name, rev)
+
+def bibxml_for_draft(doc, rev=None):
+
+    if rev != None and rev != doc.rev:
+        # find the entry in the history
+        for h in doc.history_set.order_by("-time"):
+            if rev == h.rev:
+                doc = h
+                break
+    if rev and rev != doc.rev:
+        raise Http404("Revision not found")
+
+    # Build the date we want to claim for the document in the bibxml
+    # For documents that have relevent NewRevisionDocEvents, use the date of the event.
+    # Very old documents don't have NewRevisionDocEvents - just use the document time.
+        
+    latest_revision_event = doc.latest_event(NewRevisionDocEvent, type="new_revision")
+    latest_revision_rev = latest_revision_event.rev if latest_revision_event else None
+    best_events = NewRevisionDocEvent.objects.filter(doc__name=doc.name, rev=(rev or latest_revision_rev))
+    if best_events.exists():
+        # There was a period where it was possible to get more than one NewRevisionDocEvent for a revision.
+        # A future data cleanup would allow this to be simplified
+        best_event = best_events.order_by('-time').last()
+        log.assertion('doc.rev == best_event.rev')
+        doc.date = best_event.time.date()
+    else:
+        doc.date = doc.time.date()      # Even if this may be incoreect, what would be better?
+
+    return render_to_string('doc/bibxml.xml', {'name':doc.name, 'doc': doc, 'doc_bibtype':'I-D'})
+

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -1321,7 +1321,7 @@ def fuzzy_find_documents(name, rev=None):
 
 def bibxml_for_draft(doc, rev=None):
 
-    if rev != None and rev != doc.rev:
+    if rev is not None and rev != doc.rev:
         # find the entry in the history
         for h in doc.history_set.order_by("-time"):
             if rev == h.rev:
@@ -1340,7 +1340,7 @@ def bibxml_for_draft(doc, rev=None):
     if best_events.exists():
         # There was a period where it was possible to get more than one NewRevisionDocEvent for a revision.
         # A future data cleanup would allow this to be simplified
-        best_event = best_events.order_by('-time').last()
+        best_event = best_events.order_by('time').first()
         log.assertion('doc.rev == best_event.rev')
         doc.date = best_event.time.date()
     else:

--- a/ietf/templates/doc/bibxml.xml
+++ b/ietf/templates/doc/bibxml.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <reference anchor="{{doc_bibtype}}.{{name|slice:"6:"}}">
    <front>
-      <title>{{doc.title}}</title>{% if doc.submission %}{% for author in doc.submission.authors %}
-      <author fullname="{{ author.name }}">
-	 {% if author.affiliation %}<organization>{{ author.affiliation }}</organization>
-      {% endif %}</author>{% endfor %}{% else %}{% for author in doc.documentauthor_set.all %}
+      <title>{{doc.title}}</title>{% for author in doc.documentauthor_set.all %}
       <author initials="{{ author.person.initials }}" surname="{{ author.person.last_name }}" fullname="{{ author.person.name }}">
          {% if author.affiliation %}<organization>{{ author.affiliation }}</organization>
-      {% endif %}</author>{% endfor %}{% endif %}
+      {% endif %}</author>{% endfor %}
       <date month="{{doc.date|date:"F"}}" day="{{doc.date.day}}" year="{{doc.date.year}}" />
       <abstract>
 	 <t>{{doc.abstract}}


### PR DESCRIPTION
Fixes #4384.

Refactors bibxml production to remove repeated logic.

Abandons the half-implemented idea that returning information from the Submission object might be better than the Document or DocHistory objects.