### PR TITLE
Limit the width of the document selectors to the width of the parent.

### DIFF
--- a/ietf/templates/doc/document_history_form.html
+++ b/ietf/templates/doc/document_history_form.html
@@ -13,6 +13,7 @@
 {% endif %}
             <select class="form-select{% if document_html %} form-select-sm mb-1{% endif %} select2-field"
                     data-max-entries="1"
+                    data-width="resolve"
                     data-allow-clear="false"
                     data-minimum-input-length="0"
                     {% if not document_html %}id="url1"{% else %}aria-label="From revision"{% endif %}
@@ -40,6 +41,7 @@
 {% endif %}
             <select class="form-select{% if document_html %} form-select-sm mb-1{% endif %} select2-field"
                     data-max-entries="1"
+                    data-width="resolve"
                     data-allow-clear="false"
                     data-minimum-input-length="0"
                     {% if not document_html %}id="url2"{% else %}aria-label="To revision"{% endif %}

--- a/ietf/templates/doc/document_html.html
+++ b/ietf/templates/doc/document_html.html
@@ -41,6 +41,14 @@
         {% include "base/icons.html" %}
         {% include "doc/opengraph.html" %}
          {% analytical_head_bottom %}
+        <style>
+            {# Force "text-overflow: ellipsis" to hide the beginning of a doc name #}
+            .diff-form .select2-selection__rendered {
+                direction: rtl;
+                text-align: left;
+            }
+            }
+        </style>
     </head>
     <body>
         {% analytical_body_top %}


### PR DESCRIPTION
It's unfortunately not responsive (select2 limitation), but better than being too long.