### PR TITLE
fix: `add_links_in_new_revision_events` wasn't doing anything, remove

### DIFF
--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -13,7 +13,6 @@ import textwrap
 
 from collections import defaultdict, namedtuple, Counter
 from typing import Union
-from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 from django.conf import settings

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -370,42 +370,6 @@ def augment_events_with_revision(doc, events):
                 cur_rev = "00"
             e.rev = cur_rev
 
-def add_links_in_new_revision_events(doc, events, diff_revisions):
-    """Add direct .txt links and diff links to new_revision events."""
-    prev = None
-
-    diff_urls = dict(((name, revision), url) for name, revision, time, url in diff_revisions)
-
-    for e in sorted(events, key=lambda e: (e.time, e.id)):
-        if not e.type == "new_revision":
-            continue
-
-        for sub in ['newrevisiondocevent', 'submissiondocevent', ]:
-            if hasattr(e, sub):
-                e = getattr(e, sub)
-                break
-
-        if not (e.doc.name, e.rev) in diff_urls:
-            continue
-
-        full_url = diff_url = diff_urls[(e.doc.name, e.rev)]
-
-        if doc.type_id in "draft": # work around special diff url for drafts
-            full_url = "https://www.ietf.org/archive/id/" + diff_url + ".txt"
-
-        # build links
-        links = r'<a href="%s">\1</a>' % full_url
-        if prev:
-            links += ""
-
-        if prev != None:
-            links += ' (<a href="%s?url1=%s&amp;url2=%s">diff from previous</a>)' % (settings.RFCDIFF_BASE_URL, quote(prev, safe="~"), quote(diff_url, safe="~"))
-
-        # replace the bold filename part
-        e.desc = re.sub(r"<b>(.+-[0-9][0-9].txt)</b>", links, e.desc)
-
-        prev = diff_url
-
 
 def add_events_message_info(events):
     for e in events:

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -58,7 +58,7 @@ from ietf.doc.models import ( Document, DocAlias, DocHistory, DocEvent, BallotDo
     ConsensusDocEvent, NewRevisionDocEvent, TelechatDocEvent, WriteupDocEvent, IanaExpertDocEvent,
     IESG_BALLOT_ACTIVE_STATES, STATUSCHANGE_RELATIONS, DocumentActionHolder, DocumentAuthor,
     RelatedDocument, RelatedDocHistory)
-from ietf.doc.utils import (add_links_in_new_revision_events, augment_events_with_revision,
+from ietf.doc.utils import (augment_events_with_revision,
     can_adopt_draft, can_unadopt_draft, get_chartering_type, get_tags_for_stream_id,
     needed_ballot_positions, nice_consensus, prettify_std_name, update_telechat, has_same_ballot,
     get_initial_notify, make_notify_changed_event, make_rev_history, default_consensus,
@@ -1004,7 +1004,6 @@ def document_history(request, name):
     events = doc.docevent_set.all().order_by("-time", "-id").select_related("by")
 
     augment_events_with_revision(doc, events)
-    add_links_in_new_revision_events(doc, events, diff_revisions)
     add_events_message_info(events)
 
     # figure out if the current user can add a comment to the history


### PR DESCRIPTION
Whatever `add_links_in_new_revision_events` was supposed to do, it didn't do it. The linkification of things has been happening via the `format_history_text` template tag.