### PR TITLE
test: validate HTML in own test case and report all results

### DIFF
--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -325,10 +325,6 @@ class ValidatingTemplate(Template):
         settings.validate_html.batches[kind].append(
             (self.origin.name, content, fingerprint)
         )
-        # FWIW, a batch size of 30 seems to result in less than 10% runtime overhead
-        if len(settings.validate_html.batches[kind]) >= 30:
-            settings.validate_html.validate(kind)
-
         return content
 
 

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -338,7 +338,7 @@ class TemplateValidationTests(unittest.TestCase):
         self.validate_html = validate_html
         super().__init__(**kwargs)
 
-    def test_template_validation(self):
+    def report_template_validation(self):
         if self.validate_html:
             for kind in self.validate_html.batches:
                 self.validate_html.validate(kind)
@@ -1092,7 +1092,7 @@ class IetfTestRunner(DiscoverRunner):
                 TemplateValidationTests(
                     test_runner=self,
                     validate_html=self,
-                    methodName='test_template_validation',
+                    methodName='report_template_validation',
                 ),
             ]
 


### PR DESCRIPTION
This fixes two shortcomings with the HTML validation:
1. Validation results are now reported in a single test case at the end instead of being tacked on to often unrelated tests
2. All validation results are reported - previously, the last batch (up to 30 of each `kind`) were silently dropped during the test runner teardown

Using `memory_profiler`, it appears that these changes add ~50 MB to the ~600 MB peak ram used by running the full test suite. The test run is a bit faster than before (consistent with old code comments estimating about 10% speed overhead).

A side effect of point 2 was that, when running only a few tests, HTML validations were run but their results discarded. That was the immediate impetus for this pull request.