### PR TITLE
fix(nomcom-ui): Use pre instead of relying on now-missing pasted styling

### DIFF
--- a/ietf/dbtemplate/templates/dbtemplate/template_show.html
+++ b/ietf/dbtemplate/templates/dbtemplate/template_show.html
@@ -34,7 +34,7 @@
     <h2>Template content</h2>
 
     <div class="card">
-        <p class="pasted">{{ template.content }}</p>
+        <pre class="pasted">{{ template.content|escape }}</pre>
     </div>
 
 {% endblock %}

--- a/ietf/templates/nomcom/view_feedback_nominee.html
+++ b/ietf/templates/nomcom/view_feedback_nominee.html
@@ -78,9 +78,9 @@
                             <dt class="col-sm-2">
                                 Feedback
                             </dt>
-                            <dd class="col-sm-10 pasted">
+                            <dd class="col-sm-10 pasted"><pre>
                                 {% decrypt feedback.comments request year 1 %}
-                            </dd>
+                            </pre></dd>
                         </dl>
                         {% if not forloop.last %}<hr>{% endif %}
                     {% endif %}

--- a/ietf/templates/nomcom/view_feedback_topic.html
+++ b/ietf/templates/nomcom/view_feedback_topic.html
@@ -41,9 +41,9 @@
                             <dt class="col-sm-2">
                                 Feedback
                             </dt>
-                            <dd class="col-sm-10 pasted">
+                            <dd class="col-sm-10 pasted"><pre>
                                 {% decrypt feedback.comments request year 1 %}
-                            </dd>
+                            </pre></dd>
                         </dl>
                         {% if not forloop.last %}<hr>{% endif %}
                     {% endif %}

--- a/ietf/templates/nomcom/view_feedback_unrelated.html
+++ b/ietf/templates/nomcom/view_feedback_unrelated.html
@@ -42,9 +42,9 @@
                         <dt class="col-sm-2">
                             Feedback
                         </dt>
-                        <dd class="col-sm-10 pasted">
+                        <dd class="col-sm-10 pasted"><pre>
                             {% decrypt feedback.comments request year 1 %}
-                        </dd>
+                        </pre></dd>
                     </dl>
                 {% endfor %}
             </div>


### PR DESCRIPTION
Note that the nomcom decrypt templatetag already aggressively escapes.

Somewhere along the way, the pasted class seems to have been abandoned - there is no styling for it, and nothing tries to select for it in code. Should we just remove the class at this point (this PR changes the last of the places where we were relying on its styling back to use `<pre>` instead.

corrects the newline part of #4634 