### PR TITLE
fix: sort higher capacity rooms first in schedule editor

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -672,7 +672,7 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
                 # timeslot structure will be neighbors. The grouping algorithm relies on this!
                 room_data[room.pk]['start_and_duration'],
                 # Within each group, sort higher capacity rooms first.
-                room.capacity if room.capacity is not None else -1,  # sort rooms with capacity = None at end
+                -room.capacity if room.capacity is not None else 1,  # sort rooms with capacity = None at end
                 # Finally, sort alphabetically by name
                 room.name
             )

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -672,7 +672,7 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
                 # timeslot structure will be neighbors. The grouping algorithm relies on this!
                 room_data[room.pk]['start_and_duration'],
                 # Within each group, sort higher capacity rooms first.
-                room.capacity,
+                room.capacity if room.capacity is not None else -1,  # sort rooms with capacity = None at end
                 # Finally, sort alphabetically by name
                 room.name
             )


### PR DESCRIPTION
In the meeting schedule editor, rooms were meant to be sorted in decreasing order of capacity (among other criteria). Due to a bug, they were actually sorted in increasing order. Oops.

This fixes that and also handles the case where `capacity is None`.

Partially addresses #4377 but there is probably further work to do there.