### PR TITLE
chore: Use `codespell` to fix typos in comments.

### DIFF
--- a/ietf/doc/migrations/0015_2_add_doc_document_m2m_fields.py
+++ b/ietf/doc/migrations/0015_2_add_doc_document_m2m_fields.py
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
             field=models.ManyToManyField(blank=True, related_name='tagdocs', through='doc.DocumentTags', to='name.DocTagName'),
         ),
         # Here we copy the content of the existing implicit m2m tables for
-        # the Document m2m fields into the explicit through tabeles, in order
+        # the Document m2m fields into the explicit through tables, in order
         # to be able to later set the correct id from name
         migrations.RunPython(timestamp, timestamp),
         migrations.RunSQL(

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -215,7 +215,7 @@ class DocumentInfo(models.Model):
         which returns an url to the datatracker page for the document.   
         """
         # If self.external_url truly is an url, use it.  This is a change from
-        # the earlier resulution order, but there's at the moment one single
+        # the earlier resolution order, but there's at the moment one single
         # instance which matches this (with correct results), so we won't
         # break things all over the place.
         if not hasattr(self, '_cached_href'):
@@ -921,7 +921,7 @@ class Document(DocumentInfo):
 
     def last_presented(self):
         """ returns related SessionPresentation objects for the most recent meeting in the past"""
-        # Assumes no two meetings have the same start date - if the assumption is violated, one will be chosen arbitrariy
+        # Assumes no two meetings have the same start date - if the assumption is violated, one will be chosen arbitrarily
         today = date_today()
         candidate_presentations = self.sessionpresentation_set.filter(session__meeting__date__lte=today)
         candidate_meetings = set([p.session.meeting for p in candidate_presentations if p.session.meeting.end_date()<today])
@@ -1320,7 +1320,7 @@ class BallotDocEvent(DocEvent):
                 if e.pos != prev:
                     latest.old_positions.append(e.pos)
 
-        # get rid of trailling "No record" positions, some old ballots
+        # get rid of trailing "No record" positions, some old ballots
         # have plenty of these
         for p in positions:
             while p.old_positions and p.old_positions[-1].slug == "norecord":

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -660,7 +660,7 @@ def can_defer(user,doc):
 
 @register.filter()
 def can_ballot(user,doc):
-    # Only IRSG memebers (and the secretariat, handled by code separately) can take positions on IRTF documents
+    # Only IRSG members (and the secretariat, handled by code separately) can take positions on IRTF documents
     # Otherwise, an AD can take a position on anything that has a ballot open
     if doc.type_id == 'draft' and doc.stream_id == 'irtf':
         return has_role(user,'IRSG Member')

--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -817,7 +817,7 @@ Man                    Expires September 22, 2015               [Page 3]
         self.assertContains(r, updated_by.canonical_name())
         self.assertContains(r, updated_by.title)
 
-        # naked RFC - also wierd that we test a PS from the ISE
+        # naked RFC - also weird that we test a PS from the ISE
         rfc = IndividualDraftFactory(
             name="rfc1234567",
             title="RFC without a Draft",
@@ -2580,7 +2580,7 @@ class MaterialsTests(TestCase):
         self.doc.save_with_history([e])
 
         # This is necessary for the view to be able to find the document
-        # which hints that the view has an issue : if a materials document is taken out of all SessionPresentations, it is no longer accessable by this view
+        # which hints that the view has an issue : if a materials document is taken out of all SessionPresentations, it is no longer accessible by this view
         SessionPresentationFactory(session__meeting__number=meeting_number, session__group=self.doc.group, document=self.doc)
 
     def test_markdown_and_text(self):

--- a/ietf/doc/tests_draft.py
+++ b/ietf/doc/tests_draft.py
@@ -635,7 +635,7 @@ class ExpireIDsTests(DraftFileMixin, TestCase):
     def test_in_draft_expire_freeze(self):
         from ietf.doc.expire import in_draft_expire_freeze
 
-        # If there is no "next" meeting, we musn't be in a freeze
+        # If there is no "next" meeting, we mustn't be in a freeze
         self.assertTrue(not in_draft_expire_freeze())
 
         meeting = Meeting.objects.create(number="123",

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -1346,7 +1346,7 @@ def bibxml_for_draft(doc, rev=None):
         raise Http404("Revision not found")
 
     # Build the date we want to claim for the document in the bibxml
-    # For documents that have relevent NewRevisionDocEvents, use the date of the event.
+    # For documents that have relevant NewRevisionDocEvents, use the date of the event.
     # Very old documents don't have NewRevisionDocEvents - just use the document time.
         
     latest_revision_event = doc.latest_event(NewRevisionDocEvent, type="new_revision")

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -163,7 +163,7 @@ def change_state(request, name, option=None):
                 if message or charter_state.slug == "intrev" or charter_state.slug == "extrev":
                     email_admin_re_charter(request, group, "Charter state changed to \"%s\"" % charter_state.name, message,'charter_state_edit_admin_needed')
 
-                # TODO - do we need a seperate set of recipients for state changes to charters vrs other kind of documents
+                # TODO - do we need a separate set of recipients for state changes to charters vrs other kind of documents
                 email_state_changed(request, charter, "State changed to %s." % charter_state, 'doc_state_edited')
 
                 if charter_state.slug == "intrev" and group.type_id == "wg":

--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -280,7 +280,7 @@ def search_for_name(request, name):
     if redirect_to:
         return cached_redirect(cache_key, urlreverse("ietf.doc.views_doc.document_main", kwargs={ "name": redirect_to }))
     else:
-        # check for embedded rev - this may be ambigious, so don't
+        # check for embedded rev - this may be ambiguous, so don't
         # chop it off if we don't find a match
         rev_split = re.search("^(.+)-([0-9]{2})$", n)
         if rev_split:

--- a/ietf/group/models.py
+++ b/ietf/group/models.py
@@ -335,7 +335,7 @@ class GroupMilestoneHistory(GroupMilestoneInfo):
     milestone = ForeignKey(GroupMilestone, related_name="history_set")
 
 class GroupStateTransitions(models.Model):
-    """Captures that a group has overriden the default available
+    """Captures that a group has overridden the default available
     document state transitions for a certain state."""
     group = ForeignKey(Group)
     state = ForeignKey('doc.State', help_text="State for which the next states should be overridden")

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -1963,7 +1963,7 @@ class AcronymValidationTests(TestCase):
         self.assertIn('acronym',form.errors)
         form = AdminGroupForm({'acronym':'f','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)
-        # For the ITU we have a heirarchy of group names that use hyphens as delimeters
+        # For the ITU we have a hierarchy of group names that use hyphens as delimiters
         form = AdminGroupForm({'acronym':'should-pass','name':'should pass','type':'sdo','state':'active','used_roles':'[]','time':now})
         self.assertTrue(form.is_valid())
         form = AdminGroupForm({'acronym':'shouldfail-','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})

--- a/ietf/group/tests_review.py
+++ b/ietf/group/tests_review.py
@@ -227,7 +227,7 @@ class ReviewTests(TestCase):
         self.assertContains(r, review_req1.doc.name)
         self.assertContains(r, review_req2.doc.name)
         # None of the reviews should be completed this time,
-        # note that "Days Since Completed has soft hypens in it, so it
+        # note that "Days Since Completed has soft hyphens in it, so it
         # will not match
         self.assertNotContains(r, "Completed")
         # add multiple completed reviews
@@ -303,7 +303,7 @@ class ReviewTests(TestCase):
             else:
                 self.assertNotContains(r, reqs[i].doc.name)
         # Add assigned items, they should be visible as long as they
-        # are withing time period
+        # are within time period
         review_req4 = ReviewRequestFactory(state_id='completed', team=team)
         ReviewAssignmentFactory(
             review_request__doc=review_req4.doc,
@@ -369,10 +369,10 @@ class ReviewTests(TestCase):
         login_testing_unauthorized(self, "secretary", unassigned_url)
 
         # Need one more person in review team one so we can test incrementing skip_count without immediately decrementing it
-        another_reviewer = PersonFactory.create(name = "Extra TestReviewer") # needs to be lexically greater than the exsting one
+        another_reviewer = PersonFactory.create(name = "Extra TestReviewer") # needs to be lexically greater than the existing one
         another_reviewer.role_set.create(name_id='reviewer', email=another_reviewer.email(), group=review_req1.team)
         ReviewerSettingsFactory(team=review_req3.team, person = another_reviewer)
-        yet_another_reviewer = PersonFactory.create(name = "YetAnotherExtra TestReviewer") # needs to be lexically greater than the exsting one
+        yet_another_reviewer = PersonFactory.create(name = "YetAnotherExtra TestReviewer") # needs to be lexically greater than the existing one
         yet_another_reviewer.role_set.create(name_id='reviewer', email=yet_another_reviewer.email(), group=review_req1.team)
         ReviewerSettingsFactory(team=review_req3.team, person = yet_another_reviewer)
 

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -197,7 +197,7 @@ class IetfAuthTests(TestCase):
     def test_create_whitelisted_account(self):
         email = "new-account@example.com"
 
-        # add whitelist entry
+        # add allowlist entry
         r = self.client.post(urlreverse(ietf.ietfauth.views.login), {"username":"secretary", "password":"secretary+password"})
         self.assertEqual(r.status_code, 302)
         self.assertEqual(urlsplit(r["Location"])[2], urlreverse(ietf.ietfauth.views.profile))
@@ -214,7 +214,7 @@ class IetfAuthTests(TestCase):
         r = self.client.get(urlreverse('django.contrib.auth.views.logout'))
         self.assertEqual(r.status_code, 200)
 
-        # register and verify whitelisted email
+        # register and verify allowlisted email
         self.register_and_verify(email)
 
 

--- a/ietf/liaisons/forms.py
+++ b/ietf/liaisons/forms.py
@@ -41,7 +41,7 @@ from functools import reduce
 NOTES:
 Authorized individuals are people (in our Person table) who are authorized to send
 messages on behalf of some other group - they have a formal role in the other group,
-whereas the liasion manager has a formal role with the IETF (or more correctly,
+whereas the liaison manager has a formal role with the IETF (or more correctly,
 with the IAB).
 '''
 

--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -888,7 +888,7 @@ def make_materials_directories(meeting):
     This function takes a meeting object and creates the appropriate materials directories
     '''
     path = meeting.get_materials_path()
-    # Default umask is 0x022, meaning strip write premission for group and others.
+    # Default umask is 0x022, meaning strip write permission for group and others.
     # Change this temporarily to 0x0, to keep write permission for group and others.
     # (WHY??) (Note: this code is old -- was present already when the secretariat code
     # was merged with the regular datatracker code; then in secr/proceedings/views.py

--- a/ietf/meeting/management/commands/populate_attended.py
+++ b/ietf/meeting/management/commands/populate_attended.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                 # In the expected dumps from MeetEcho, if there was only one session for group foo, it would just be named 'foo'.
                 # If there were _three_, we would see 'foo' for the first, 'foo_2' for the second, and 'foo_3' for the third.
                 # order below is the index into what is returned from sort_sessions -- 0 is the first session for a group at that meeting.
-                # There is brutal fixup below for older meetings where we had special arrangements where meetecho reported the non-existant
+                # There is brutal fixup below for older meetings where we had special arrangements where meetecho reported the non-existent
                 # group of 'plenary', mapping it into the appropriate 'ietf' group session.
                 # A bug in the export scripts at MeetEcho trimmed the '-t' from 'model-t'.
                 order = 0

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -244,7 +244,7 @@ class Meeting(models.Model):
         Attendance = namedtuple('Attendance', 'onsite remote')
 
         # MeetingRegistration.attended started conflating badge-pickup and session attendance before IETF 114.
-        # We've separated session attendence off to ietf.meeting.Attended, but need to report attendance at older
+        # We've separated session attendance off to ietf.meeting.Attended, but need to report attendance at older
         # meetings correctly.
 
         attended_per_meetingregistration = (

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -2786,7 +2786,7 @@ class ReorderSlidesTests(TestCase):
             self.assertEqual(r.json()['success'],True)
             self.assertEqual(session.sessionpresentation_set.count(),1)
 
-            # Ingore a request to add slides that are already in a session
+            # Ignore a request to add slides that are already in a session
             r = self.client.post(url, {'order':1, 'name':slides.name })
             self.assertEqual(r.status_code, 200)
             self.assertEqual(r.json()['success'],True)

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -216,7 +216,7 @@ def materials_document(request, document, num=None, ext=None):
         name, rev = document, None
     # This view does not allow the use of DocAliases. Right now we are probably only creating one (identity) alias, but that may not hold in the future.
     doc = Document.objects.filter(name=name).first()
-    # Handle edge case where the above name, rev splitter misidentifies the end of a document name as a revision mumber
+    # Handle edge case where the above name, rev splitter misidentifies the end of a document name as a revision number
     if not doc:
         if rev:
             name = name + '-' + rev

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -1612,7 +1612,7 @@ Junk body for testing
         fb = Feedback.objects.get(id=fb.id)
         self.assertEqual(fb.type_id,'junk')
 
-        # comments, nominations, and questionnare responses are catagorized via a second 
+        # comments, nominations, and questionnaire responses are categorized via a second
         # formset presented by the view (signaled by having 'end' appear in the POST)
         fb = FeedbackFactory(nomcom=self.nc,type_id=None)
         np = NomineePosition.objects.filter(position__nomcom = self.nc,state='accepted').first()

--- a/ietf/person/factories.py
+++ b/ietf/person/factories.py
@@ -28,10 +28,10 @@ fake = faker.Factory.create()
 
 def setup():
     global acceptable_fakers
-    # The transliteration of some arabic and devanagari names introduces
-    # non-alphabetic characgters that don't work with the draft author
-    # extraction code, and also don't seem to match the way people with arabic
-    # names romanize arabic names.  Exlude those locales from name generation
+    # The transliteration of some Arabic and Devanagari names introduces
+    # non-alphabetic characters that don't work with the draft author
+    # extraction code, and also don't seem to match the way people with Arabic
+    # names romanize Arabic names.  Exclude those locales from name generation
     # in order to avoid test failures.
     locales = set( [ l for l in faker.config.AVAILABLE_LOCALES if not (l.startswith('ar_') or l.startswith('sg_') or l=='fr_QC') ] )
     acceptable_fakers = [faker.Faker(locale) for locale in locales]

--- a/ietf/person/utils.py
+++ b/ietf/person/utils.py
@@ -50,7 +50,7 @@ def merge_persons(request, source, target, file=sys.stdout, verbose=False):
 #    request.user = User.objects.filter(is_superuser=True).first()
     deletable_objects = admin.utils.get_deleted_objects(objs, request, admin.site)
     deletable_objects_summary = deletable_objects[1]
-    if len(deletable_objects_summary) > 1:    # should only inlcude one object (Person)
+    if len(deletable_objects_summary) > 1:    # should only include one object (Person)
         print("Not Deleting Person: {}({})".format(source.ascii,source.pk), file=file)
         print("Related objects remain:", file=file)
         pprint.pprint(deletable_objects[1], stream=file)

--- a/ietf/review/migrations/0025_repair_assignments.py
+++ b/ietf/review/migrations/0025_repair_assignments.py
@@ -140,7 +140,7 @@ def forward(apps, schema_editor):
     # review-ietf-detnet-mpls-over-udp-ip-06-opsdir-lc-romascanu-2020-09-03 2020-09-03 02:49:33
     # review-ietf-detnet-mpls-over-udp-ip-06-opsdir-lc-romascanu-2020-09-03-2 2020-09-03 02:49:33
     # <snip/>
-    # Both of those are places where the submit button got hit twice in rapid successsion.
+    # Both of those are places where the submit button got hit twice in rapid succession.
     # Messages went to the list twice. No threads were started
     # The review assignments currently point to the -2 versions. I think we change them to point to the not -2 versions and delete the -2 version documents.
     #

--- a/ietf/secr/groups/views.py
+++ b/ietf/secr/groups/views.py
@@ -230,7 +230,7 @@ def search(request):
             type = form.cleaned_data['type']
             meeting = get_current_meeting()
 
-            # construct seach query
+            # construct search query
             if group_acronym:
                 kwargs['acronym__istartswith'] = group_acronym
             if group_name:

--- a/ietf/secr/proceedings/proc_utils.py
+++ b/ietf/secr/proceedings/proc_utils.py
@@ -47,7 +47,7 @@ def _get_session(number,name,date,time):
     return assignment.session
 
 def _get_urls_from_json(doc):
-    '''Returns list of dictonary titel,url from search results'''
+    '''Returns list of dictionary title,url from search results'''
     urls = []
     for item in doc['items']:
         title = item['snippet']['title']

--- a/ietf/secr/utils/decorators.py
+++ b/ietf/secr/utils/decorators.py
@@ -18,7 +18,7 @@ from ietf.utils.response import permission_denied
             
 def check_for_cancel(redirect_url):
     """
-    Decorator to make a view redirect to the given url if the reuqest is a POST which contains
+    Decorator to make a view redirect to the given url if the request is a POST which contains
     a submit=Cancel.
     """
     def decorator(func):

--- a/ietf/secr/utils/group.py
+++ b/ietf/secr/utils/group.py
@@ -42,7 +42,7 @@ def get_my_groups(user,conclude=False):
     Returns a list of groups the user has access to.  Rules are as follows
     secretariat - has access to all groups
     area director - has access to all groups in their area
-    wg chair or secretary - has acceses to their own group
+    wg chair or secretary - has access to their own group
     chair of irtf has access to all irtf groups
 
     If user=None than all groups are returned.

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -630,7 +630,7 @@ MAX_WG_DELEGATES = 3
 # document state:
 GROUP_STATES_WITH_EXTRA_PROCESSING = ["sub-pub", "rfc-edit", ]
 
-# Review team releated settings
+# Review team related settings
 GROUP_REVIEW_MAX_ITEMS_TO_SHOW_IN_REVIEWER_LIST = 10
 GROUP_REVIEW_DAYS_TO_SHOW_IN_REVIEWER_LIST = 365
 

--- a/ietf/static/js/datepicker.js
+++ b/ietf/static/js/datepicker.js
@@ -1638,7 +1638,7 @@
 				options = typeof option === 'object' && option;
 			if (!data){
 				var elopts = opts_from_el(this, 'date'),
-					// Preliminary otions
+					// Preliminary options
 					xopts = $.extend({}, defaults, elopts, options),
 					locopts = opts_from_locale(xopts.language),
 					// Options priority: js args, data-attrs, locales, defaults

--- a/ietf/static/js/listjs-search.js
+++ b/ietf/static/js/listjs-search.js
@@ -119,7 +119,7 @@ module.exports = function (list) {
       var target = e.target || e.srcElement, // IE have srcElement
         alreadyCleared = target.value === '' && !list.searched
       if (!alreadyCleared) {
-        // If oninput already have resetted the list, do nothing
+        // If oninput has already reset the list, do nothing
         searchMethod(target.value)
       }
     }, list.searchDelay)

--- a/ietf/submit/forms.py
+++ b/ietf/submit/forms.py
@@ -799,8 +799,8 @@ class SubmissionEmailForm(forms.Form):
     Used to add a message to a submission or to create a new submission.
     This message is NOT a reply to a previous message but has arrived out of band
     
-    if submission_pk is None we are startign a new submission and name
-    must be unique. Otehrwise the name must match the submission.name.
+    if submission_pk is None we are starting a new submission and name
+    must be unique. Otherwise the name must match the submission.name.
     '''
     name = forms.CharField(required=True, max_length=255, label="Draft name")
     submission_pk = forms.IntegerField(required=False, widget=forms.HiddenInput())

--- a/ietf/submit/tests.py
+++ b/ietf/submit/tests.py
@@ -1445,7 +1445,7 @@ class SubmitTests(BaseSubmitTestCase):
         self.assertEqual(r.status_code, 302)
         unprivileged_status_url = r['Location']
 
-        # status page as unpriviliged => no edit button
+        # status page as unprivileged => no edit button
         r = self.client.get(unprivileged_status_url)
         self.assertContains(r, "Submission status of %s" % name)
         q = PyQuery(r.content)

--- a/ietf/sync/iana.py
+++ b/ietf/sync/iana.py
@@ -195,7 +195,7 @@ def update_history_with_changes(changes, send_email=True):
                     continue
 
                 # the naive way of extracting prev_state here means
-                # that we assume these changes are cronologically
+                # that we assume these changes are chronologically
                 # applied
                 prev_state = doc.get_state(state_type)
                 e = add_state_change_event(doc, system, prev_state, state, timestamp=timestamp)

--- a/ietf/utils/management/commands/mergedata.py
+++ b/ietf/utils/management/commands/mergedata.py
@@ -188,7 +188,7 @@ class Command(LoadCommand):
                                             #debug.say("Found matching object with new pk: %s" % (obj.object.pk, ))
                             new_pk = obj.object.pk
                             if new_pk != old_pk:
-                                # Update other objects refering to this
+                                # Update other objects referring to this
                                 # object to use the new pk
                                 #debug.show('old_pk, new_pk')
                                 mname = model._meta.app_label + '.' + model.__name__

--- a/ietf/utils/migrations/0002_convert_timestamps_to_utc.py
+++ b/ietf/utils/migrations/0002_convert_timestamps_to_utc.py
@@ -114,7 +114,7 @@ expected_datetime_columns = (
 def convert_pre1970_timestamps(apps, schema_editor):
     """Convert timestamps that CONVERT_TZ cannot handle
 
-    This could be made to do the entire conversion but some tables that require converison
+    This could be made to do the entire conversion but some tables that require conversion
     do not use 'id' as their PK. Rather than reinvent the ORM, we'll let SQL do what it can
     with CONVERT_TZ and clean up after. The tables that have pre-1970 timestamps both have
     'id' columns.

--- a/ietf/utils/patch.py
+++ b/ietf/utils/patch.py
@@ -185,7 +185,7 @@ def fromstring(s):
 
 def fromurl(url):
   """ Parse patch from an URL, return False
-      if an error occured. Note that this also
+      if an error occurred. Note that this also
       can throw urlopen() exceptions.
   """
   ps = PatchSet( urllib_request.urlopen(url) )
@@ -749,7 +749,7 @@ class PatchSet(object):
   def diffstat(self):
     """ calculate diffstat and return as a string
         Notes:
-          - original diffstat ouputs target filename
+          - original diffstat outputs target filename
           - single + or - shouldn't escape histogram
     """
     names = []
@@ -1181,7 +1181,7 @@ def main():
     patch.apply(options.strip, root=options.directory.encode()) or sys.exit(-1)
 
   # todo: document and test line ends handling logic - patch.py detects proper line-endings
-  #       for inserted hunks and issues a warning if patched file has incosistent line ends
+  #       for inserted hunks and issues a warning if patched file has inconsistent line ends
 
 
 if __name__ == "__main__":

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -428,7 +428,7 @@ def get_template_paths(apps=None):
 
 def save_test_results(failures, test_labels):
     # Record the test result in a file, in order to be able to check the
-    # results and avoid re-running tests if we've alread run them with OK
+    # results and avoid re-running tests if we've already run them with OK
     # result after the latest code changes:
     tfile = io.open(".testresult", "a", encoding='utf-8')
     timestr = time.strftime("%Y-%m-%d %H:%M:%S")

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -162,7 +162,7 @@ def get_callbacks(urllist, namespace=None):
                 callbacks.add(qualified(entry.name))
             if hasattr(entry, 'lookup_str') and entry.lookup_str:
                 callbacks.add(qualified(entry.lookup_str))
-            # There are some entries we don't handle here, mostly clases
+            # There are some entries we don't handle here, mostly classes
             # (such as Feed subclasses)
 
     return list(callbacks)

--- a/ietf/utils/text.py
+++ b/ietf/utils/text.py
@@ -111,7 +111,7 @@ def fill(text, width):
     return "\n\n".join(wrapped)
 
 def wordwrap(text, width=80):
-    """Wraps long lines without loosing the formatting and indentation
+    """Wraps long lines without losing the formatting and indentation
        of short lines"""
     if not isinstance(text, str):
         return text


### PR DESCRIPTION
First part of replacement of #4651