### PR TITLE
fix: Sort agenda editor rows by room size first

### DIFF
--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -134,7 +134,7 @@ class EditMeetingScheduleTests(IetfSeleniumTestCase):
         self.assertEqual(session_info_container.find_element(By.CSS_SELECTOR, ".other-session .time").text, "not yet scheduled")
 
         # deselect
-        self.driver.find_element(By.CSS_SELECTOR, '.drop-target').click()
+        self.driver.find_element(By.CSS_SELECTOR, '.timeslot[data-type="regular"] .drop-target').click()
 
         self.assertEqual(session_info_container.find_elements(By.CSS_SELECTOR, ".title"), [])
         self.assertNotIn('other-session-selected', s2b_element.get_attribute('class'))
@@ -193,9 +193,9 @@ class EditMeetingScheduleTests(IetfSeleniumTestCase):
 
         # violated due to constraints - both the timeslot and its timeslot label
         self.assertTrue(self.driver.find_elements(By.CSS_SELECTOR, '#timeslot{}.would-violate-hint'.format(slot1.pk)))
-        # Find the timeslot label for slot1 - it's the first timeslot in the first room group
+        # Find the timeslot label for slot1 - it's the first timeslot in the room group containing room 1
         slot1_roomgroup_elt = self.driver.find_element(By.CSS_SELECTOR,
-            '.day-flow .day:first-child .room-group:nth-child(2)'  # count from 2 - first-child is the day label
+            '.day-flow .day:first-child .room-group[data-rooms="1"]'
         )
         self.assertTrue(
             slot1_roomgroup_elt.find_elements(By.CSS_SELECTOR,

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -659,7 +659,9 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
         sorted_rooms = sorted(
             rooms_with_timeslots,
             key=lambda room: (
-                # First, sort regular session rooms ahead of others - these will usually
+                # Sort higher capacity rooms first.
+                -room.capacity if room.capacity is not None else 1,  # sort rooms with capacity = None at end
+                # Sort regular session rooms ahead of others - these will usually
                 # have more timeslots than other room types.
                 0 if room_data[room.pk]['timeslot_count'] == max_timeslots else 1,
                 # Sort rooms with earlier timeslots ahead of later
@@ -669,8 +671,6 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
                 # Sort by list of starting time and duration so that groups with identical
                 # timeslot structure will be neighbors. The grouping algorithm relies on this!
                 room_data[room.pk]['start_and_duration'],
-                # Within each group, sort higher capacity rooms first.
-                -room.capacity if room.capacity is not None else 1,  # sort rooms with capacity = None at end
                 # Finally, sort alphabetically by name
                 room.name
             )


### PR DESCRIPTION
Fixes #4377.

This tends to split the display into more "room groups" because rooms with identical timeslot arrangements are no longer neighbors. As a result, the editor takes up a bit more vertical space with timeslot label rows. I don't think that's a major problem, though - there were already many more room groups than ideal due to many or most rooms having unique timeslot arrangements outside the core meeting days/hours.