### PR TITLE
test: fix date-related timezone errors in tests

### DIFF
--- a/ietf/doc/tests_review.py
+++ b/ietf/doc/tests_review.py
@@ -526,7 +526,7 @@ class ReviewTests(TestCase):
             messages = r.json()["messages"]
             self.assertEqual(len(messages), 2)
 
-            today = date_today()
+            today = date_today(datetime.timezone.utc)
 
             self.assertEqual(messages[0]["url"], "https://www.example.com/testmessage")
             self.assertTrue("John Doe" in messages[0]["content"])

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -7,6 +7,7 @@ import datetime
 
 from pyquery import PyQuery
 from urllib.parse import quote, urlparse
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.urls import reverse as urlreverse
@@ -596,7 +597,7 @@ I would like to revoke this declaration.
         self.assertEqual(r.status_code,302)
         self.assertEqual(len(outbox),2)
         self.assertIn(
-            'Secretariat on ' + ipr.get_latest_event_submitted().time.astimezone().strftime("%Y-%m-%d"),
+            'Secretariat on ' + ipr.get_latest_event_submitted().time.astimezone(ZoneInfo(settings.TIME_ZONE)).strftime("%Y-%m-%d"),
             get_payload_text(outbox[1]).replace('\n',' '),
         )
         self.assertIn(f'{settings.IDTRACKER_BASE_URL}{urlreverse("ietf.ipr.views.showlist")}', get_payload_text(outbox[1]).replace('\n',' '))

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -595,7 +595,10 @@ I would like to revoke this declaration.
         r = self.client.post(url, data )
         self.assertEqual(r.status_code,302)
         self.assertEqual(len(outbox),2)
-        self.assertIn('Secretariat on '+ipr.get_latest_event_submitted().time.strftime("%Y-%m-%d"), get_payload_text(outbox[1]).replace('\n',' '))
+        self.assertIn(
+            'Secretariat on ' + ipr.get_latest_event_submitted().time.astimezone().strftime("%Y-%m-%d"),
+            get_payload_text(outbox[1]).replace('\n',' '),
+        )
         self.assertIn(f'{settings.IDTRACKER_BASE_URL}{urlreverse("ietf.ipr.views.showlist")}', get_payload_text(outbox[1]).replace('\n',' '))
 
     def send_ipr_email_helper(self):

--- a/ietf/liaisons/tests.py
+++ b/ietf/liaisons/tests.py
@@ -700,7 +700,7 @@ class LiaisonManagementTests(TestCase):
         from_groups = [ str(g.pk) for g in Group.objects.filter(type="sdo") ]
         to_group = Group.objects.get(acronym="mars")
         submitter = Person.objects.get(user__username="marschairman")
