### PR TITLE
fix: Don't show checker validations on HTMLization page

### DIFF
--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -296,6 +296,7 @@ href="{% url 'ietf.doc.views_draft.review_possibly_replaces' name=doc.name %}">E
             {% endif %}
         </td>
     </tr>
+    {% if not document_html %}
     {% for check in doc.submission.latest_checks %}
         {% if check.passed != None and check.symbol.strip %}
             <tr>
@@ -331,7 +332,6 @@ href="{% url 'ietf.doc.views_draft.review_possibly_replaces' name=doc.name %}">E
             </tr>
         {% endif %}
     {% endfor %}
-    {% if not document_html %}
     {% if review_assignments or can_request_review %}
         <tr>
             <td></td>


### PR DESCRIPTION
Modals in static sidebars don't work; fixing this needs a larger rework.

Fixes #4865