### PR TITLE
fix: Handle plaintext documents with lines of 80ch

### DIFF
--- a/ietf/static/css/document_html.scss
+++ b/ietf/static/css/document_html.scss
@@ -165,10 +165,28 @@ $tooltip-margin: inherit !default;
 }
 
 .rfcmarkup {
-
+    // A lot of plaintext documents seem to have line lengths >72ch.
+    // To handle that, we calculate with 80ch here and adjust some of the
+    // font sizes down accordingly.
     pre {
-        width: 72ch;
+        width: 80ch;
         white-space: pre-wrap;
+    }
+
+    @media screen {
+        @include media-breakpoint-only(xs) {
+            font-size: min(6.75pt, var(--doc-ptsize-max));
+        }
+
+        @include media-breakpoint-up(sm) {
+            font-size: min(8.75pt, var(--doc-ptsize-max));
+        }
+
+        @include media-breakpoint-up(md) {
+            font-size: min(8.75pt, var(--doc-ptsize-max));
+        }
+
+        // Rest of font sizes is inherited from above.
     }
 
     h1,


### PR DESCRIPTION
Fixes #5079 and #5087 (hopefully)