### PR TITLE
chore: update create_dummy_meeting to specify session purposes

### DIFF
--- a/ietf/meeting/management/commands/create_dummy_meeting.py
+++ b/ietf/meeting/management/commands/create_dummy_meeting.py
@@ -181,6 +181,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1584,  # grow
                     attendees=75,
                     agenda_note="",
@@ -201,6 +202,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2166,  # sidrops
                     attendees=62,
                     agenda_note="",
@@ -225,6 +227,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1452,  # dnsop
                     attendees=160,
                     agenda_note="",
@@ -236,6 +239,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1452,  # dnsop
                     attendees=160,
                     agenda_note="",
@@ -264,6 +268,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1895,  # dnssd
                     attendees=75,
                     agenda_note="Joint with HOMENET",
@@ -275,6 +280,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1895,  # dnssd
                     attendees=75,
                     agenda_note="",
@@ -309,6 +315,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2216,  # lsvr
                     attendees=100,
                     agenda_note="",
@@ -335,6 +342,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2161,  # quic
                     attendees=200,
                     agenda_note="",
@@ -347,6 +355,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2161,  # quic
                     attendees=200,
                     agenda_note="",
@@ -403,6 +412,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1463,  # tsvwg
                     attendees=100,
                     agenda_note="",
@@ -414,6 +424,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1463,  # tsvwg
                     attendees=100,
                     agenda_note="",
@@ -453,6 +464,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1524,  # ccamp
                     attendees=50,
                     agenda_note="",
@@ -477,6 +489,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1763,  # dispatch
                     attendees=80,
                     agenda_note="Joint with ARTAREA",
@@ -518,6 +531,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1578,  # v6ops
                     attendees=100,
                     agenda_note="",
@@ -543,6 +557,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1899,  # stir
                     attendees=60,
                     agenda_note="",
@@ -580,6 +595,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1397,  # pim
                     attendees=30,
                     agenda_note="",
@@ -613,6 +629,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2211,  # suit
                     attendees=80,
                     agenda_note="",
@@ -650,6 +667,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2234,  # coinrg
                     attendees=100,
                     agenda_note="",
@@ -673,6 +691,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1883,  # nwcrg
                     attendees=35,
                     agenda_note="",
@@ -700,6 +719,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1620,  # tcpm
                     attendees=60,
                     agenda_note="",
@@ -725,6 +745,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1089,  # ippm
                     attendees=60,
                     agenda_note="",
@@ -761,6 +782,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2164,  # lamps
                     attendees=45,
                     agenda_note="",
@@ -796,6 +818,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1718,  # httpbis
                     attendees=150,
                     agenda_note="",
@@ -807,6 +830,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1718,  # httpbis
                     attendees=150,
                     agenda_note="",
@@ -830,6 +854,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1924,  # taps
                     attendees=50,
                     agenda_note="",
@@ -877,6 +902,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1958,  # dprive
                     attendees=120,
                     agenda_note="",
@@ -901,6 +927,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2194,  # teep
                     attendees=50,
                     agenda_note="",
@@ -912,6 +939,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2194,  # teep
                     attendees=50,
                     agenda_note="",
@@ -938,6 +966,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=42,  # iccrg
                     attendees=100,
                     agenda_note="",
@@ -963,6 +992,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2231,  # rats
                     attendees=40,
                     agenda_note="",
@@ -974,6 +1004,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2231,  # rats
                     attendees=40,
                     agenda_note="",
@@ -1002,6 +1033,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2219,  # secdispatch
                     attendees=200,
                     agenda_note="",
@@ -1037,6 +1069,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1118,  # mboned
                     attendees=30,
                     agenda_note="",
@@ -1065,6 +1098,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1960,  # bess
                     attendees=90,
                     agenda_note="",
@@ -1076,6 +1110,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1960,  # bess
                     attendees=90,
                     agenda_note="",
@@ -1100,6 +1135,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1803,  # homenet
                     attendees=60,
                     agenda_note="Joint with DNSSD",
@@ -1135,6 +1171,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1995,  # acme
                     attendees=70,
                     agenda_note="",
@@ -1158,6 +1195,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2150,  # babel
                     attendees=21,
                     agenda_note="",
@@ -1182,6 +1220,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2215,  # lsr
                     attendees=100,
                     agenda_note="",
@@ -1193,6 +1232,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2215,  # lsr
                     attendees=100,
                     agenda_note="",
@@ -1216,6 +1256,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1575,  # netconf
                     attendees=65,
                     agenda_note="",
@@ -1242,6 +1283,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2145,  # maprg
                     attendees=200,
                     agenda_note="",
