### PR TITLE
fix: Allow additional draft forms to be added to IPR disclosure edit form

### DIFF
--- a/ietf/ipr/views.py
+++ b/ietf/ipr/views.py
@@ -296,7 +296,7 @@ def edit(request, id, updates=None):
     ipr = get_object_or_404(IprDisclosureBase, id=id).get_child()
     type = class_to_type[ipr.__class__.__name__]
     
-    DraftFormset = inlineformset_factory(IprDisclosureBase, IprDocRel, form=DraftForm, can_delete=True, extra=1)
+    DraftFormset = inlineformset_factory(IprDisclosureBase, IprDocRel, form=DraftForm, can_delete=True, extra=0)
 
     if request.method == 'POST':
         form = ipr_form_mapping[ipr.__class__.__name__](request.POST,instance=ipr)
@@ -316,7 +316,7 @@ def edit(request, id, updates=None):
         else:
             valid_formsets = True
 
-        if form.is_valid() and valid_formsets: 
+        if form.is_valid() and valid_formsets:
             updates = form.cleaned_data.get('updates')
             disclosure = form.save(commit=False)
             disclosure.save()

--- a/ietf/static/js/ipr-edit.js
+++ b/ietf/static/js/ipr-edit.js
@@ -18,7 +18,7 @@ $(document)
                         ["for", "id", "name"].forEach(function (at) {
                             var val = x.attr(at);
                             if (val && val.match("iprdocrel")) {
-                                x.attr(at, val.replace('-1-', '-' + total + '-'));
+                                x.attr(at, val.replace('__prefix__', total.toString()));
                             }
                         });
                     });

--- a/ietf/static/js/ipr-edit.js
+++ b/ietf/static/js/ipr-edit.js
@@ -27,6 +27,8 @@ $(document)
                 totalField.val(total);
 
                 template.before(el);
+
+                el.find('.select2-field').each((index, element) => setupSelect2Field($(element)));
             });
 
         function updateRevisions() {

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -148,20 +148,6 @@
                     </div>
                 </div>
             {% endfor %}
-            {% comment %}
-            {% for draft_form in draft_formset %}
-                <div class="row draft-row {% if forloop.last %}template{% endif %}">
-                    <div class="col-md-2 fw-bold">{% bootstrap_label draft_form.document.label %}</div>
-                    <div class="col-md-6">{% bootstrap_field draft_form.document label_class="d-none" show_help=False %}</div>
-                    <div class="col-md-2">
-                        {% bootstrap_field draft_form.revisions placeholder="Revisions, e.g., 04-07" label_class="d-none" show_help=False %}
-                    </div>
-                    <div class="col-md-2">
-                        {% bootstrap_field draft_form.sections placeholder="Sections" label_class="d-none" show_help=False %}
-                    </div>
-                </div>
-            {% endfor %}
-            {% endcomment %}
             <div class="mb-3 row">
                 <div class="col-md-2"></div>
                 <div class="col-md-10">

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -131,23 +131,13 @@
             </p>
             {{ draft_formset.management_form }}
             {% for draft_form in draft_formset %}
-                <div class="row draft-row {% if forloop.last %}template d-none{% endif %}">
-                    <label class="col-md-2 fw-bold" for="{{ draft_form.document.id_for_label }}">{{ draft_form.document.label }}</label>
-                    <div class="col-md-6">
-                        {{ draft_form.id }}
-                        {{ draft_form.document }}
-                        {% if draft_form.document.errors %}<div class="alert alert-danger my-3">{{ draft_form.document.errors }}</div>{% endif %}
-                    </div>
-                    <div class="col-md-2">
-                        {% bootstrap_field draft_form.revisions class="form-control" placeholder="Revisions, e.g., 04-07" show_help=False show_label=False %}
-                        <label class="d-none" for="{{ draft_form.revisions.id_for_label }}">{{ draft_form.revisions.label }}</label>
-                    </div>
-                    <div class="col-md-2">
-                        {% bootstrap_field draft_form.sections class="form-control" placeholder="Sections" show_help=False show_label=False %}
-                        <label class="d-none" for="{{ draft_form.sections.id_for_label }}">{{ draft_form.sections.label }}</label>
-                    </div>
+                <div class="row draft-row">
+                    {% include "ipr/details_edit_draft.html" with draft_form=draft_form only %}
                 </div>
             {% endfor %}
+            <div class="row draft-row template d-none">
+                {% include "ipr/details_edit_draft.html" with draft_form=draft_formset.empty_form only %}
+            </div>
             <div class="mb-3 row">
                 <div class="col-md-2"></div>
                 <div class="col-md-10">

--- a/ietf/templates/ipr/details_edit_draft.html
+++ b/ietf/templates/ipr/details_edit_draft.html
@@ -1,0 +1,14 @@
+{% load django_bootstrap5 %}<label class="col-md-2 fw-bold" for="{{ draft_form.document.id_for_label }}">{{ draft_form.document.label }}</label>
+<div class="col-md-6">
+    {{ draft_form.id }}
+    {{ draft_form.document }}
+    {% if draft_form.document.errors %}<div class="alert alert-danger my-3">{{ draft_form.document.errors }}</div>{% endif %}
+</div>
+<div class="col-md-2">
+    {% bootstrap_field draft_form.revisions class="form-control" placeholder="Revisions, e.g., 04-07" show_help=False show_label=False %}
+    <label class="d-none" for="{{ draft_form.revisions.id_for_label }}">{{ draft_form.revisions.label }}</label>
+</div>
+<div class="col-md-2">
+    {% bootstrap_field draft_form.sections class="form-control" placeholder="Sections" show_help=False show_label=False %}
+    <label class="d-none" for="{{ draft_form.sections.id_for_label }}">{{ draft_form.sections.label }}</label>
+</div>


### PR DESCRIPTION
Together with #4951, fixes some major breakage on the IPR disclosure edit view. 

Adding a new draft form to the formset was broken because of a missing call to `setupSelect2Field()` after adding the fields to the DOM. This adds that call.

In addition to the completely broken Django validation fixed by #4951, submitting the form failed because the JS was incorrectly numbering the formset entries it added when clicking the "Add more" button. This was happening because the `details_edit.html` template rendered a blank formset for the javascript to duplicate by tagging the "extra" formset form with the `template` class. This PR fixes this by getting rid of the extra form hack and using the `empty_form` provided by Django's formset class instead.