### PR TITLE
fix: Format NomCom feedback table per suggestion of @richsalz

### DIFF
--- a/ietf/static/js/list.js
+++ b/ietf/static/js/list.js
@@ -86,10 +86,9 @@ $(document)
                 $(header_row)
                     .children("[data-sort]")
                     .addClass("sort");
-                // $(header_row)
-                //     .children("th, td")
-                //     .wrapInner('<span class="tablesorter-th"></span>');
-                //     // .each((i, e) => field_magic(i, e, fields));
+                $(header_row)
+                    .children("th, td")
+                    .each((i, e) => field_magic(i, e, fields));
 
                 if ($(header_row)
                     .text()

--- a/ietf/templates/nomcom/private_index.html
+++ b/ietf/templates/nomcom/private_index.html
@@ -8,7 +8,7 @@
 {% block nomcom_content %}
     {% origin %}
     <h2 class="mt-3">Nomination status</h2>
-    <table class="table table-sm table-striped table-hover tablesorter">
+    <table class="table table-sm table-striped-columns table-hover tablesorter">
         <thead class="wrap-anywhere">
             <tr>
                 <th scope="col" data-sort="position">Position</th>
@@ -156,7 +156,7 @@
                             <i class="bi bi-check"></i>
                         </th>
                     {% endif %}
-                    <th scope="col" data-sort="nominee" colspan="2">
+                    <th scope="col" data-sort="nominee">
                         Nominee
                     </th>
                     <th scope="col" data-sort="position">
@@ -194,9 +194,7 @@
                             <a href="{% url 'ietf.person.views.profile' email_or_name=np.nominee.name %}">
                                 {{ np.nominee.email.name_and_email }}
                             </a>
-                        </td>
-                        <td>
-                            <a class="btn btn-primary btn-sm"
+                            <a class="btn btn-primary btn-sm float-end"
                                href="{% url 'ietf.nomcom.views.view_feedback_nominee' year=year nominee_id=np.nominee.id %}#comment">
                                 View feedback
                             </a>


### PR DESCRIPTION
Also makes table header alignment the same as for columns, site-wide.

Fixes #4529