### PR TITLE
feat: remove the format element from the bibxml-id source of truth

### DIFF
--- a/ietf/templates/doc/bibxml.xml
+++ b/ietf/templates/doc/bibxml.xml
@@ -13,5 +13,5 @@
    </front>
    <seriesInfo name="Internet-Draft" value="{{name}}-{{doc.rev}}" />
    {% if doi %}<seriesInfo name="DOI" value="{{doi}}" />
-   {% endif %}<format type="TXT" target="https://www.ietf.org/archive/id/{{name}}-{{doc.rev}}.txt" />
+   {% endif %}
 </reference>


### PR DESCRIPTION
fixes #5018 