### PR TITLE
feat: Generate a partial schedule when there are more sessions than timeslots

### DIFF
--- a/ietf/meeting/management/commands/generate_schedule.py
+++ b/ietf/meeting/management/commands/generate_schedule.py
@@ -170,9 +170,7 @@ class ScheduleHandler(object):
           * sunday timeslots
           *  timeslots used by the base schedule, if any
         """
-        # n.b., models.TimeSlot is not the same as TimeSlot!
-        timeslots_db = models.TimeSlot.objects.filter(
-            meeting=self.meeting,
+        timeslots_db = self.meeting.timeslot_set.that_can_be_scheduled().filter(
             type_id='regular',
         ).exclude(
             location__capacity=None,
@@ -195,12 +193,7 @@ class ScheduleHandler(object):
 
         Extra arguments are passed to the Session constructor.
         """
-        sessions_db = models.Session.objects.filter(
-            meeting=self.meeting,
-            type_id='regular',
-            schedulingevent__status_id='schedw',
-        )
-
+        sessions_db = self.meeting.session_set.that_can_be_scheduled().filter(type_id='regular')
         if self.base_schedule is None:
             fixed_sessions = models.Session.objects.none()
         else:
@@ -712,7 +705,7 @@ class TimeSlot(object):
 
 class Session(object):
     """
-    This TimeSlot class is analogous to the Session class in the models,
+    This Session class is analogous to the Session class in the models,
     i.e. it represents a single session to be scheduled. It also pulls
     in data about constraints, group parents, etc.
     """

--- a/ietf/meeting/management/commands/generate_schedule.py
+++ b/ietf/meeting/management/commands/generate_schedule.py
@@ -480,9 +480,10 @@ class Schedule(object):
         best_cost = math.inf
         shuffle_next_run = False
         last_run_cost = None
-        switched_with = None
-        
-        for run_count in range(1, self.max_cycles+1):
+        run_count = 0
+
+        for _ in range(self.max_cycles):
+            run_count += 1
             items = list(self.schedule.items())
             random.shuffle(items)
 
@@ -622,7 +623,7 @@ class Schedule(object):
             del proposed_schedule[timeslot1]
         return self.calculate_dynamic_cost(proposed_schedule)[1]
 
-    def _switch_sessions(self, timeslot1, timeslot2):
+    def _switch_sessions(self, timeslot1, timeslot2) -> Optional['Session']:
         """
         Switch the sessions currently in timeslot1 and timeslot2.
         If timeslot2 had a session scheduled, returns that Session instance.
@@ -630,11 +631,11 @@ class Schedule(object):
         session1 = self.schedule.get(timeslot1)
         session2 = self.schedule.get(timeslot2)
         if timeslot1 == timeslot2:
-            return False
+            return None
         if session1 and not session1.fits_in_timeslot(timeslot2):
-            return False
+            return None
         if session2 and not session2.fits_in_timeslot(timeslot1):
-            return False
+            return None
         if session1:
             self.schedule[timeslot2] = session1
         elif session2:

--- a/ietf/meeting/management/commands/generate_schedule.py
+++ b/ietf/meeting/management/commands/generate_schedule.py
@@ -291,7 +291,7 @@ class Schedule(object):
             print('{}: {}{}'.format(
                 models.TimeSlot.objects.get(pk=slot.timeslot_pk),
                 models.Session.objects.get(pk=sched[slot].session_pk),
-                ' [BASE]' if slot in self.base_schedule else '',
+                ' [BASE]' if self.base_schedule and slot in self.base_schedule else '',
             ))
 
         print("""

--- a/ietf/meeting/management/commands/generate_schedule.py
+++ b/ietf/meeting/management/commands/generate_schedule.py
@@ -14,6 +14,7 @@ import time
 from collections import defaultdict
 from functools import lru_cache
 from typing import NamedTuple, Optional
+from warnings import warn
 
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.core.management.base import BaseCommand, CommandError
@@ -1015,12 +1016,8 @@ class Session(object):
                 if len(my_sessions) != 2:
                     # This is not expected to happen. Alert the user if it comes up but proceed -
                     # the violation scoring may be incorrect but the scheduler won't fail because of this.
-                    self.stdout.write(
-                        'WARNING: "time relation" constraint only makes sense for 2 sessions but {} has {}'.format(
-                            self.group,
-                            len(my_sessions),
-                        )
-                    )
+                    warn('"time relation" constraint only makes sense for 2 sessions but {} has {}'
+                         .format(self.group, len(my_sessions)))
 
                 if all(session.is_fixed for _, session in my_sessions):
                     pass  # ignore conflict between fixed sessions

--- a/ietf/meeting/tests_schedule_generator.py
+++ b/ietf/meeting/tests_schedule_generator.py
@@ -3,6 +3,8 @@ import calendar
 import datetime
 import pytz
 from io import StringIO
+from warnings import filterwarnings
+
 
 from django.core.management.base import CommandError
 
@@ -107,9 +109,11 @@ class ScheduleGeneratorTest(TestCase):
     def test_too_many_sessions(self):
         self._create_basic_sessions()
         self._create_basic_sessions()
-        with self.assertRaises(CommandError):
-            generator = generate_schedule.ScheduleHandler(self.stdout, self.meeting.number, verbosity=0)
-            generator.run()
+        filterwarnings('ignore', '"time relation" constraint only makes sense for 2 sessions')
+        generator = generate_schedule.ScheduleHandler(self.stdout, self.meeting.number, verbosity=1)
+        generator.run()
+        self.stdout.seek(0)
+        self.assertIn('Some sessions will not be scheduled', self.stdout.read())
 
     def test_invalid_meeting_number(self):
         with self.assertRaises(CommandError):


### PR DESCRIPTION
Fixes #4533. This is a fairly minimal approach to supporting the requested feature.

Contrary to the suggestion in the ticket, this does not assign a cost to sessions that are not placed in the schedule. The simplest case, assigning a cost to a session that is not on the schedule, would be a fixed cost becuse there will always be the same number of unscheduled sessions. This will not impact the schedule generator because it only uses the dynamic costs during optimization.

It might be worth exploring dynamic costs for leaving sessions off the schedule. There is a lot of room to explore there.