### PR TITLE
fix: revert photo-on-menubar enhancement

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -227,13 +227,6 @@ th {
     }
 }
 
-// Style the navbar user photo
-.nav-link .user-photo {
-    object-fit: cover;
-    height: 40px;
-    width: 40px;
-}
-
 // Style the righthand navigation panel
 #righthand-panel {
     max-height: 80vh;

--- a/ietf/templates/base/menu_user.html
+++ b/ietf/templates/base/menu_user.html
@@ -5,18 +5,12 @@
 <li class="nav-item dropdown">
     {% if flavor == "top" %}
         <a href="#"
-           class="nav-link dropdown-toggle{% if user.person.photo_thumb %} p-0{% endif %}"
+           class="nav-link dropdown-toggle"
            role="button"
            data-bs-toggle="dropdown"
            aria-expanded="false">
             {% if user.is_authenticated %}
-                {% if user.person.photo_thumb %}
-                    <img class="user-photo rounded-circle ms-1" width="40" height="40"
-                         src="{{ user.person.photo_thumb.url }}"
-                         alt="Photo of {{ user.person.name }}">
-                {% else %}
-                    {{ user.username|split:'@'|first }}
-                {% endif %}
+                {{ user.username|split:'@'|first }}
             {% else %}
                 User
             {% endif %}


### PR DESCRIPTION
Turns out the state of our thumbs is poor enough to make this a non-starter for now.

We need to revisit whether to clean up our image store or to shift to a third-party (gravatar, or clouflare's self-serve image manager for example).