### PR TITLE
fix: Listify initial field value when SearchableField.max_entries == 1

### DIFF
--- a/ietf/utils/fields.py
+++ b/ietf/utils/fields.py
@@ -320,6 +320,13 @@ class SearchableField(forms.MultipleChoiceField):
 
         return objs.first() if self.max_entries == 1 else objs
 
+    def has_changed(self, initial, data):
+        # When max_entries == 1, we behave like a ChoiceField so initial will likely be a single
+        # value. Make it a list so MultipleChoiceField's has_changed() can work with it.
+        if self.max_entries == 1 and not isinstance(initial, (list, tuple)):
+            initial = [initial]
+        return super().has_changed(initial, data)
+
 
 class IETFJSONField(jsonfield.fields.forms.JSONField):
     def __init__(self, *args, empty_values=jsonfield.fields.forms.JSONField.empty_values,

--- a/ietf/utils/fields.py
+++ b/ietf/utils/fields.py
@@ -323,7 +323,7 @@ class SearchableField(forms.MultipleChoiceField):
     def has_changed(self, initial, data):
         # When max_entries == 1, we behave like a ChoiceField so initial will likely be a single
         # value. Make it a list so MultipleChoiceField's has_changed() can work with it.
-        if self.max_entries == 1 and not isinstance(initial, (list, tuple)):
+        if initial is not None and self.max_entries == 1 and not isinstance(initial, (list, tuple)):
             initial = [initial]
         return super().has_changed(initial, data)
 


### PR DESCRIPTION
Augments `has_changed()` to allow a `SearchableField` with `max_entries == 1` to handle a non-list `initial` value. This is needed when using such a field in a formset.

Fixes part of a problem submitting the IPR disclosure form.