### PR TITLE
fix: use a single Meeting instance for all assignments in agenda views

### DIFF
--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -119,6 +119,11 @@ def preprocess_assignments_for_agenda(assignments_queryset, meeting, extra_prefe
     groups = [ ]
     for a in assignments:
         if a.session:
+            # Ensure that all Sessions refer to the same Meeting instance so they can share the
+            # _groups_at_the_time() cache. The Sessions should all belong to the same meeting, but
+            # check before blindly assigning to meeting just in case.
+            if a.session.meeting.pk == meeting.pk:
+                a.session.meeting = meeting
             a.session.order_number = None
 
             if a.session.group and a.session.group not in groups:


### PR DESCRIPTION
It was noted in #4853 that the caching in `groups_at_the_time()` was only partially effective. For a typical meeting agenda, group histories were being looked up 100-200 times. This was adding several seconds to the agenda retrieval (up to about 8 on my dev machine).

The cause for this was that the code to look up schedule assignments caused each `Session` to have its own `Meeting` instance. Each instance retrieved the data for its own separate cache.

This PR forces all `Session` instances to share the original `Meeting` instance used to find the agenda data. While a bit of a hack, this reduces the number of group history lookups to 1.