### PR TITLE
feat: add 'IETF Meetings' filter to upcoming meetings page

### DIFF
--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -256,6 +256,10 @@ class AgendaFilterOrganizer(AgendaKeywordTool):
         self.special_filters = None
         if self._use_legacy_keywords():
             self.extra_labels += ('Plenary',)  # need this when not using session purpose
+        self.manual_extra_labels = set()
+
+    def add_extra_filter(self, kw):
+        self.manual_extra_labels.add(kw)
 
     def get_non_area_keywords(self):
         """Get list of any 'non-area' (aka 'special') keywords
@@ -436,13 +440,13 @@ class AgendaFilterOrganizer(AgendaKeywordTool):
     def _extra_filters(self):
         """Get list of filters corresponding to self.extra_labels"""
         item_source = self.assignments or self.sessions or []
-        candidates = set(self.extra_labels)
+        candidates = set(self.extra_labels).union(self.manual_extra_labels)
         return self._filter_column(
             label=None,
             keyword=None,
             children=[
                 self._filter_entry(label=label, keyword=xslugify(label), toggled_by=[], is_bof=False)
-                for label in candidates if any(
+                for label in candidates if label in self.manual_extra_labels or any(
                     # Keep only those that will affect at least one session
                     [label.lower() in item.filter_keywords for item in item_source]
                 )]

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -4507,8 +4507,16 @@ class InterimTests(TestCase):
         # Just a quick check of functionality - details tested by test_js.InterimTests
         make_meeting_test_data(create_interims=True)
         url = urlreverse("ietf.meeting.views.upcoming_ical")
-        r = self.client.get(url + '?show=mars')
 
+        r = self.client.get(url + '?show=mars')
+        self.assertEqual(r.status_code, 200)
+        assert_ical_response_is_valid(self, r,
+                                      expected_event_summaries=[
+                                          'mars - Martian Special Interest Group',
+                                      ],
+                                      expected_event_count=1)
+
+        r = self.client.get(url + '?show=mars,ietf-meetings')
         self.assertEqual(r.status_code, 200)
         assert_ical_response_is_valid(self, r,
                                       expected_event_summaries=[

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3548,9 +3548,14 @@ def upcoming_ical(request):
             a.session = sessions.get(a.session_id) or a.session
             a.session.ical_status = ical_session_status(a)
 
-    # handle IETFs separately
-    ietfs = [m for m in meetings if m.type_id == 'ietf']
-    preprocess_meeting_important_dates(ietfs)
+    # Handle IETFs separately. Manually apply the 'ietf-meetings' filter.
+    if filter_params is None or (
+            'ietf-meetings' in filter_params['show'] and 'ietf-meetings' not in filter_params['hide']
+    ):
+        ietfs = [m for m in meetings if m.type_id == 'ietf']
+        preprocess_meeting_important_dates(ietfs)
+    else:
+        ietfs = []
 
     meeting_vtz = {meeting.vtimezone() for meeting in meetings}
     meeting_vtz.discard(None)

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3456,6 +3456,10 @@ def upcoming(request):
     # Set up for agenda filtering - only one filter_category here
     AgendaKeywordTagger(sessions=interim_sessions).apply()
     filter_organizer = AgendaFilterOrganizer(sessions=interim_sessions, single_category=True)
+    # Allow filtering to show only IETF Meetings. This adds a button labeled "IETF Meetings" to the
+    # "Other" column of the filter UI. When enabled, this adds the keyword "ietf-meetings" to the "show"
+    # filter list. The IETF meetings are explicitly labeled with this keyword in upcoming.html.
+    filter_organizer.add_extra_filter('IETF Meetings')
 
     entries = list(ietf_meetings)
     entries.extend(list(interim_sessions))

--- a/ietf/templates/meeting/upcoming.html
+++ b/ietf/templates/meeting/upcoming.html
@@ -46,7 +46,12 @@
             <tbody>
                 {% for entry in entries %}
                     <tr class="entry"
-                        {% if entry|classname == 'Session' %}data-filter-keywords="{{ entry.filter_keywords|join:',' }}"{% endif %}>
+                        {% if entry|classname == 'Session' %}
+                            data-filter-keywords="{{ entry.filter_keywords|join:',' }}"
+                        {% elif entry|classname == 'Meeting' %}
+                            data-filter-keywords="ietf-meetings"
+                        {% endif %}
+                    >
                         {% if entry|classname == 'Meeting' %}
                             {% with meeting=entry %}
                                 <td class="meeting-time"

--- a/ietf/templates/meeting/upcoming.html
+++ b/ietf/templates/meeting/upcoming.html
@@ -127,6 +127,7 @@
                       {% with meeting=entry %}
                           {
                               ietf_meeting_number: '{{ meeting.number }}',
+                              filter_keywords: ['ietf-meetings'],
                               start_moment: moment.tz('{{meeting.date}}', '{{ meeting.time_zone }}').startOf('day'),
                               end_moment: moment.tz('{{meeting.end_date}}', '{{ meeting.time_zone }}').endOf('day'),
                               url: '{% url 'agenda' num=meeting.number %}'


### PR DESCRIPTION
Fixes #4807.

Changes both the `upcoming()` and `upcoming_ics()` views to apply a keyword, `ietf-meetings`, to IETF meetings. This is a bit kludgy but follows the same rules as existing keywords.

Note that with these changes, IETF meetings are only included in the iCalendar output when explicitly requested with that keyword. Previously, the filters affected only interim meetings and IETF meetings were always included.