### PR TITLE
feat: Only show IPR search form when not showing search results 

### DIFF
--- a/ietf/templates/ipr/search_form.html
+++ b/ietf/templates/ipr/search_form.html
@@ -3,86 +3,103 @@
 {% load origin %}
 {% origin %}
 <h1>IPR Search</h1>
-<form class="ipr-search">
-    {% if user|has_role:"Secretariat" %}
-        <h2 class="mt-4">State Filter</h2>
-        {% bootstrap_field form.state %}
-    {% endif %}
-    <h2 class="mt-4">Document search</h2>
-    <div class="mb-3">
-        {% bootstrap_label form.draft.label label_for=form.draft.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.draft class="form-control" placeholder="draft-..." %}
-            <button class="btn btn-primary" type="submit" value="draft">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
+
+<div class="accordion" id="ipr-search-form">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="ipr-search-form-heading">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="{{ request.GET|yesno:'false,true'}}" aria-controls="collapseOne">
+        IPR search criteria...
+      </button>
+    </h2>
+    <div id="collapseOne" class="accordion-collapse collapse{% if not request.GET %} show{% endif %}" aria-labelledby="ipr-search-form-heading" data-bs-parent="#ipr-search-form">
+      <div class="accordion-body">
+
+        <form class="ipr-search">
+            {% if user|has_role:"Secretariat" %}
+                <h2>State Filter</h2>
+                {% bootstrap_field form.state %}
+            {% endif %}
+            <h2>Document search</h2>
+            <div class="mb-3">
+                {% bootstrap_label form.draft.label label_for=form.draft.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.draft class="form-control" placeholder="draft-..." %}
+                    <button class="btn btn-primary" type="submit" value="draft">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </div>
+            <div class="mb-3">
+                {% bootstrap_label form.rfc.label label_for=form.rfc.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.rfc class="form-control" placeholder="123..." %}
+                    <button class="btn btn-primary" type="submit" value="rfc">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </div>
+            <div class="mb-3">
+                {% bootstrap_label form.doctitle.label|cut:":" label_for=form.doctitle.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.doctitle class="form-control" placeholder="protocol..." %}
+                    <button class="btn btn-primary" type="submit" value="doctitle">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </div>
+            <div class="mb-3">
+                {% bootstrap_label form.group.label|cut:":" label_for=form.group.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.group class="form-select" %}
+                    <button class="btn btn-primary btn-block"
+                            type="submit"
+                            value="group">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </div>
+            <h2>IPR search</h2>
+            <div class="mb-3">
+                {% bootstrap_label form.holder.label|cut:":" label_for=form.holder.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.holder class="form-control" placeholder="John Doe..." %}
+                    <button class="btn btn-primary" type="submit" value="holder">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </div>
+            <div class="mb-3">
+                {% bootstrap_label form.iprtitle.label|cut:":" label_for=form.iprtitle.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.iprtitle class="form-control" placeholder="protocol..." %}
+                    <button class="btn btn-primary" type="submit" value="iprtitle">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </div>
+            <div class="mb-3">
+                {% bootstrap_label form.patent.label|cut:":" label_for=form.patent.id_for_label label_class="form-label" %}
+                <div class="input-group">
+                    {% render_field form.patent class="form-control" %}
+                    <button class="btn btn-primary" type="submit" value="patent">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+                <div class="form-text">
+                    This search string must contain at least three characters, including
+                    at least one digit, and include punctuation marks. For best results,
+                    please enter the entire string, or as much of it as possible.
+                </div>
+            </div>
+            <input type="hidden" name="submit">
+        </form>
+
+      </div>
     </div>
-    <div class="mb-3">
-        {% bootstrap_label form.rfc.label label_for=form.rfc.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.rfc class="form-control" placeholder="123..." %}
-            <button class="btn btn-primary" type="submit" value="rfc">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
-    </div>
-    <div class="mb-3">
-        {% bootstrap_label form.doctitle.label|cut:":" label_for=form.doctitle.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.doctitle class="form-control" placeholder="protocol..." %}
-            <button class="btn btn-primary" type="submit" value="doctitle">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
-    </div>
-    <div class="mb-3">
-        {% bootstrap_label form.group.label|cut:":" label_for=form.group.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.group class="form-select" %}
-            <button class="btn btn-primary btn-block"
-                    type="submit"
-                    value="group">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
-    </div>
-    <h2 class="mt-4">IPR search</h2>
-    <div class="mb-3">
-        {% bootstrap_label form.holder.label|cut:":" label_for=form.holder.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.holder class="form-control" placeholder="John Doe..." %}
-            <button class="btn btn-primary" type="submit" value="holder">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
-    </div>
-    <div class="mb-3">
-        {% bootstrap_label form.iprtitle.label|cut:":" label_for=form.iprtitle.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.iprtitle class="form-control" placeholder="protocol..." %}
-            <button class="btn btn-primary" type="submit" value="iprtitle">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
-    </div>
-    <div class="mb-3">
-        {% bootstrap_label form.patent.label|cut:":" label_for=form.patent.id_for_label label_class="form-label" %}
-        <div class="input-group">
-            {% render_field form.patent class="form-control" %}
-            <button class="btn btn-primary" type="submit" value="patent">
-                <i class="bi bi-search"></i> Search
-            </button>
-        </div>
-        <div class="form-text">
-            This search string must contain at least three characters, including
-            at least one digit, and include punctuation marks. For best results,
-            please enter the entire string, or as much of it as possible.
-        </div>
-    </div>
-    <input type="hidden" name="submit">
-</form>
-<p class="alert alert-info my-3">
+  </div>
+</div>
+
+<p class="alert alert-warning my-3">
     The material posted as IPR disclosures should be viewed as originating
     from the source of that information, and any issue or question related
     to the material should be directed to the source rather than the

--- a/ietf/templates/ipr/search_form.html
+++ b/ietf/templates/ipr/search_form.html
@@ -7,11 +7,11 @@
 <div class="accordion" id="ipr-search-form">
   <div class="accordion-item">
     <h2 class="accordion-header" id="ipr-search-form-heading">
-      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="{{ request.GET|yesno:'false,true'}}" aria-controls="collapseOne">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#ipr-search-collapse" aria-expanded="{{ request.GET|yesno:'false,true'}}" aria-controls="ipr-search-collapse">
         IPR search criteria...
       </button>
     </h2>
-    <div id="collapseOne" class="accordion-collapse collapse{% if not request.GET %} show{% endif %}" aria-labelledby="ipr-search-form-heading" data-bs-parent="#ipr-search-form">
+    <div id="ipr-search-collapse" class="accordion-collapse collapse{% if not request.GET %} show{% endif %}" aria-labelledby="ipr-search-form-heading" data-bs-parent="#ipr-search-form">
       <div class="accordion-body">
 
         <form class="ipr-search">


### PR DESCRIPTION
Put it into a collapsible that is only expanded by default when not
showing search results.

Fixes #4569