### PR TITLE
fix: restore generation of rswg/rsab chair aliases

### DIFF
--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -534,7 +534,7 @@ class DocExtResourceFactory(factory.django.DjangoModelFactory):
 class EditorialDraftFactory(BaseDocumentFactory):
 
     type_id = 'draft'
-    group = factory.SubFactory('ietf.group.factories.GroupFactory',acronym='rswg', type_id='rfcedtyp')
+    group = factory.SubFactory('ietf.group.factories.GroupFactory',acronym='rswg', type_id='edwg')
     stream_id = 'editorial'
 
     @factory.post_generation

--- a/ietf/group/management/commands/generate_group_aliases.py
+++ b/ietf/group/management/commands/generate_group_aliases.py
@@ -26,8 +26,8 @@ from ietf.utils.aliases import dump_sublist
 
 DEFAULT_YEARS = 5
 ACTIVE_STATES=['active', 'bof', 'proposed']
-GROUP_TYPES=['wg', 'rg', 'rag', 'dir', 'team', 'review', 'program', 'rfcedtyp']
-NO_AD_GROUP_TYPES=['rg', 'rag', 'team', 'program', 'rfcedtyp']
+GROUP_TYPES=['wg', 'rg', 'rag', 'dir', 'team', 'review', 'program', 'rfcedtyp', 'edappr', 'edwg'] # This should become groupfeature driven...
+NO_AD_GROUP_TYPES=['rg', 'rag', 'team', 'program', 'rfcedtyp', 'edappr', 'edwg']
 IETF_DOMAIN=['ietf.org', ]
 IRTF_DOMAIN=['irtf.org', ]
 IAB_DOMAIN=['iab.org', ]

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -71,7 +71,7 @@ class GroupPagesTests(TestCase):
         self.assertContains(r, group.name)
         self.assertContains(r, escape(group.ad_role().person.name))
 
-        for t in ('rg','area','ag', 'rag', 'dir','review','team','program','iabasg','adm','rfcedtyp'):
+        for t in ('rg','area','ag', 'rag', 'dir','review','team','program','iabasg','adm','rfcedtyp'): # See issue 5120
             g = GroupFactory.create(type_id=t,state_id='active') 
             if t in ['dir','review']:
                 g.parent = GroupFactory.create(type_id='area',state_id='active')

--- a/ietf/ietfauth/utils.py
+++ b/ietf/ietfauth/utils.py
@@ -167,8 +167,8 @@ def is_authorized_in_doc_stream(user, doc):
         group_req = Q(group__acronym=doc.stream.slug)
     elif doc.stream.slug == "editorial":
         group_req = Q(group=doc.group) | Q(group__acronym='rsab')
-        if doc.group.type.slug in ("individ", "rfcedtype"):
-            docman_roles = GroupFeatures.objects.get(type_id="rfcedtyp").docman_roles
+        if doc.group.type.slug in ("individ", "edappr"):
+            docman_roles = GroupFeatures.objects.get(type_id="edappr").docman_roles
     else:
         group_req = Q()  # no group constraint for other cases
 

--- a/ietf/name/fixtures/names.json
+++ b/ietf/name/fixtures/names.json
@@ -16326,7 +16326,7 @@
     "fields": {
       "command": "xym",
       "switch": "--version",
-      "time": "2023-01-24T08:09:45.071Z",
+      "time": "2023-01-31T08:09:46.678Z",
       "used": true,
       "version": "xym 0.6.2"
     },
@@ -16337,7 +16337,7 @@
     "fields": {
       "command": "pyang",
       "switch": "--version",
-      "time": "2023-01-24T08:09:45.405Z",
+      "time": "2023-01-31T08:09:47.011Z",
       "used": true,
       "version": "pyang 2.5.3"
     },
@@ -16348,7 +16348,7 @@
     "fields": {
       "command": "yanglint",
       "switch": "--version",
-      "time": "2023-01-24T08:09:45.421Z",
+      "time": "2023-01-31T08:09:47.028Z",
       "used": true,
       "version": "yanglint SO 1.9.2"
     },
@@ -16359,7 +16359,7 @@
     "fields": {
       "command": "xml2rfc",
       "switch": "--version",
-      "time": "2023-01-24T08:09:46.384Z",
+      "time": "2023-01-31T08:09:48.031Z",
       "used": true,
       "version": "xml2rfc 3.16.0"
     },

--- a/ietf/utils/test_data.py
+++ b/ietf/utils/test_data.py
@@ -72,7 +72,7 @@ def make_immutable_base_data():
     irtf = create_group(name="IRTF", acronym="irtf", type_id="irtf")
     create_person(irtf, "chair")
 
-    rsab = create_group(name="RSAB", acronym="rsab", type_id="rfcedtyp")
+    rsab = create_group(name="RSAB", acronym="rsab", type_id="edappr")
     p = create_person(rsab, "chair")
     p.role_set.create(group=rsab, name_id="member", email=p.email())
 


### PR DESCRIPTION
The recent editorial stream refactoring changed the rswg and rsab group types. A few consequences, including alias generation, were missed.