### PR TITLE
fix: init time inputs in correct tz when editing an interim request

### DIFF
--- a/ietf/meeting/forms.py
+++ b/ietf/meeting/forms.py
@@ -223,10 +223,10 @@ class InterimMeetingModelForm(forms.ModelForm):
 
 class InterimSessionModelForm(forms.ModelForm):
     date = DatepickerDateField(date_format="yyyy-mm-dd", picker_settings={"autoclose": "1"}, label='Date', required=False)
-    time = forms.TimeField(widget=forms.TimeInput(format='%H:%M'), required=True, help_text="Local time")
+    time = forms.TimeField(widget=forms.TimeInput(format='%H:%M'), required=True, help_text="Start time in meeting time zone")
     time.widget.attrs['placeholder'] = "HH:MM"
     requested_duration = CustomDurationField(required=True)
-    end_time = forms.TimeField(required=False, help_text="Local time")
+    end_time = forms.TimeField(required=False, help_text="End time in meeting time zone")
     end_time.widget.attrs['placeholder'] = "HH:MM"
     remote_participation = forms.ChoiceField(choices=(), required=False)
     remote_instructions = forms.CharField(
@@ -258,8 +258,8 @@ class InterimSessionModelForm(forms.ModelForm):
         self.is_edit = bool(self.instance.pk)
         # setup fields that aren't intrinsic to the Session object
         if self.is_edit:
-            self.initial['date'] = self.instance.official_timeslotassignment().timeslot.time
-            self.initial['time'] = self.instance.official_timeslotassignment().timeslot.time
+            self.initial['date'] = self.instance.official_timeslotassignment().timeslot.local_start_time().date()
+            self.initial['time'] = self.instance.official_timeslotassignment().timeslot.local_start_time().time()
             if self.instance.agenda():
                 doc = self.instance.agenda()
                 content = doc.text_or_error()

--- a/ietf/meeting/tests_forms.py
+++ b/ietf/meeting/tests_forms.py
@@ -6,6 +6,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings, RequestFactory
 
 from ietf.group.factories import GroupFactory
+from ietf.meeting.factories import SessionFactory
 from ietf.meeting.forms import (FileUploadForm, ApplyToAllFileUploadForm, InterimSessionModelForm,
                                 InterimMeetingModelForm)
 from ietf.person.factories import PersonFactory
@@ -122,6 +123,15 @@ class InterimSessionModelFormTests(TestCase):
         choice_vals = [choice[0] for choice in form.fields['remote_participation'].choices]
         self.assertNotIn('meetecho', choice_vals)
         self.assertIn('manual', choice_vals)
+
+    def test_edits_in_meeting_time_zone(self):
+        # use a time zone that never has a UTC offset of 0, even with DST
+        session = SessionFactory(meeting__type_id='interim', meeting__time_zone='America/Halifax')
+        form = InterimSessionModelForm(instance=session)
+        self.assertEqual(
+            form.initial['time'].strftime('%H:%M'),
+            session.official_timeslotassignment().timeslot.local_start_time().strftime('%H:%M'),
+        )
 
 
 class InterimMeetingModelFormTests(TestCase):


### PR DESCRIPTION
Fixes #4832 