### PR TITLE
fix: Change versions in htmlized rev picker based on shown doc rev

### DIFF
--- a/ietf/templates/doc/document_history.html
+++ b/ietf/templates/doc/document_history.html
@@ -18,7 +18,7 @@
     {{ top|safe }}
     {% if diff_revisions and diff_revisions|length > 1 or doc.name|rfcbis %}
         <h2 class="my-3">Revision differences</h2>
-        {% include "doc/document_history_form.html" with doc=doc diff_revisions=diff_revisions action=rfcdiff_base_url only %}
+        {% include "doc/document_history_form.html" with doc=doc diff_revisions=diff_revisions action=rfcdiff_base_url snapshot=snapshot only %}
     {% endif %}
     <h2 class="my-3">Document history</h2>
     {% if can_add_comment %}

--- a/ietf/templates/doc/document_history_form.html
+++ b/ietf/templates/doc/document_history_form.html
@@ -11,6 +11,7 @@
         <label for="url1" class="col-form-label col-sm-2 fw-bold">From revision</label>
         <div class="col-sm-10">
 {% endif %}
+{% with prev_rev=doc.rev|add:"-1"|stringformat:"02d" %}
             <select class="form-select{% if document_html %} form-select-sm mb-1{% endif %} select2-field"
                     data-max-entries="1"
                     data-allow-clear="false"
@@ -19,14 +20,24 @@
                     name="url1">
                 {% for name, rev, time, url in diff_revisions %}
                     <option value="{{ url }}"
-                            {% if diff_revisions|length > 1 and forloop.counter == 2 %} selected="selected"{% endif %}>
+                            {% if document_html %}
+                                {% if name == doc.name %}
+                                    {% if rev == prev_rev or doc.rev == "00" and rev == "00" %} selected{% endif %}
+                                {% endif %}
+                            {% else %}
+                                {% if diff_revisions|length > 1 and forloop.counter == 2 %} selected{% endif %}
+                            {% endif %}>
                         {{ name|prettystdname }}{% if rev %}-{{ rev }}{% endif %}
                         {% if not document_html %}({{ time|date:"Y-m-d" }}){% endif %}
                     </option>
                 {% endfor %}
                 {% if doc.name|rfcbis %}
                     <option value="{{ doc.name|rfcbis }}"
-                            {% if diff_revisions and diff_revisions|length == 1 %} selected="selected"{% endif %}>
+                            {% if document_html %}
+                                {% if rev == prev_rev %} selected{% endif %}
+                            {% else %}
+                                {% if diff_revisions and diff_revisions|length == 1 %} selected{% endif %}
+                            {% endif %}>
                         {{ doc.name|rfcbis|prettystdname }}
                     </option>
                 {% endif %}
@@ -46,7 +57,11 @@
                     name="url2">
                 {% for name, rev, time, url in diff_revisions %}
                     <option value="{{ url }}"
-                            {% if forloop.counter == 1 %} selected="selected"{% endif %}>
+                        {% if document_html %}
+                            {% if not snapshot and doc.get_state_slug == "rfc" and name == "rfc"|add:doc.rfc_number or snapshot and name == doc.name and rev == doc.rev %} selected{% endif %}
+                        {% else %}
+                            {% if forloop.counter == 1 %} selected{% endif %}
+                        {% endif %}>
                         {{ name|prettystdname }}{% if rev %}-{{ rev }}{% endif %}
                         {% if not document_html %}({{ time|date:"Y-m-d" }}){% endif %}
                     </option>
@@ -90,6 +105,7 @@
                     name="difftype">
                 Inline
             </button>
+{% endwith %}
 {% if not document_html %}
         </div>
     </div>

--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -85,7 +85,7 @@
                 <th scope="row">Compare versions</th>
                 <td class="edit"></td>
                 <td>
-                    {% include "doc/document_history_form.html" with doc=doc diff_revisions=diff_revisions action=rfcdiff_base_url document_html=document_html only %}
+                    {% include "doc/document_history_form.html" with doc=doc diff_revisions=diff_revisions action=rfcdiff_base_url document_html=document_html snapshot=snapshot only %}
                 </td>
             </tr>
         {% endif %}

--- a/ietf/templates/doc/revisions_list.html
+++ b/ietf/templates/doc/revisions_list.html
@@ -10,7 +10,7 @@
             {% if rev %}
                 <li class="page-item {% if rev == doc.rev %}{% if snapshot or doc.get_state_slug != 'rfc' %}active{% endif %}{% endif %}">
                     <a class="page-link"
-                       href="{% if snapshot and doc.get_state_slug == 'rfc' %}{% if document_html %}{% url 'ietf.doc.views_doc.document_html' name=doc.doc.name %}{% else %}{% url 'ietf.doc.views_doc.document_main' name=doc.doc.name %}{% endif %}{% else %}{% if document_html %}{% url 'ietf.doc.views_doc.document_html' name=doc.name rev=rev %}{% else %}{% url 'ietf.doc.views_doc.document_main' name=doc.name rev=rev %}{% endif %}{% endif %}"
+                       href="{% if document_html %}{% url 'ietf.doc.views_doc.document_html' name=doc.name rev=rev %}{% else %}{% url 'ietf.doc.views_doc.document_main' name=doc.name rev=rev %}{% endif %}"
                        {% if rev != '00' and rev != latest_rev %}rel="nofollow"{% endif %}>
                         {{ rev }}
                     </a>


### PR DESCRIPTION
Also fix an issue with the revisions list only linking to the latest version in some cases.

Fixes #4972