### PR TITLE
feat: Grab slides for reorder using the handle instead of entire row

### DIFF
--- a/ietf/templates/meeting/session_details.html
+++ b/ietf/templates/meeting/session_details.html
@@ -3,8 +3,8 @@
 {% load origin ietf_filters static %}
 {% block title %}{{ meeting }} : {{ acronym }}{% endblock %}
 {% block morecss %}
-    .draggable {
-        cursor: pointer;
+    .drag-handle {
+        cursor: move;
     }
 {% endblock %}
 {% block content %}
@@ -64,6 +64,7 @@
             var options = {
                 group: "slides",
                 animation: 150,
+                handle: ".drag-handle",
                 onAdd: function(event) {onAdd(event)},
                 onRemove: function(event) {onRemove(event)},
                 onEnd: function(event) {onEnd(event)}

--- a/ietf/templates/meeting/session_details_panel.html
+++ b/ietf/templates/meeting/session_details_panel.html
@@ -137,16 +137,11 @@
                        data-remove-from-session="{% url 'ietf.meeting.views.ajax_remove_slides_from_session' session_id=session.pk num=session.meeting.number %}"
                        data-reorder-in-session="{% url 'ietf.meeting.views.ajax_reorder_slides_in_session' session_id=session.pk num=session.meeting.number %}">
                     {% for pres in session.filtered_slides %}
-                        <tr data-name="{{ pres.document.name }}"
-                            {% if can_manage_materials %}
-                                class="draggable"
-                                title="Drag to reorder."
-                            {% endif %}
-                        >
+                        <tr data-name="{{ pres.document.name }}" {% if can_manage_materials %} class="draggable" {% endif %}>
                             {% url 'ietf.doc.views_doc.document_main' name=pres.document.name as url %}
                             {% if can_manage_materials %}
                                 <td>
-                                    <i class="bi bi-grip-vertical"></i>
+                                    <i class="bi bi-grip-vertical drag-handle" title="Drag to reorder"></i>
                                 </td>
                             {% endif %}
                             <td>


### PR DESCRIPTION
Fixes #3864 

To address the specific request, moves the title text from the entire draggable row onto the handle icon. At least on Firefox, the resulting tooltip is placed to the right of the handle which covers the content of the row - not ideal, but I think it's overall better than what was there.

Also requires grabbing the slides by the handle. This has the benefit that text can be selected on the rest of the rows and leaves the cursor in its default mode except over the handle. I like this better, but it might make use more difficult for mobile or other touchscreen users.

Changes the cursor from "pointer" to "move" when over the drag handle. I think this is well supported and distinguishes between clicking on the slide link and dragging the row.