### PR TITLE
test: permit multiple <h1> tags in a document

### DIFF
--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -873,15 +873,17 @@ class IetfTestRunner(DiscoverRunner):
             config["doc"]["rules"]["require-sri"] = "off"
             # Turn "element-required-ancestor" back on
             del config["doc"]["rules"]["element-required-ancestor"]
-            # permit discontinuous heading numbering in cards, modals and dialogs:
             config["doc"]["rules"]["heading-level"] = [
                 "error",
                 {
+                    # permit discontinuous heading numbering in cards, modals and dialogs:
                     "sectioningRoots": [
                         ".card-body",
                         ".modal-content",
                         '[role="dialog"]',
-                    ]
+                    ],
+                    # permit multiple H1 elements in a single document
+                    "allowMultipleH1": True,
                 },
             ]
 


### PR DESCRIPTION
Eliminates the failure here: https://github.com/ietf-tools/datatracker/actions/runs/3421760702/jobs/5700738094

The prohibition on multiple h1 tags is not needed - it was mostly an SEO concern and is outdated by HTML5. The code setting off the validation failure there is not new but was newly exercised by the test case added in PR #4734.