### PR TITLE
fix: Eliminate use of django.utils.datetime_safe

### DIFF
--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -60,16 +60,6 @@ for name in pytz.common_timezones:
 timezones.sort()
 
 
-# this is used in models to format dates, as the built-in json serializer
-# can not deal with them, and the django provided serializer is inaccessible.
-from django.utils import datetime_safe
-DATE_FORMAT = "%Y-%m-%d"
-TIME_FORMAT = "%H:%M:%S"
-
-def fmt_date(o):
-    d = datetime_safe.new_date(o)
-    return d.strftime(DATE_FORMAT)
-
 class Meeting(models.Model):
     # number is either the number for IETF meetings, or some other
     # identifier for interim meetings/IESG retreats/liaison summits/...


### PR DESCRIPTION
<s>Use standard library instead. Hard to test since the code part using `datetime_safe` does not seem to be called from anywhere. Another alternative to this patch attempt would be to simply remove that code part.</s>

Instead of replacing `datetime_safe` by the standard api, just remove that part of the code (because it is unused).

Fixes #4513