### PR TITLE
fix: restore display of additional resources.

### DIFF
--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -14,12 +14,14 @@ from django.utils import timezone
 
 from ietf.doc.models import ( Document, DocEvent, NewRevisionDocEvent, DocAlias, State, DocumentAuthor,
     StateDocEvent, BallotPositionDocEvent, BallotDocEvent, BallotType, IRSGBallotDocEvent, TelechatDocEvent,
-    DocumentActionHolder, BofreqEditorDocEvent, BofreqResponsibleDocEvent )
+    DocumentActionHolder, BofreqEditorDocEvent, BofreqResponsibleDocEvent, DocExtResource )
 from ietf.group.models import Group
 from ietf.person.factories import PersonFactory
 from ietf.group.factories import RoleFactory
+from ietf.name.models import ExtResourceName
 from ietf.utils.text import xslugify
 from ietf.utils.timezone import date_today
+
 
 
 def draft_name_generator(type_id,group,n):
@@ -520,3 +522,12 @@ class ProceedingsMaterialDocFactory(BaseDocumentFactory):
                 obj.set_state(State.objects.get(type_id=state_type_id,slug=state_slug))
         else:
             obj.set_state(State.objects.get(type_id='procmaterials', slug='active'))
+
+class DocExtResourceFactory(factory.django.DjangoModelFactory):
+
+    name = factory.Iterator(ExtResourceName.objects.filter(type_id='url'))
+    value = factory.Faker('url')
+    doc = factory.SubFactory('ietf.doc.factories.BaseDocumentFactory')
+    class Meta:
+        model = DocExtResource
+

--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -40,7 +40,7 @@ from ietf.doc.factories import ( DocumentFactory, DocEventFactory, CharterFactor
     ConflictReviewFactory, WgDraftFactory, IndividualDraftFactory, WgRfcFactory, 
     IndividualRfcFactory, StateDocEventFactory, BallotPositionDocEventFactory, 
     BallotDocEventFactory, DocumentAuthorFactory, NewRevisionDocEventFactory,
-    StatusChangeFactory, BofreqFactory)
+    StatusChangeFactory, BofreqFactory, DocExtResourceFactory)
 from ietf.doc.forms import NotifyForm
 from ietf.doc.fields import SearchableDocumentsField
 from ietf.doc.utils import create_ballot_if_not_open, uppercase_std_abbreviated_name
@@ -602,6 +602,8 @@ Man                    Expires September 22, 2015               [Page 3]
         updated_by = IndividualDraftFactory()
         updated_by.relateddocument_set.create(relationship_id='updates',source=obsoleted_by,target=draft.docalias.first())
 
+        external_resource = DocExtResourceFactory(doc=draft)
+
         # these tests aren't testing all attributes yet, feel free to
         # expand them
 
@@ -622,6 +624,7 @@ Man                    Expires September 22, 2015               [Page 3]
         self.assertNotContains(r, updated.title)
         self.assertNotContains(r, updated_by.canonical_name())
         self.assertNotContains(r, updated_by.title)
+        self.assertContains(r, external_resource.value)
 
         r = self.client.get(urlreverse("ietf.doc.views_doc.document_main", kwargs=dict(name=draft.name)) + "?include_text=0")
         self.assertEqual(r.status_code, 200)

--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -394,7 +394,6 @@ href="{% url 'ietf.doc.views_draft.review_possibly_replaces' name=doc.name %}">E
     {% endif %}
     {% endif %}
     {% with doc.docextresource_set.all as resources %}
-        {% if document_html and resources or document_html and doc.group and doc.group.list_archive %}
         {% if resources or doc.group and doc.group.list_archive or can_edit_stream_info or can_edit_individual %}
             <tr>
                 <td>
@@ -442,7 +441,6 @@ href="{% url 'ietf.doc.views_draft.review_possibly_replaces' name=doc.name %}">E
                     {% endif %}
                 </td>
             </tr>
-        {% endif %}
         {% endif %}
     {% endwith %}
 </tbody>


### PR DESCRIPTION
This fixes #4948 

@larseggert - I couldn't find why the lines I removed from document_info.html had come in - the logic in them made no sense - what were they for?

The resources are not showing on the htmlized page because the view always passes in a DocHistory object, which has no docextresource_set. If we're willing to show what the current resources are even when looking at an older document, the view could decorate the history being passed to the template with it (but this may cause confusion).

We may want to consider capturing the external resources each time a DocHistory is created (similar to RelatedDocHistory) at some point in the future.