### PR TITLE
chore: import jquery so dynamic_inlines.js source map works

### DIFF
--- a/ietf/secr/static/js/dynamic_inlines.js
+++ b/ietf/secr/static/js/dynamic_inlines.js
@@ -5,6 +5,8 @@ http://www.arnebrodowski.de/blog/507-Add-and-remove-Django-Admin-Inlines-with-Ja
 field as primary key.  Also for some reason the "active" boolean field doesn't get saved properly
 if the checkbox input has an empty "value" argument.
 */
+import $ from 'jquery';
+
 function increment_form_ids(el, to, name) {
     var from = to-1
     $(':input', $(el)).each(function(i,e){


### PR DESCRIPTION
Without this import, the source map Parcel generates for `dynamic_inlines.js` does not match up with the code.