### PR TITLE
test: fix a couple tz problems in tests run soon after midnight UTC

### DIFF
--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -1646,7 +1646,13 @@ class DocTestCase(TestCase):
         doc.save_with_history([e])
         r = self.client.get(urlreverse("ietf.doc.views_doc.document_ballot", kwargs=dict(name=doc.name)))
         self.assertEqual(r.status_code, 200)
-        self.assertRegex(r.content.decode(), r'\(\s*%s\s+for\s+-%s\s*\)' % (pos.comment_time.strftime('%Y-%m-%d'), oldrev))
+        self.assertRegex(
+            r.content.decode(),
+            r'\(\s*%s\s+for\s+-%s\s*\)' % (
+                pos.comment_time.astimezone(ZoneInfo(settings.TIME_ZONE)).strftime('%Y-%m-%d'),
+                oldrev,
+            )
+        )
 
         # Now simulate a new ballot against the new revision and make sure the "was" position is included
         pos2 = BallotPositionDocEvent.objects.create(

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -578,7 +578,10 @@ I would like to revoke this declaration.
         self.assertIn('posted on '+date_today().strftime("%Y-%m-%d"), get_payload_text(outbox[len_before]).replace('\n',' '))
         self.assertTrue('draft-ietf-mars-test@ietf.org' in outbox[len_before+1]['To'])
         self.assertTrue('mars-wg@ietf.org' in outbox[len_before+1]['Cc'])
-        self.assertIn('Secretariat on '+ipr.get_latest_event_submitted().time.strftime("%Y-%m-%d"), get_payload_text(outbox[len_before+1]).replace('\n',' '))
+        self.assertIn(
+            'Secretariat on ' + ipr.get_latest_event_submitted().time.astimezone(ZoneInfo(settings.TIME_ZONE)).strftime("%Y-%m-%d"),
+            get_payload_text(outbox[len_before + 1]).replace('\n', ' ')
+        )
         self.assertIn(f'{settings.IDTRACKER_BASE_URL}{urlreverse("ietf.ipr.views.showlist")}', get_payload_text(outbox[len_before]).replace('\n',' '))
         self.assertIn(f'{settings.IDTRACKER_BASE_URL}{urlreverse("ietf.ipr.views.history",kwargs=dict(id=ipr.pk))}', get_payload_text(outbox[len_before+1]).replace('\n',' '))
 


### PR DESCRIPTION
This fixes two tests that failed in https://github.com/ietf-tools/datatracker/actions/runs/3466626001/jobs/5790677332

The other two tests that failed there (`ietf.doc.tests.ChartTests.test_personal_chart` and `ietf.doc.tests.ChartTests.test_search_chart_data`) may reflect a bug, so I'm going to create a ticket to investigate rather than quickly patching.