### PR TITLE
fix: Guard against null form-group around name fields in session_details_form.js

### DIFF
--- a/ietf/static/js/session_details_form.js
+++ b/ietf/static/js/session_details_form.js
@@ -55,9 +55,19 @@
 
     function update_name_field_visibility(name_elts, purpose) {
         if (!purpose || purpose === 'regular') {
-            name_elts.forEach(e => e.closest('.form-group').classList.add('hidden'));
+            name_elts.forEach(e => {
+                const formGroup = e.closest('.form-group');
+                if (formGroup) {
+                    formGroup.classList.add('hidden');
+                }
+            });
         } else {
-            name_elts.forEach(e => e.closest('.form-group').classList.remove('hidden'));
+            name_elts.forEach(e => {
+                const formGroup = e.closest('.form-group');
+                if (formGroup) {
+                    formGroup.classList.remove('hidden');
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #5174 

This JS file supports the `ietf.meeting.forms.SessionDetailsForm` form. In normal use, the form is rendered with its inputs (including `name` and `short`) inside `div.form-group` elements. However, the form is also reused in the `secr.sreq` app, where the fields are rendered _ad hoc_. The `short` field was recently added as an always-hidden field not contained inside a `div.form-group`, causing the JS code to fail. As a result, the visibility of various fields was not updated, including the purpose/type fields complained about in #5174.