-        today = date_today()
+        today = date_today(datetime.timezone.utc)
         related_liaison = liaison
         r = self.client.post(url,
                              dict(from_groups=from_groups,
@@ -779,7 +779,7 @@ class LiaisonManagementTests(TestCase):
         from_group = Group.objects.get(acronym="mars")
         to_group = Group.objects.filter(type="sdo")[0]
         submitter = Person.objects.get(user__username="marschairman")
-        today = date_today()
+        today = date_today(datetime.timezone.utc)
         related_liaison = liaison
         r = self.client.post(url,
                              dict(from_groups=str(from_group.pk),
@@ -847,7 +847,7 @@ class LiaisonManagementTests(TestCase):
         from_group = Group.objects.get(acronym="mars")
         to_group = Group.objects.filter(type="sdo")[0]
         submitter = Person.objects.get(user__username="marschairman")
-        today = date_today()
+        today = date_today(datetime.timezone.utc)
         r = self.client.post(url,
                              dict(from_groups=str(from_group.pk),
                                   from_contact=submitter.email_address(),
@@ -866,7 +866,7 @@ class LiaisonManagementTests(TestCase):
         self.assertEqual(len(outbox), mailbox_before + 1)
 
     def test_liaison_add_attachment(self):
-        liaison = LiaisonStatementFactory(deadline=date_today()+datetime.timedelta(days=1))
+        liaison = LiaisonStatementFactory(deadline=date_today(DEADLINE_TZINFO)+datetime.timedelta(days=1))
         LiaisonStatementEventFactory(statement=liaison,type_id='submitted')
 
         self.assertEqual(liaison.attachments.count(),0)

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -10,6 +10,7 @@ import shutil
 from pyquery import PyQuery
 from urllib.parse import urlparse
 from itertools import combinations
+from zoneinfo import ZoneInfo
 
 from django.db import IntegrityError
 from django.db.models import Max
@@ -1506,7 +1507,7 @@ class NewActiveNomComTests(TestCase):
     def test_accept_reject_nomination_edges(self):
         self.client.logout()
         np = self.nc.nominee_set.order_by('pk').first().nomineeposition_set.order_by('pk').first()
-        date_str = np.time.astimezone().strftime("%Y%m%d")  # in settings.TIME_ZONE
+        date_str = np.time.astimezone(ZoneInfo(settings.TIME_ZONE)).strftime("%Y%m%d")
         kwargs={'year':self.nc.year(),
                 'nominee_position_id':np.id,
                 'state':'accepted',
@@ -1521,7 +1522,7 @@ class NewActiveNomComTests(TestCase):
         settings.DAYS_TO_EXPIRE_NOMINATION_LINK = 2
         np.time = np.time - datetime.timedelta(days=3)
         np.save()
-        date_str = np.time.astimezone().strftime("%Y%m%d")  # in settings.TIME_ZONE
+        date_str = np.time.astimezone(ZoneInfo(settings.TIME_ZONE)).strftime("%Y%m%d")
         kwargs['date'] = date_str
         kwargs['hash'] = get_hash_nominee_position(date_str, np.id)
         url = reverse('ietf.nomcom.views.process_nomination_status', kwargs=kwargs)
@@ -1537,7 +1538,7 @@ class NewActiveNomComTests(TestCase):
 
     def test_accept_reject_nomination_comment(self):
         np = self.nc.nominee_set.order_by('pk').first().nomineeposition_set.order_by('pk').first()
-        date_str = np.time.astimezone().strftime("%Y%m%d")  # in settings.TIME_ZONE
+        date_str = np.time.astimezone(ZoneInfo(settings.TIME_ZONE)).strftime("%Y%m%d")
         hash = get_hash_nominee_position(date_str, np.id)
         url = reverse('ietf.nomcom.views.process_nomination_status',
                       kwargs={'year':self.nc.year(),

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -1506,11 +1506,12 @@ class NewActiveNomComTests(TestCase):
     def test_accept_reject_nomination_edges(self):
         self.client.logout()
         np = self.nc.nominee_set.order_by('pk').first().nomineeposition_set.order_by('pk').first()
+        date_str = np.time.astimezone().strftime("%Y%m%d")  # in settings.TIME_ZONE
         kwargs={'year':self.nc.year(),
                 'nominee_position_id':np.id,
                 'state':'accepted',
-                'date':np.time.strftime("%Y%m%d"),
-                'hash':get_hash_nominee_position(np.time.strftime("%Y%m%d"),np.id),
+                'date':date_str,
+                'hash':get_hash_nominee_position(date_str, np.id),
                }
         url = reverse('ietf.nomcom.views.process_nomination_status', kwargs=kwargs)
         response = self.client.get(url)
@@ -1520,8 +1521,9 @@ class NewActiveNomComTests(TestCase):
         settings.DAYS_TO_EXPIRE_NOMINATION_LINK = 2
         np.time = np.time - datetime.timedelta(days=3)
         np.save()
-        kwargs['date'] = np.time.strftime("%Y%m%d")
-        kwargs['hash'] = get_hash_nominee_position(np.time.strftime("%Y%m%d"),np.id)
+        date_str = np.time.astimezone().strftime("%Y%m%d")  # in settings.TIME_ZONE
+        kwargs['date'] = date_str
+        kwargs['hash'] = get_hash_nominee_position(date_str, np.id)
         url = reverse('ietf.nomcom.views.process_nomination_status', kwargs=kwargs)
         response = self.client.get(url)
         self.assertEqual(response.status_code,403)
@@ -1535,12 +1537,13 @@ class NewActiveNomComTests(TestCase):
 
     def test_accept_reject_nomination_comment(self):
         np = self.nc.nominee_set.order_by('pk').first().nomineeposition_set.order_by('pk').first()
-        hash = get_hash_nominee_position(np.time.strftime("%Y%m%d"),np.id)
+        date_str = np.time.astimezone().strftime("%Y%m%d")  # in settings.TIME_ZONE
+        hash = get_hash_nominee_position(date_str, np.id)
         url = reverse('ietf.nomcom.views.process_nomination_status',
                       kwargs={'year':self.nc.year(),
                               'nominee_position_id':np.id,
                               'state':'accepted',
-                              'date':np.time.strftime("%Y%m%d"),
+                              'date':date_str,
                               'hash':hash,
                              }
                      )


### PR DESCRIPTION
Should fix problems that cropped up in https://github.com/ietf-tools/datatracker/actions/runs/3402144494/jobs/5657694491

That particular test run spanned midnight UTC but I think these would affect runs between midnight and 8am UTC