### PR TITLE
fix: work around dataTransfer.getData limitation in agenda editor

### DIFF
--- a/ietf/static/js/edit-meeting-schedule.js
+++ b/ietf/static/js/edit-meeting-schedule.js
@@ -412,7 +412,6 @@ $(function () {
             let dropElement = jQuery(this);
 
             const sessionElement = getDraggedSession(event);
-            console.log(`Hiya: {sessionElement}`);
             if (!sessionElement) {
                 // not drag event or not from a session we recognize
                 dropElement.parent().removeClass("dropping");

--- a/ietf/static/js/edit-meeting-schedule.js
+++ b/ietf/static/js/edit-meeting-schedule.js
@@ -312,7 +312,9 @@ $(function () {
 
     // Was this drag started by dragging a session?
     function isSessionDragEvent(event) {
-        return Boolean(event.originalEvent.dataTransfer.getData(dnd_mime_type));
+        return event.originalEvent.dataTransfer.types.some(
+          (item_type) => item_type.indexOf(dnd_mime_type) !== -1
+        );
     }
 
     /**
@@ -324,7 +326,7 @@ $(function () {
         if (!isSessionDragEvent(event)) {
             return null;
         }
-        const sessionId = event.originalEvent.dataTransfer.getData(dnd_mime_type);
+        const sessionId = event.originalEvent.dataTransfer.types[0].slice(dnd_mime_type.length);
         const sessionElements = sessions.filter("#" + sessionId);
         if (sessionElements.length > 0) {
             return sessionElements[0];
@@ -357,7 +359,15 @@ $(function () {
         // dragging
         sessions.on("dragstart", function (event) {
             if (canEditSession(this)) {
-                event.originalEvent.dataTransfer.setData(dnd_mime_type, this.id);
+                /* Bit of a hack here - per the w3c drag and drop spec, the data being dragged
+                 * and dropped are only available during dragstart and drop events. Otherwise,
+                 * only their count and type are guaranteed to be available. (See
+                 * https://www.w3.org/TR/2011/WD-html5-20110113/dnd.html#drag-data-store-mode)
+                 * To work around this, append the sessionId to the dnd_mime_type in the type we
+                 * report for our event. The event handlers can then pull it out when needed.
+                 * (At least Chrome v106 breaks if we try to peek at the payload.)
+                 */
+                event.originalEvent.dataTransfer.setData(dnd_mime_type + this.id, this.id);
                 jQuery(this).addClass("dragging");
                 selectSessionElement(this);
                 showPastTimeslotHints();
@@ -402,6 +412,7 @@ $(function () {
             let dropElement = jQuery(this);
 
             const sessionElement = getDraggedSession(event);
+            console.log(`Hiya: {sessionElement}`);
             if (!sessionElement) {
                 // not drag event or not from a session we recognize
                 dropElement.parent().removeClass("dropping");

--- a/ietf/static/js/edit-meeting-schedule.js
+++ b/ietf/static/js/edit-meeting-schedule.js
@@ -313,7 +313,7 @@ $(function () {
     // Was this drag started by dragging a session?
     function isSessionDragEvent(event) {
         return event.originalEvent.dataTransfer.types.some(
-          (item_type) => item_type.indexOf(dnd_mime_type) !== -1
+          (item_type) => item_type.indexOf(dnd_mime_type) === 0
         );
     }
 


### PR DESCRIPTION
The agenda editor was broken as of Chrome 106 without this patch. It's a bit of a hack, but I believe it respects the letter of the relevant specs.