### PR TITLE
fix: Let charter revisions be variable length in the version paginator

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -220,6 +220,12 @@ th,
     }
 }
 
+.charter.revision-list {
+    .page-item {
+        width: auto;
+    }
+}
+
 // Style the photo cards
 .photo {
     width: 12em;

--- a/ietf/templates/doc/revisions_list.html
+++ b/ietf/templates/doc/revisions_list.html
@@ -1,14 +1,14 @@
 {# Copyright The IETF Trust 2015, All Rights Reserved #}
-{% load origin %}
+{% load origin ietf_filters %}
 {% origin %}
 {% if not document_html %}
     <label class="my-1 fw-bold">Versions:</label>
     <nav class="mb-3">
 {% endif %}
-    <ul class="revision-list {{ doc.type.slug}} pagination pagination-sm text-center flex-wrap{% if document_html %} my-0{% endif %}">
+    <ul class="revision-list{%if doc.type.slug == 'charter' %} charter{% endif %} pagination pagination-sm text-center flex-wrap{% if document_html %} my-0{% endif %}">
         {% for rev in revisions %}
             {% if rev %}
-                <li class="page-item {% if rev == doc.rev %}{% if snapshot or doc.get_state_slug != 'rfc' %}active{% endif %}{% endif %}">
+                <li class="page-item {%if doc.type.slug == 'charter' and rev == rev|charter_major_rev %}fw-bold {% endif %}{% if rev == doc.rev %}{% if snapshot or doc.get_state_slug != 'rfc' %}active{% endif %}{% endif %}">
                     <a class="page-link"
                        href="{% if snapshot and doc.get_state_slug == 'rfc' %}{% if document_html %}{% url 'ietf.doc.views_doc.document_html' name=doc.doc.name %}{% else %}{% url 'ietf.doc.views_doc.document_main' name=doc.doc.name %}{% endif %}{% else %}{% if document_html %}{% url 'ietf.doc.views_doc.document_html' name=doc.name rev=rev %}{% else %}{% url 'ietf.doc.views_doc.document_main' name=doc.name rev=rev %}{% endif %}{% endif %}"
                        {% if rev != '00' and rev != latest_rev %}rel="nofollow"{% endif %}>

--- a/ietf/templates/doc/revisions_list.html
+++ b/ietf/templates/doc/revisions_list.html
@@ -5,7 +5,7 @@
     <label class="my-1 fw-bold">Versions:</label>
     <nav class="mb-3">
 {% endif %}
-    <ul class="revision-list pagination pagination-sm text-center flex-wrap{% if document_html %} my-0{% endif %}">
+    <ul class="revision-list {{ doc.type.slug}} pagination pagination-sm text-center flex-wrap{% if document_html %} my-0{% endif %}">
         {% for rev in revisions %}
             {% if rev %}
                 <li class="page-item {% if rev == doc.rev %}{% if snapshot or doc.get_state_slug != 'rfc' %}active{% endif %}{% endif %}">


### PR DESCRIPTION
Fixes #4988