### PR TITLE
fix: rfc2html creates "a" tags without href for references, handle that

### DIFF
--- a/ietf/utils/text.py
+++ b/ietf/utils/text.py
@@ -51,7 +51,8 @@ validate_url = URLValidator()
 
 def check_url_validity(attrs, new=False):
     if (None, "href") not in attrs:
-        return None
+        # rfc2html creates a tags without href
+        return attrs
     url = attrs[(None, "href")]
     try:
         if url.startswith("http"):


### PR DESCRIPTION
Fixes the issue raised by @becarpenter in https://mailarchive.ietf.org/arch/msg/tools-discuss/oz-Fl58l0cffW-NENTAAn598dqA

CC @cabo