### PR TITLE
fix: Point to IAB liaison page from datatracker liaison pages

### DIFF
--- a/ietf/templates/liaisons/detail.html
+++ b/ietf/templates/liaisons/detail.html
@@ -13,6 +13,7 @@
         <br>
         <small class="text-muted">{% include 'liaisons/liaison_title.html' %}</small>
     </h1>
+    {% include "liaisons/liaison_desc.html" only %}
     {% include "liaisons/detail_tabs.html" %}
     <table class="table table-sm table-striped">
         <tbody>

--- a/ietf/templates/liaisons/liaison_base.html
+++ b/ietf/templates/liaisons/liaison_base.html
@@ -11,6 +11,7 @@
 {% block content %}
     {% origin %}
     <h1>Liaison Statements</h1>
+    {% include "liaisons/liaison_desc.html" only %}
     {% if with_search %}
         <div class="ietf-box search-form-box">{% include "liaisons/search_form.html" %}</div>
     {% endif %}

--- a/ietf/templates/liaisons/liaison_desc.html
+++ b/ietf/templates/liaisons/liaison_desc.html
@@ -1,0 +1,4 @@
+<div class="alert alert-info">
+    Additional information about IETF liaison relationships is available on the
+    <a href="https://www.iab.org/liaisons/" target="_blank">Internet Architecture Board liaison webpage</a>.
+</div>


### PR DESCRIPTION
Fixes #4971