### PR TITLE
fix: do not create ReviewRequestDocEvent when assigning a review req

### DIFF
--- a/ietf/doc/tests_review.py
+++ b/ietf/doc/tests_review.py
@@ -345,6 +345,16 @@ class ReviewTests(TestCase):
         self.assertIn("This team has completed other reviews", message)
         self.assertIn("{} -01 Serious Issues".format(reviewer_email.person.ascii), message)
 
+        # check events
+        assignment_events = assignment.reviewassignmentdocevent_set.all()
+        self.assertEqual(assignment_events.count(), 1)
+        e = assignment_events.first()
+        self.assertEqual(e.type, 'assigned_review_request')
+        self.assertIn('is assigned', e.desc)
+        self.assertEqual(e.doc, doc)
+        request_events = review_req.reviewrequestdocevent_set.all()
+        self.assertEqual(request_events.count(), 0)
+
     def test_previously_reviewed_replaced_doc(self):
         review_team = ReviewTeamFactory(acronym="reviewteam", name="Review Team", type_id="review", list_email="reviewteam@ietf.org", parent=Group.objects.get(acronym="farfut"))
         rev_role = RoleFactory(group=review_team,person__user__username='reviewer',person__user__email='reviewer@example.com',person__name='Some Reviewer',name_id='reviewer')

--- a/ietf/review/utils.py
+++ b/ietf/review/utils.py
@@ -398,15 +398,6 @@ def assign_review_request_to_reviewer(request, review_req, reviewer, add_skip=Fa
             review_req.team.acronym.upper(),
             reviewer.person if reviewer else "(None)")
     update_change_reason(assignment, descr)
-    ReviewRequestDocEvent.objects.create(
-        type="assigned_review_request",
-        doc=review_req.doc,
-        rev=review_req.doc.rev,
-        by=request.user.person,
-        desc=descr,
-        review_request=review_req,
-        state_id='assigned',
-    )
 
     ReviewAssignmentDocEvent.objects.create(
         type="assigned_review_request",
@@ -416,7 +407,7 @@ def assign_review_request_to_reviewer(request, review_req, reviewer, add_skip=Fa
         desc="Request for {} review by {} is assigned to {}".format(
             review_req.type.name,
             review_req.team.acronym.upper(),
-            reviewer.person,
+            reviewer.person if reviewer else "(None)",
         ),
         review_assignment=assignment,
         state_id='assigned',


### PR DESCRIPTION
Fixes #4748.

Assumes that existing `ReviewRequestDocEvent` instances of type `assigned_review_request` will be manually removed. A migration could be written but I think it's better to treat this manually. On my dev instance with a recent DB image:

```
>>> ReviewRequestDocEvent.objects.filter(type='assigned_review_request').count()
14046
>>> ReviewRequestDocEvent.objects.filter(type='assigned_review_request').delete()
(28092, {'doc.DocReminder': 0, 'doc.ReviewRequestDocEvent': 14046, 'doc.DocEvent': 14046})
```

gets rid of the duplicate history items. There are still a small number (< 40) of near-duplicate events that look like assignments were made twice. E.g., 

```
>>> hh[0]
<QuerySet [<ReviewAssignmentDocEvent: draft-ietf-httpbis-messaging assigned review request by Barry Leiba at 2021-08-24 18:07:27+00:00>, <ReviewAssignmentDocEvent: draft-ietf-httpbis-messaging assigned review request by Barry Leiba at 2021-08-24 18:06:38+00:00>]>
>>> hh[0].values_list('desc')
<QuerySet [('Request for Last Call review by ARTART is assigned to Marco Tiloca',), ('Request for Last Call review by ARTART is assigned to Marco Tiloca',)]>
```
