### PR TITLE
refactor: Simplify tests and comply with StandardJS style

### DIFF
--- a/ietf/static/js/document_html.js
+++ b/ietf/static/js/document_html.js
@@ -62,8 +62,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
             const val = in_localStorage.includes(btn.name) ?
                 localStorage.getItem(btn.name) : cookies.get(btn.name);
-            if (val == id || ((val == undefined || val == null) &&
-                    btn_pref[btn.name] == id)) {
+            if (val === id ||
+              ((val == null) && btn_pref[btn.name] === id)) {
                 btn.checked = true;
             }
 

--- a/ietf/static/js/document_html.js
+++ b/ietf/static/js/document_html.js
@@ -62,8 +62,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
             const val = in_localStorage.includes(btn.name) ?
                 localStorage.getItem(btn.name) : cookies.get(btn.name);
-            if (val === id ||
-              ((val == null) && btn_pref[btn.name] === id)) {
+            if (val === id || (val === null && btn_pref[btn.name] === id)) {
                 btn.checked = true;
             }
 


### PR DESCRIPTION
Use === instead of ==, except where it's used to match both null and undefined. (I think just null is enough because both `cookies.get()` and `Storage.getItem()` return `null` when they have no data, but no harm in being liberal.)

@larseggert may want to look to be sure I didn't break this, but I think it's equivalent.