### PR TITLE
feat: Lighter styling on internal irefs

### DIFF
--- a/ietf/static/css/document_html_txt.scss
+++ b/ietf/static/css/document_html_txt.scss
@@ -368,7 +368,7 @@ td, th {
 }
 
 /* Links */
-a.selfRef, a.pilcrow {
+a.selfRef, a.pilcrow, .iref + a.internal {
   color: black;
   text-decoration: none;
 }


### PR DESCRIPTION
Documents like
https://datatracker.ietf.org/doc/html/draft-ietf-ohai-ohttp-06 use a tagging scheme for certain keywords that turns them into links.  This can be useful in giving people the ability to quickly jump to the definition of an important term, but it tends to produce a lot of visual noise.  The resulting links are blue and underlined, which can be distracting when there are lots of these links.

This change removes styling for these links.  If there is an `<iref>` tag (which renders as an empty `<span>`) immediately preceding a link and that link is tagged `class="internal"`, link styling is removed. These will still result in the cursor changing to a pointer, but the blue and underlining will reduce line noise.

Note that this change depends on a corresponding change in kramdown-rfc that reorders the generation of the iref and xref tags.  The above document will not change in appearance as a result, because that version of kramdown-rfc generated the tags in the wrong order.  A new version generated with an updated kramdown-rfc is forthcoming.