### PR TITLE
fix: reduce agenda data calculation time

### DIFF
--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -95,6 +95,7 @@ def preprocess_assignments_for_agenda(assignments_queryset, meeting, extra_prefe
       a.session.historic_parent
       a.session.rescheduled_to (if rescheduled)
       a.session.prefetched_active_materials
+      a.session.order_number
     """
     assignments_queryset = assignments_queryset.prefetch_related(
             'timeslot', 'timeslot__type', 'timeslot__meeting',

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1621,6 +1621,8 @@ def api_get_agenda_data (request, num=None):
     # Get Floor Plans
     floors = FloorPlan.objects.filter(meeting=meeting).order_by('order')
 
+    #debug.show('all([(item.acronym,item.session.order_number,item.session.order_in_meeting()) for item in filtered_assignments])')
+
     return JsonResponse({
         "meeting": {
             "number": schedule.meeting.number,
@@ -1712,7 +1714,7 @@ def agenda_extract_schedule (item):
         } if item.session.agenda() is not None else {
             "url": None
         },
-        "orderInMeeting": item.session.order_in_meeting(),
+        "orderInMeeting": item.session.order_number,
         "short": item.session.short if item.session.short else item.session.short_name,
         "sessionToken": item.session.docname_token_only_for_multiple(),
         "links": {


### PR DESCRIPTION
This intentionally leaves a commented out debug statement. Against main without #4621, it will report differences with the secretariat group. It will report equal once #4621 is in place.

I had done the work to precalculate the order in the view, but while investigating what led to #4621, discovered that the calculations had _already been made and attached to the objects_.

It's not clear why it wasn't being used.