@@ -1281,6 +1323,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1897,  # 6lo
                     attendees=55,
                     agenda_note="",
@@ -1319,6 +1362,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1723,  # 6man
                     attendees=120,
                     agenda_note="",
@@ -1330,6 +1374,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1723,  # 6man
                     attendees=120,
                     agenda_note="",
@@ -1355,6 +1400,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1853,  # irtfopen
                     attendees=150,
                     agenda_note="",
@@ -1395,6 +1441,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2148,  # lpwan
                     attendees=75,
                     agenda_note="",
@@ -1425,6 +1472,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1903,  # 6tisch
                     attendees=60,
                     agenda_note="",
@@ -1455,6 +1503,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1751,  # lisp
                     attendees=45,
                     agenda_note="",
@@ -1490,6 +1539,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1764,  # mptcp
                     attendees=50,
                     agenda_note="",
@@ -1514,6 +1564,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1730,  # roll
                     attendees=50,
                     agenda_note="",
@@ -1525,6 +1576,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1730,  # roll
                     attendees=50,
                     agenda_note="",
@@ -1555,6 +1607,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1187,  # saag
                     attendees=150,
                     agenda_note="",
@@ -1600,6 +1653,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1140,  # mpls
                     attendees=100,
                     agenda_note="",
@@ -1634,6 +1688,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1630,  # pce
                     attendees=75,
                     agenda_note="",
@@ -1668,6 +1723,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1962,  # detnet
                     attendees=100,
                     agenda_note="",
@@ -1700,6 +1756,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1744,  # alto
                     attendees=25,
                     agenda_note="",
@@ -1720,6 +1777,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1968,  # gaia
                     attendees=60,
                     agenda_note="",
@@ -1736,6 +1794,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2233,  # git
                     attendees=65,
                     agenda_note="",
@@ -1783,6 +1842,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2227,  # pearg
                     attendees=120,
                     agenda_note="",
@@ -1813,6 +1873,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1326,  # tls
                     attendees=120,
                     agenda_note="",
@@ -1824,6 +1885,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1326,  # tls
                     attendees=120,
                     agenda_note="",
@@ -1858,6 +1920,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1679,  # tsvarea
                     attendees=120,
                     agenda_note="",
@@ -1892,6 +1955,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2169,  # secevent
                     attendees=None,
                     agenda_note="",
@@ -1904,6 +1968,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2209,  # dinrg
                     attendees=90,
                     agenda_note="",
@@ -1925,6 +1990,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1714,  # opsawg
                     attendees=70,
                     agenda_note="Combined OpsAWG / OpsAREA",
@@ -1950,6 +2016,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1812,  # avtcore
                     attendees=30,
                     agenda_note="",
@@ -1982,6 +2049,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1628,  # bfd
                     attendees=50,
                     agenda_note="",
@@ -2011,6 +2079,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1674,  # emu
                     attendees=50,
                     agenda_note="",
@@ -2049,6 +2118,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1988,  # hrpc
                     attendees=100,
                     agenda_note="",
@@ -2072,6 +2142,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2002,  # cose
                     attendees=60,
                     agenda_note="",
@@ -2099,6 +2170,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1996,  # dots
                     attendees=50,
                     agenda_note="",
@@ -2123,6 +2195,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1041,  # idr
                     attendees=75,
                     agenda_note="",
@@ -2134,6 +2207,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1041,  # idr
                     attendees=75,
                     agenda_note="",
@@ -2162,6 +2236,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=945,  # bmwg
                     attendees=30,
                     agenda_note="",
@@ -2189,6 +2264,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2202,  # panrg
                     attendees=75,
                     agenda_note="",
@@ -2223,6 +2299,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=38,  # nmrg
                     attendees=80,
                     agenda_note="",
@@ -2234,6 +2311,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=38,  # nmrg
                     attendees=80,
                     agenda_note="",
@@ -2256,6 +2334,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1665,  # intarea
                     attendees=60,
                     agenda_note="",
@@ -2283,6 +2362,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1817,  # lwig
                     attendees=50,
                     agenda_note="",
@@ -2316,6 +2396,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1619,  # rtgwg
                     attendees=150,
                     agenda_note="",
@@ -2327,6 +2408,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1619,  # rtgwg
                     attendees=150,
                     agenda_note="",
@@ -2348,6 +2430,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2214,  # rift
                     attendees=70,
                     agenda_note="",
@@ -2374,6 +2457,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1905,  # spring
                     attendees=140,
                     agenda_note="",
@@ -2385,6 +2469,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1905,  # spring
                     attendees=140,
                     agenda_note="",
