### PR TITLE
fix: Restore `value` attribute needed for backend logic

### DIFF
--- a/ietf/templates/liaisons/detail.html
+++ b/ietf/templates/liaisons/detail.html
@@ -87,6 +87,7 @@
                             {% csrf_token %}
                             <button class="btn btn-warning btn-sm"
                                    type="submit"
+                                   value="Mark as action taken"
                                    name="do_action_taken">
                                 Mark as action taken
                             </button>


### PR DESCRIPTION
Fixes #5042