### PR TITLE
test: fix (and simplify) changed email address generation

### DIFF
--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -1305,9 +1305,8 @@ Man                    Expires September 22, 2015               [Page 3]
             basis=change_reason
         )
 
-        old_email = new_email = draft.authors()[0].email()
-        while new_email == old_email:
-            new_email = EmailFactory(person=draft.authors()[0])
+        old_address = draft.authors()[0].email()
+        new_email = EmailFactory(person=draft.authors()[0], address=f'changed-{old_address}')
         post_data['author-0-email'] = new_email.address
         post_data['author-1-affiliation'] = 'University of Nowhere'
         post_data['author-2-country'] = 'Chile'


### PR DESCRIPTION
This is a better fix than #4918. The generate-and-check loop with the `EmailFactory` was nonsense. The loop checked whether two `Email` instances were the same which would never be true (aside from the initial test before the factory was called). The condition should have tested equality of `Email.address`, but that is the primary key for the model/table so was guaranteed to be different unless the factory had caused a primary key collision.

This just specifies a changed email address and gets rid of the loop and randomness.