@@ -2405,6 +2490,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=988,  # dhc
                     attendees=25,
                     agenda_note="",
@@ -2433,6 +2519,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1740,  # ipsecme
                     attendees=50,
                     agenda_note="",
@@ -2460,6 +2547,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2146,  # regext
                     attendees=50,
                     agenda_note="",
@@ -2484,6 +2572,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=31,  # cfrg
                     attendees=150,
                     agenda_note="",
@@ -2532,6 +2621,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1849,  # icnrg
                     attendees=80,
                     agenda_note="",
@@ -2559,6 +2649,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1847,  # dmm
                     attendees=45,
                     agenda_note="",
@@ -2578,6 +2669,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2176,  # jmap
                     attendees=20,
                     agenda_note="",
@@ -2612,6 +2704,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1953,  # calext
                     attendees=15,
                     agenda_note="1330 - 1430",
@@ -2635,6 +2728,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2175,  # cbor
                     attendees=50,
                     agenda_note="",
@@ -2679,6 +2773,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2242,  # rum
                     attendees=20,
                     agenda_note="",
@@ -2703,6 +2798,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2220,  # mls
                     attendees=125,
                     agenda_note="",
@@ -2732,6 +2828,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2205,  # extra
                     attendees=15,
                     agenda_note="1430 - 1530",
@@ -2751,6 +2848,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1132,  # manet
                     attendees=20,
                     agenda_note="",
@@ -2770,6 +2868,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1838,  # rmcat
                     attendees=30,
                     agenda_note="",
@@ -2798,6 +2897,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1956,  # anima
                     attendees=80,
                     agenda_note="",
@@ -2809,6 +2909,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1956,  # anima
                     attendees=80,
                     agenda_note="",
@@ -2845,6 +2946,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1642,  # ntp
                     attendees=30,
                     agenda_note="",
@@ -2870,6 +2972,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1748,  # oauth
                     attendees=50,
                     agenda_note="",
@@ -2881,6 +2984,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1748,  # oauth
                     attendees=50,
                     agenda_note="",
@@ -2908,6 +3012,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1869,  # sacm
                     attendees=30,
                     agenda_note="",
@@ -2939,6 +3044,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1964,  # bier
                     attendees=30,
                     agenda_note="",
@@ -2960,6 +3066,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1985,  # teas
                     attendees=100,
                     agenda_note="",
@@ -2987,6 +3094,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1638,  # netmod
                     attendees=100,
                     agenda_note="",
@@ -2998,6 +3106,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1638,  # netmod
                     attendees=100,
                     agenda_note="",
@@ -3019,6 +3128,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1789,  # core
                     attendees=60,
                     agenda_note="",
@@ -3031,6 +3141,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1789,  # core
                     attendees=60,
                     agenda_note="",
@@ -3079,6 +3190,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1991,  # t2trg
                     attendees=90,
                     agenda_note="",
@@ -3126,6 +3238,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1921,  # ace
                     attendees=50,
                     agenda_note="",
@@ -3160,6 +3273,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2254,  # wpack
                     attendees=150,
                     agenda_note="",
@@ -3182,6 +3296,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2260,  # webtrans
                     attendees=100,
                     agenda_note="",
@@ -3203,6 +3318,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2253,  # abcd
                     attendees=200,
                     agenda_note="",
@@ -3219,6 +3335,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2255,  # tmrid
                     attendees=30,
                     agenda_note="",
@@ -3239,6 +3356,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2248,  # mops
                     attendees=100,
                     agenda_note="",
@@ -3266,6 +3384,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2256,  # raw
                     attendees=100,
                     agenda_note="",
@@ -3288,6 +3407,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2257,  # txauth
                     attendees=150,
                     agenda_note="",
@@ -3326,6 +3446,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2252,  # gendispatch
                     attendees=75,
                     agenda_note="",
@@ -3360,6 +3481,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1966,  # dtn
                     attendees=30,
                     agenda_note="",
@@ -3380,6 +3502,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2249,  # lake
                     attendees=100,
                     agenda_note="",
@@ -3401,6 +3524,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2258,  # mathmesh
                     attendees=100,
                     agenda_note="",
@@ -3416,6 +3540,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=2228,  # qirg
                     attendees=50,
                     agenda_note="",
@@ -3437,6 +3562,7 @@ class Command(BaseCommand):
                 s = Session.objects.create(
                     meeting=m,
                     type_id="regular",
+                    purpose_id="regular",
                     group_id=1840,  # nvo3
                     attendees=50,
                     agenda_note="",


### PR DESCRIPTION
Also broken on the main branch, but fixing on feat/tzaware because no one is likely to run the command on main until after the tzaware switch.