### PR TITLE
fix: agenda meeting updated datetime

### DIFF
--- a/client/agenda/Agenda.vue
+++ b/client/agenda/Agenda.vue
@@ -317,7 +317,14 @@ const meetingDate = computed(() => {
   }
 })
 const meetingUpdated = computed(() => {
-  return agendaStore.meeting.updated ? DateTime.fromISO(agendaStore.meeting.updated).setZone(agendaStore.timezone).toFormat(`DD 'at' tt ZZZZ`) : false
+  if (!agendaStore.meeting.updated) { return false }
+  
+  const updatedDatetime = DateTime.fromISO(agendaStore.meeting.updated).setZone(agendaStore.timezone)
+  if (!updatedDatetime.isValid || updatedDatetime < DateTime.fromISO('1980-01-01')) {
+    return false
+  }
+  
+  return updatedDatetime.toFormat(`DD 'at' T ZZZZ`)
 })
 const colorLegendShown = computed(() => {
   return agendaStore.colorPickerVisible || (agendaStore.colorLegendShown && Object.keys(agendaStore.colorAssignments).length > 0)

--- a/client/agenda/FloorPlan.vue
+++ b/client/agenda/FloorPlan.vue
@@ -5,7 +5,6 @@
       span #[strong IETF {{agendaStore.meeting.number}}] Floor Plan
       .meeting-h1-badges.d-none.d-sm-flex
         span.meeting-warning(v-if='agendaStore.meeting.warningNote') {{agendaStore.meeting.warningNote}}
-        span.meeting-beta BETA
     h4
       span {{agendaStore.meeting.city}}, {{ meetingDate }}
 

--- a/playwright/tests/meeting/agenda.spec.js
+++ b/playwright/tests/meeting/agenda.spec.js
@@ -136,7 +136,7 @@ test.describe('past - desktop', () => {
       const localDateTime = DateTime.fromISO(meetingData.meeting.updated)
         .setZone(BROWSER_TIMEZONE)
         .setLocale(BROWSER_LOCALE)
-        .toFormat('DD \'at\' tt ZZZZ')
+        .toFormat('DD \'at\' T ZZZZ')
       await expect(page.locator('.agenda h6').first()).toContainText(localDateTime)
       // Switch to UTC
       await tzUtcBtnLocator.click()
@@ -145,7 +145,7 @@ test.describe('past - desktop', () => {
       const utcDateTime = DateTime.fromISO(meetingData.meeting.updated)
         .setZone('utc')
         .setLocale(BROWSER_LOCALE)
-        .toFormat('DD \'at\' tt ZZZZ')
+        .toFormat('DD \'at\' T ZZZZ')
       await expect(page.locator('.agenda h6').first()).toContainText(utcDateTime)
       await expect(page.locator('.agenda .agenda-timezone-ddn')).toContainText('UTC')
       // Switch back to meeting timezone
@@ -694,7 +694,7 @@ test.describe('past - desktop', () => {
     const localDateTime = DateTime.fromISO(meetingData.meeting.updated)
       .setZone(BROWSER_TIMEZONE)
       .setLocale(BROWSER_LOCALE)
-      .toFormat('DD \'at\' tt ZZZZ')
+      .toFormat('DD \'at\' T ZZZZ')
     await expect(page.locator('.agenda h6').first()).toContainText(localDateTime)
     // Switch to UTC
     await tzButtonsLocator.last().click()
@@ -703,7 +703,7 @@ test.describe('past - desktop', () => {
     const utcDateTime = DateTime.fromISO(meetingData.meeting.updated)
       .setZone('utc')
       .setLocale(BROWSER_LOCALE)
-      .toFormat('DD \'at\' tt ZZZZ')
+      .toFormat('DD \'at\' T ZZZZ')
     await expect(page.locator('.agenda h6').first()).toContainText(utcDateTime)
     // Switch back to meeting timezone
     await tzButtonsLocator.first().click()
@@ -837,7 +837,7 @@ test.describe('past - desktop', () => {
     const localDateTime = DateTime.fromISO(meetingData.meeting.updated)
       .setZone(BROWSER_TIMEZONE)
       .setLocale(BROWSER_LOCALE)
-      .toFormat('DD \'at\' tt ZZZZ')
+      .toFormat('DD \'at\' T ZZZZ')
     await expect(page.locator('.agenda h6').first()).toContainText(localDateTime)
     // Switch to UTC
     await tzUtcBtnLocator.click()
@@ -846,7 +846,7 @@ test.describe('past - desktop', () => {
     const utcDateTime = DateTime.fromISO(meetingData.meeting.updated)
       .setZone('utc')
       .setLocale(BROWSER_LOCALE)
-      .toFormat('DD \'at\' tt ZZZZ')
+      .toFormat('DD \'at\' T ZZZZ')
     await expect(page.locator('.agenda h6').first()).toContainText(utcDateTime)
     // Switch back to meeting timezone
     await tzMeetingBtnLocator.click()

--- a/playwright/tests/meeting/agenda.spec.js
+++ b/playwright/tests/meeting/agenda.spec.js
@@ -68,7 +68,7 @@ test.describe('past - desktop', () => {
     const updatedDateTime = DateTime.fromISO(meetingData.meeting.updated)
       .setZone(meetingData.meeting.timezone)
       .setLocale(BROWSER_LOCALE)
-      .toFormat('DD \'at\' tt ZZZZ')
+      .toFormat('DD \'at\' T ZZZZ')
     await expect(page.locator('.agenda h6').first(), 'should have meeting last updated datetime').toContainText(updatedDateTime)
 
     // NAV


### PR DESCRIPTION
- Hide updated datetime if valid but earlier than 1980.
- Remove "BETA" badge leftover from floorplan page.