### PR TITLE
fix: Limit `overflow-wrap: break-word` to paragraphs and references

### DIFF
--- a/ietf/static/css/document_html_txt.scss
+++ b/ietf/static/css/document_html_txt.scss
@@ -43,11 +43,13 @@
   margin-bottom: var(--line);
   margin-left: 3ch;
 
+  section > p, section > dl.references > dd {
   /* Really long lines can wrap when all else fails.
    * This won't affect <pre> or <table>, or cases where soft-wrapping occurs.
    * Mostly this exists so that long URLs wrap properly in Safari, which
    * doesn't break words at '/' like other browsers. */
   overflow-wrap: break-word;
+  }
 
 h1, h2, h3, h4, h5 {
   font-weight: bold;


### PR DESCRIPTION
Fixes #5073.

Thanks @martinthomson