### PR TITLE
fix: use UTC for model_to_timeline_data()

### DIFF
--- a/ietf/doc/views_stats.py
+++ b/ietf/doc/views_stats.py
@@ -49,7 +49,7 @@ def model_to_timeline_data(model, field='time', **kwargs):
         # This is needed for sqlite, when we're running tests:
         if type(obj_list[0]['date']) != datetime.date:
             obj_list = [ {'date': dt(e['date']), 'count': e['count']} for e in obj_list ]
-        today = date_today()
+        today = date_today(datetime.timezone.utc)
         if not obj_list[-1]['date'] == today:
             obj_list += [ {'date': today, 'count': 0} ]
         data = [ ((e['date'].toordinal()-epochday)*1000*60*60*24, e['count']) for e in obj_list ]


### PR DESCRIPTION
This changes the method to operate in UTC instead of server time. The existing code was mixing UTC and server time, though, giving timestamps purporting to be UTC but computed from the date in the server timezone. To the extent that it matters, I think this change is preferable to restoring the original behavior.