### PR TITLE
fix: Show links for more session types on the agenda

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -270,7 +270,9 @@ const meetingEvents = computed(() => {
 
     // -> Populate event links
     const links = []
-    if (item.flags.showAgenda || ['regular', 'plenary'].includes(item.type)) {
+    const typesWithLinks = ['regular', 'plenary', 'other']
+    const purposesWithoutLinks = ['admin', 'closed_meeting', 'officehours', 'social']
+    if (item.flags.showAgenda || (typesWithLinks.includes(item.type) && !purposesWithoutLinks.includes(item.purpose))) {
       if (item.flags.agenda) {
         links.push({
           id: `lnk-${item.id}-tar`,

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1708,6 +1708,7 @@ def agenda_extract_schedule (item):
         "startDateTime": item.timeslot.time.isoformat(),
         "status": item.session.current_status,
         "type": item.session.type.slug,
+        "purpose": item.session.purpose.slug,
         "isBoF": item.session.group_at_the_time().state_id == "bof",
         "filterKeywords": item.filter_keywords,
         "groupAcronym": item.session.group_at_the_time().acronym,

--- a/playwright/tests/meeting/agenda.spec.js
+++ b/playwright/tests/meeting/agenda.spec.js
@@ -268,7 +268,7 @@ test.describe('past - desktop', () => {
         }
         // Scheduled
         case 'sched': {
-          if (event.flags.showAgenda || ['regular', 'plenary'].includes(event.type)) {
+          if (event.flags.showAgenda || (['regular', 'plenary', 'other'].includes(event.type) && !['admin', 'closed_meeting', 'officehours', 'social'].includes(event.purpose))) {
             const eventButtons = row.locator('.agenda-table-cell-links > .agenda-table-cell-links-buttons')
             if (event.flags.agenda) {
               // Show meeting materials button

--- a/playwright/tests/meeting/agenda.spec.js
+++ b/playwright/tests/meeting/agenda.spec.js
@@ -1145,7 +1145,7 @@ test.describe('future - desktop', () => {
       // -----------------------
       if (event.status === 'sched') {
         const eventButtons = row.locator('.agenda-table-cell-links > .agenda-table-cell-links-buttons')
-        if (event.flags.showAgenda || ['regular', 'plenary'].includes(event.type)) {
+        if (event.flags.showAgenda || (['regular', 'plenary', 'other'].includes(event.type) && !['admin', 'closed_meeting', 'officehours', 'social'].includes(event.purpose))) {
           if (event.flags.agenda) {
             // Show meeting materials button
             await expect(eventButtons.locator('i.bi.bi-collection')).toBeVisible()


### PR DESCRIPTION
Fixes #4745 

Adds buttons based on the session links for most 'other' type sessions. Excludes them from sessions whose purpose is admin, closed_meeting, officehours, or social.