### PR TITLE
test: fix timezone_not_near_midnight not to use pytz

### DIFF
--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -491,13 +491,13 @@ class TimezoneTests(TestCase):
     def test_timezone_not_near_midnight(self, mock):
         # give it several choices that should be rejected and one that should be accepted
         with patch(
-                'ietf.utils.timezone.pytz.common_timezones',
-                [
+                'ietf.utils.timezone.available_timezones',
+                return_value=set([
                     'America/Chicago',  # time is 23:15, should be rejected
                     'America/Lima',  # time is 23:15, should be rejected
                     'America/New_York',  # time is 00:15, should be rejected
                     'Europe/Riga',  # time is 07:15, acceptable
-                ],
+                ]),
         ):
             # check a few times (will pass by chance < 0.1% of the time)
             self.assertEqual(timezone_not_near_midnight(), 'Europe/Riga')
@@ -508,12 +508,12 @@ class TimezoneTests(TestCase):
 
         # now give it no valid choice
         with patch(
-                'ietf.utils.timezone.pytz.common_timezones',
-                [
+                'ietf.utils.timezone.available_timezones',
+                return_value=set([
                     'America/Chicago',  # time is 23:15, should be rejected
                     'America/Lima',  # time is 23:15, should be rejected
                     'America/New_York',  # time is 00:15, should be rejected
-                ],
+                ]),
         ):
             with self.assertRaises(RuntimeError):
                 timezone_not_near_midnight()


### PR DESCRIPTION
This changes from pytz to zoneinfo for the recently added test helpers. I checked that pytz and zoneinfo know about the same timezones (aside from the two special cases dropped from the available_timezones() set in this code)