### PR TITLE
fix: be more sure to create interim's timeslot / update duration

### DIFF
--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -1060,8 +1060,7 @@ def sessions_post_save(request, forms):
                 by=request.user.person,
             )
         
-        if ('date' in form.changed_data) or ('time' in form.changed_data):
-            update_interim_session_assignment(form)
+        update_interim_session_assignment(form)
         if 'agenda' in form.changed_data:
             form.save_agenda()
 
@@ -1140,6 +1139,8 @@ def update_interim_session_assignment(form):
     """Helper function to create / update timeslot assigned to interim session
 
     form is an InterimSessionModelForm
+
+    Only updates timeslot time (a datetime) and duration
     """
     session = form.instance
     meeting = session.meeting
@@ -1148,9 +1149,10 @@ def update_interim_session_assignment(form):
     )
     if session.official_timeslotassignment():
         slot = session.official_timeslotassignment().timeslot
-        slot.time = time
-        slot.duration = session.requested_duration
-        slot.save()
+        if slot.time != time or slot.duration != session.requested_duration:
+            slot.time = time
+            slot.duration = session.requested_duration
+            slot.save()
     else:
         slot = TimeSlot.objects.create(
             meeting=meeting,


### PR DESCRIPTION
This is an attempt to prevent the error in #4833 from recurring. I have not been able to reproduce the reported failure, though. Somehow the attempt to edit the interim resulted in sessions being created without the necessary timeslots.

The change here ensures that, whether or not the form thinks the date/time have changed, it will create a timeslot for a session if one is needed. Even if this is not causing #4833, I think this is a more robust strategy.

This also updates the timeslot duration when the session's requested_duration changes. Previously this was done only if the time or date changed.