### PR TITLE
feat: disallow collisions with legacy draft names with capital letters

### DIFF
--- a/ietf/submit/forms.py
+++ b/ietf/submit/forms.py
@@ -289,7 +289,7 @@ class SubmissionBaseUploadForm(forms.Form):
     @staticmethod
     def check_for_old_uppercase_collisions(name):
         possible_collision = Document.objects.filter(name__iexact=name).first()
-        if possible_collision and possible_collision.name!=name:
+        if possible_collision and possible_collision.name != name:
             raise forms.ValidationError(
                 f"Case-conflicting draft name found: {possible_collision.name}. "
                 "Please choose a different draft name. Case-conflicting names with "

--- a/ietf/submit/forms.py
+++ b/ietf/submit/forms.py
@@ -251,6 +251,8 @@ class SubmissionBaseUploadForm(forms.Form):
                 "element has a docName attribute which provides the full draft name including "
                 "revision number.")
 
+        self.check_for_old_uppercase_collisions(self.filename)    
+
         if self.cleaned_data.get('txt') or self.cleaned_data.get('xml'):
             # check group
             self.group = self.deduce_group(self.filename)
@@ -283,6 +285,17 @@ class SubmissionBaseUploadForm(forms.Form):
                     settings.IDSUBMIT_MAX_DAILY_SAME_GROUP, settings.IDSUBMIT_MAX_DAILY_SAME_GROUP_SIZE,
                 )
         return super().clean()
+
+    @staticmethod
+    def check_for_old_uppercase_collisions(name):
+        possible_collision = Document.objects.filter(name__iexact=name).first()
+        if possible_collision and possible_collision.name!=name:
+            raise forms.ValidationError(
+                f"Case-conflicting draft name found: {possible_collision.name}. "
+                "Please choose a different draft name. Case-conflicting names with "
+                "the small number of legacy Internet-Drafts with names containing "
+                "upper-case letters are not permitted."
+            )
 
     @staticmethod
     def check_submissions_thresholds(which, filter_kwargs, max_amount, max_size):

--- a/ietf/submit/tests.py
+++ b/ietf/submit/tests.py
@@ -3638,3 +3638,15 @@ class ValidateSubmissionFilenameTests(BaseSubmitTestCase):
 
         msg = validate_submission_rev(new_wg_doc.name, '02')
         self.assertIsNone(msg)
+
+class TestOldNamesAreProtected(BaseSubmitTestCase):
+    
+    def test_submit_case_conflited_name_fails(self):
+        WgDraftFactory(name="draft-something-HasCapitalLetters")
+        with self.assertRaisesMessage(ValidationError, "Case-conflicting draft name found"):
+            SubmissionBaseUploadForm.check_for_old_uppercase_collisions("draft-something-hascapitalletters")
+        url = urlreverse("ietf.submit.views.upload_submission")
+        files = {}
+        files["xml"], _ = submission_file("draft-something-hascapitalletters-00", "draft-something-hascapitalletters-00.xml", None, "test_submission.xml")
+        r = self.client.post(url, files)
+        self.assertContains(r,"Case-conflicting draft name found",status_code=200)


### PR DESCRIPTION
There are a small number of very old Document objects with capital letters in their names.
(This query must be run with postgres as a database)
```
>>> for n in Document.objects.filter(name__regex="[A-Z]").values_list("name", flat=True):
...     print(n)
... 
draft-chapin-clnp-ISO8473
draft-coene-ss7-IP-addr
draft-fricc-brim-BackboneRouting
draft-henry-DHCP-opt61-UUID-type
draft-hss-megaco-R2package
draft-ietf-appleip-MacIP
draft-ietf-atommib-atm2TC
draft-ietf-atommib-perfhistTC
draft-ietf-avt-X11-new
draft-ietf-conneg-W3C-ccpp
draft-ietf-dnsind-dynDNS
draft-ietf-dnsind-dynDNS-arch
draft-ietf-dnsind-dynDNS-impl
draft-ietf-drums-MHRegistry
draft-ietf-fax-feature-T30-mapping
draft-ietf-ipsec-isakmp-SA-revised
draft-ietf-sdr-IPv6-pack
draft-ietf-snmp-OsiSnmp
draft-kchapman-perfhist-sup-TC
draft-kumar-dna-rqmnt-IPv4
draft-kunzinger-idrp-ISO10747
draft-nielsen-v6ops-3GPP-zeroconf-goals
draft-okanoue-mobileip-R+A
draft-rajagopalan-CR-overlay
draft-sanchez-CSIP-v0r0
draft-sanchez-garcia-SSTP-v0r2
draft-sanchez-garcia-SSTP-v1r0
draft-various-snmpv2-adminv2C-syn
slides-edu-intro-AAA
```

For years, we've disallowed creating new Document objects with names with capital letters in them.

While on mysqld, the database prevented creating a case-varied collision (since it compares all strings in a case-insensitive way).

Postgresql is case sensitive. We're addressing some other places where this change matters using the postgresql citext extension, but `Document.name` is very heavily used and we want to avoid the performance hit citext would bring. 

This change makes it impossible to submit a new draft that would conflict with any of the above draft names.

At the moment, I propose we ignore the one slides document. The confusion that might be caused by a new Slides document named 'slides-edu-intro-aaa' is small enough to handle if the case ever arises.