### PR TITLE
fix: remove extra ':' after DTSTAMP in .ics templates

### DIFF
--- a/ietf/templates/meeting/agenda.ics
+++ b/ietf/templates/meeting/agenda.ics
@@ -10,7 +10,7 @@ SUMMARY:{% if item.session.name %}{{item.session.name|ics_esc}}{% else %}{% if n
 CLASS:PUBLIC
 DTSTART{% ics_date_time item.timeslot.local_start_time schedule.meeting.time_zone %}
 DTEND{% ics_date_time item.timeslot.local_end_time schedule.meeting.time_zone %}
-DTSTAMP:{% ics_date_time item.timeslot.modified|utc 'utc' %}{% if item.session.agenda %}
+DTSTAMP{% ics_date_time item.timeslot.modified|utc 'utc' %}{% if item.session.agenda %}
 URL:{{item.session.agenda.get_versionless_href}}{% endif %}
 DESCRIPTION:{{item.timeslot.name|ics_esc}}\n{% if item.session.agenda_note %}
  Note: {{item.session.agenda_note|ics_esc}}\n{% endif %}{% if item.timeslot.location.webex_url %}

--- a/ietf/templates/meeting/upcoming.ics
+++ b/ietf/templates/meeting/upcoming.ics
@@ -10,7 +10,7 @@ SUMMARY:{% if item.session.name %}{{item.session.group.acronym|lower}} - {{item.
 CLASS:PUBLIC
 DTSTART{% ics_date_time item.timeslot.local_start_time item.schedule.meeting.time_zone %}
 DTEND{% ics_date_time item.timeslot.local_end_time item.schedule.meeting.time_zone %}
-DTSTAMP:{% ics_date_time item.timeslot.modified|utc 'utc' %}
+DTSTAMP{% ics_date_time item.timeslot.modified|utc 'utc' %}
 {% if item.session.agenda %}URL:{{item.session.agenda.get_href}}
 DESCRIPTION:{{item.timeslot.name|ics_esc}}\n{% if item.session.agenda_note %}
  Note: {{item.session.agenda_note|ics_esc}}\n{% endif %}{% for material in item.session.materials.all %}

--- a/ietf/utils/test_utils.py
+++ b/ietf/utils/test_utils.py
@@ -145,6 +145,10 @@ def assert_ical_response_is_valid(test_inst, response, expected_event_summaries=
         test_inst.assertContains(response, 'END:VEVENT', count=expected_event_count)
         test_inst.assertContains(response, 'UID', count=expected_event_count)
 
+    # make sure no doubled colons after timestamp properties
+    test_inst.assertNotContains(response, 'DTSTART::')
+    test_inst.assertNotContains(response, 'DTEND::')
+    test_inst.assertNotContains(response, 'DTSTAMP::')
 
 
 class ReverseLazyTest(django.test.TestCase):


### PR DESCRIPTION
Fixes ironic syntax error introduced in #4630