### PR TITLE
fix: stabilize sorts of upcoming meetings

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3535,7 +3535,7 @@ def upcoming_ical(request):
         session__in=[s.pk for m in meetings for s in m.sessions if m.type_id != 'ietf'],
         timeslot__time__gte=today,
     ).order_by(
-        'schedule__meeting__date', 'session__type', 'timeslot__time'
+        'schedule__meeting__date', 'session__type', 'timeslot__time', 'schedule__meeting__number',
     ).select_related(
         'session__group', 'session__group__parent', 'timeslot', 'schedule', 'schedule__meeting'
     ).distinct())

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3467,8 +3467,12 @@ def upcoming(request):
 
     entries = list(ietf_meetings)
     entries.extend(list(interim_sessions))
-    entries.sort(key = lambda o: pytz.utc.localize(datetime.datetime.combine(o.date, datetime.datetime.min.time())) if isinstance(o,Meeting) else o.official_timeslotassignment().timeslot.utc_start_time())
-    
+    entries.sort(
+        key=lambda o: (
+            pytz.utc.localize(datetime.datetime.combine(o.date, datetime.datetime.min.time())) if isinstance(o, Meeting) else o.official_timeslotassignment().timeslot.utc_start_time(),
+            o.number if isinstance(o, Meeting) else o.meeting.number,
+        )
+    )
     for o in entries:
         if isinstance(o, Meeting):
             o.start_timestamp = int(pytz.utc.localize(datetime.datetime.combine(o.date, datetime.time.min)).timestamp())


### PR DESCRIPTION
The tzaware branch orders simultaneous meetings differently on both the `/meeting/upcoming` and the `/meeting/upcoming.ics` views. This stabilizes those sorts by adding the meeting number as a least-significant term in the sort key.

With this change, `/meeting/upcoming` on the main branch will change to match what will happen on feat/tzaware. The existing sorting on main was arbitrary, so it seems sensible to make it something meaningful.

The `/meeting/upcoming.ics` view will still change between main and tzaware, but will be a stable sort each branch. The branches will differ because the sort is done using the timeslot time in  the database. On main, that is the meeting-local time whereas in tzaware, it's UTC. This could be fixed by moving the sort to Python instead but that seems like a bigger change than is warranted.