### PR TITLE
fix: agenda mobile dropdown links + footer padding + tz start/end date

### DIFF
--- a/client/agenda/Agenda.vue
+++ b/client/agenda/Agenda.vue
@@ -298,8 +298,18 @@ const titleExtra = computed(() => {
   return title
 })
 const meetingDate = computed(() => {
-  const start = DateTime.fromISO(agendaStore.meeting.startDate, { zone: agendaStore.meeting.timezone }).setZone(agendaStore.timezone)
-  const end = DateTime.fromISO(agendaStore.meeting.endDate, { zone: agendaStore.meeting.timezone }).setZone(agendaStore.timezone)
+  // Adjust to first meeting start time (to ensure proper start date when switching timezones)
+  const firstEventStartTime = { hour: 0, minute: 0 }
+  if (agendaStore.schedule.length > 0) {
+    const evStartObj = DateTime.fromISO(agendaStore.schedule[0].startDateTime, { zone: agendaStore.meeting.timezone }).toObject()
+    firstEventStartTime.hour = evStartObj.hour
+    firstEventStartTime.minute = evStartObj.minute
+  }
+
+  // Adjust start and end dates for current timezone
+  const start = DateTime.fromISO(agendaStore.meeting.startDate, { zone: agendaStore.meeting.timezone }).set(firstEventStartTime).setZone(agendaStore.timezone)
+  const end = DateTime.fromISO(agendaStore.meeting.endDate, { zone: agendaStore.meeting.timezone }).set({ hour: 23, minute: 59}).setZone(agendaStore.timezone)
+
   if (start.month === end.month) {
     return `${start.toFormat('MMMM d')} - ${end.toFormat('d, y')}`
   } else {

--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -112,7 +112,7 @@
                     :options='item.links'
                     key-field='id'
                     :render-icon='renderLinkIcon'
-                    @select='goToSessionLink'
+                    :render-label='renderLinkLabel'
                     )
                     n-button(size='tiny')
                       i.bi.bi-three-dots
@@ -555,6 +555,10 @@ function getEventColor (itemKey) {
 
 function renderLinkIcon (opt) {
   return h('i', { class: `bi bi-${opt.icon} text-${opt.color}` })
+}
+
+function renderLinkLabel (opt) {
+  return h('a', { href: opt.href, target: '_blank' }, opt.label)
 }
 
 function recalculateRedLine () {

--- a/ietf/templates/meeting/agenda.html
+++ b/ietf/templates/meeting/agenda.html
@@ -20,6 +20,13 @@ body {
     font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
+/* Avoid hiding the page footer when on mobile with the footer toolbar overlay */
+@media screen and (max-width: 992px) {
+    body {
+        padding-bottom: 50px;
+    }
+}
+
 @keyframes initspinner {
     to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
- Fixes #4718
- Fixes #4719
- Fixes incorrect header meeting start/end when switching timezone to one west of the meeting (e.g. it would show November 4th in Montreal because the start date is November 5th at 0:00 in London time). The start date now adds the first session start time to the start date and set the end date to 23:59.