### PR TITLE
fix use of http URLs, fix #4702

### DIFF
--- a/ietf/dbtemplate/fixtures/nomcom_templates.xml
+++ b/ietf/dbtemplate/fixtures/nomcom_templates.xml
@@ -41,7 +41,7 @@ You have been nominated for the position of $position.
 
 The NomCom would appreciate receiving an indication of whether or not you accept this nomination to stand for consideration as a candidate for this position.
 
-You can accept the nomination via web going to the following link http://$domain$accept_url or decline the nomination going the following link http://$domain$decline_url
+You can accept the nomination via web going to the following link https://$domain$accept_url or decline the nomination going the following link https://$domain$decline_url
 
 If you accept, you will need to fill out a questionnaire.  You will receive the questionnaire by email.
 
@@ -107,7 +107,7 @@ You have been nominated for the position of $position.
 
 The NomCom would appreciate receiving an indication of whether or not you accept this nomination to stand for consideration as a candidate for this position.
 
-You can accept the nomination via web going to the following link http://$domain$accept_url or decline the nomination going the following link http://$domain$decline_url
+You can accept the nomination via web going to the following link https://$domain$accept_url or decline the nomination going the following link https://$domain$decline_url
 
 If you accept, you will need to fill out a questionnaire.
 


### PR DESCRIPTION
The template for the 'IETF Nomination Information' email used "http" rather than "https". This updates the template. 