### PR TITLE
feat: UI enhancements to allow control-click etc on the search results

### DIFF
--- a/ietf/static/js/select2.js
+++ b/ietf/static/js/select2.js
@@ -19,6 +19,24 @@ function prettify_tz(x) {
     return x.text.replaceAll("_", " ").replaceAll("/", " / ");
 }
 
+function search_template_result(data) {
+    if (data.url == null) {
+        return data.text;
+    }
+    var $link = $("<a>" + data.text + "</a>");
+    $link.prop("href", data.url);
+    $link.on("mouseup", function (evt) {
+        // Do not propagate any events which have modifiers keys
+        // or if some other mouse button than 1 (left) was used.
+        if (evt.shiftKey || evt.ctrlKey || evt.metaKey || evt.altKey ||
+            evt.which != 1) {
+            evt.stopPropagation();
+        }
+    });
+
+    return $link;
+}
+
 // Copyright The IETF Trust 2015-2021, All Rights Reserved
 // JS for ietf.utils.fields.SearchableField subclasses
 window.setupSelect2Field = function (e) {
@@ -37,7 +55,8 @@ window.setupSelect2Field = function (e) {
         );
     }
 
-    template_modify = e.hasClass("tz-select") ? prettify_tz : undefined;
+    template_modify = e.hasClass("tz-select") ? prettify_tz :
+	(e.hasClass("search-select") ? search_template_result : undefined);
 
     // focus the search field automatically
     $(document)

--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -69,7 +69,7 @@
                     {% endif %}
 
                     <label class="d-none d-md-block" aria-label="Document search">
-                    <input class="form-control select2-field"
+                    <input class="form-control select2-field search-select"
                            id="navbar-doc-search"
                            data-select2-ajax-url="{% url 'ietf.doc.views_search.ajax_select2_search_docs' model_name='docalias' doc_type='draft' %}"
                            type="text"


### PR DESCRIPTION
Implements https://github.com/ietf-tools/datatracker/issues/4711 i.e., allows using control-click or context menu to open items in the top right search list to open multiple documents in different tabs.

Authored by @kivinen 