### PR TITLE
feat: show session purposes on the meeting request page

### DIFF
--- a/ietf/templates/meeting/requests.html
+++ b/ietf/templates/meeting/requests.html
@@ -36,6 +36,7 @@
                     <th scope="col" data-sort="group">Group</th>
                     <th scope="col" class="d-none d-lg-table-cell" data-sort="count">Length</th>
                     <th scope="col" class="d-none d-lg-table-cell" data-sort="num">Size</th>
+                    <th scope="col" class="d-none d-lg-table-cell" data-sort="num">Purpose</th>
                     <th scope="col" class="d-none d-lg-table-cell" data-sort="requester">Requester</th>
                     <th scope="col" class="d-none d-lg-table-cell" data-sort="ad">AD</th>
                     <th scope="col" data-sort="constraints">Constraints</th>
@@ -76,6 +77,7 @@
                             {% if session.requested_duration %}{{ session.requested_duration|stringformat:"s"|slice:"0:4" }}{% endif %}
                         </td>
                         <td class="d-none d-lg-table-cell">{{ session.attendees|default:"" }}</td>
+                        <td class="d-none d-lg-table-cell">{% if session.purpose_id != "regular" %}{{session.purpose}}{% endif %}</td>
                         <td class="d-none d-lg-table-cell">{% person_link session.requested_by_person with_email=False %}</td>
                         <td class="d-none d-lg-table-cell">
                             {% if session.group.ad_role %}


### PR DESCRIPTION
Fixes #4492 

As the existing test for the view notes, the template output is almost impossible to test. It needs a refactor to allow it to be testable, but that effort is best applied when we move this out of /secr. 