### PR TITLE
fix: only show irtf stream ballot and pubreq buttons to the IRTF chair

### DIFF
--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -390,22 +390,22 @@ def document_main(request, name, rev=None, document_html=False):
         if doc.get_state_slug() == "expired" and has_role(request.user, ("Secretariat",)) and not snapshot:
             actions.append(("Resurrect", urlreverse('ietf.doc.views_draft.resurrect', kwargs=dict(name=doc.name))))
         
-        if (doc.get_state_slug() not in ["rfc", "expired"] and doc.stream_id in ("irtf",) and not snapshot and not doc.ballot_open('irsg-approve') and can_edit_stream_info):
+        if (doc.get_state_slug() not in ["rfc", "expired"] and doc.stream_id in ("irtf",) and not snapshot and not doc.ballot_open('irsg-approve') and has_role(request.user, ("Secretariat", "IRTF Chair"))):
             label = "Issue IRSG Ballot"
             actions.append((label, urlreverse('ietf.doc.views_ballot.issue_irsg_ballot', kwargs=dict(name=doc.name))))
-        if (doc.get_state_slug() not in ["rfc", "expired"] and doc.stream_id in ("irtf",) and not snapshot and doc.ballot_open('irsg-approve') and can_edit_stream_info):
+        if (doc.get_state_slug() not in ["rfc", "expired"] and doc.stream_id in ("irtf",) and not snapshot and doc.ballot_open('irsg-approve') and has_role(request.user, ("Secretariat", "IRTF Chair"))):
             label = "Close IRSG Ballot"
             actions.append((label, urlreverse('ietf.doc.views_ballot.close_irsg_ballot', kwargs=dict(name=doc.name))))
 
         if (doc.get_state_slug() not in ["rfc", "expired"] and doc.stream_id in ("ise", "irtf")
-            and can_edit_stream_info and not conflict_reviews and not snapshot):
+            and has_role(request.user, ("Secretariat", "IRTF Chair")) and not conflict_reviews and not snapshot):
             label = "Begin IETF Conflict Review"
             if not doc.intended_std_level:
                 label += " (note that intended status is not set)"
             actions.append((label, urlreverse('ietf.doc.views_conflict_review.start_review', kwargs=dict(name=doc.name))))
 
         if (doc.get_state_slug() not in ["rfc", "expired"] and doc.stream_id in ("iab", "ise", "irtf")
-            and can_edit_stream_info and not snapshot):
+            and (has_role(request.user, ("Secretariat", "IRTF Chair")) if doc.stream_id=="irtf" else can_edit_stream_info) and not snapshot):
             if doc.get_state_slug('draft-stream-%s' % doc.stream_id) not in ('rfc-edit', 'pub', 'dead'):
                 label = "Request Publication"
                 if not doc.intended_std_level:

--- a/ietf/doc/views_draft.py
+++ b/ietf/doc/views_draft.py
@@ -1292,7 +1292,10 @@ def request_publication(request, name):
 
     doc = get_object_or_404(Document, type="draft", name=name, stream__in=("iab", "ise", "irtf"))
 
-    if not is_authorized_in_doc_stream(request.user, doc):
+    if doc.stream_id == "irtf":
+        if not has_role(request.user, ("Secretariat", "IRTF Chair")):
+            permission_denied(request, "You do not have the necessary permissions to view this page.")
+    elif not is_authorized_in_doc_stream(request.user, doc):
         permission_denied(request, "You do not have the necessary permissions to view this page.")
 
     consensus_event = doc.latest_event(ConsensusDocEvent, type="changed_consensus")


### PR DESCRIPTION
fixes #5009

Tests haven't been added to verify non-IRTF chair IRSG members don't get buttons and can't access views. Those will come as part of the refactor of the views and tests in #5011