### PR TITLE
fix: Sort rooms by ascending capacity in schedule editor

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -665,8 +665,8 @@ def edit_meeting_schedule(request, num=None, owner=None, name=None):
         sorted_rooms = sorted(
             rooms_with_timeslots,
             key=lambda room: (
-                # Sort higher capacity rooms first.
-                -room.capacity if room.capacity is not None else 1,  # sort rooms with capacity = None at end
+                # Sort lower capacity rooms first.
+                room.capacity if room.capacity is not None else math.inf,  # sort rooms with capacity = None at end
                 # Sort regular session rooms ahead of others - these will usually
                 # have more timeslots than other room types.
                 0 if room_data[room.pk]['timeslot_count'] == max_timeslots else 1,

--- a/ietf/templates/meeting/upcoming.ics
+++ b/ietf/templates/meeting/upcoming.ics
@@ -1,4 +1,4 @@
-{% load humanize tz %}{% autoescape off %}{% load ietf_filters %}BEGIN:VCALENDAR
+{% load humanize tz %}{% autoescape off %}{% load ietf_filters textfilters %}BEGIN:VCALENDAR
 VERSION:2.0
 METHOD:PUBLISH
 PRODID:-//IETF//datatracker.ietf.org ical upcoming//EN
@@ -10,14 +10,16 @@ SUMMARY:{% if item.session.name %}{{item.session.group.acronym|lower}} - {{item.
 CLASS:PUBLIC
 DTSTART{% ics_date_time item.timeslot.local_start_time item.schedule.meeting.time_zone %}
 DTEND{% ics_date_time item.timeslot.local_end_time item.schedule.meeting.time_zone %}
-DTSTAMP{% ics_date_time item.timeslot.modified|utc 'utc' %}
-{% if item.session.agenda %}URL:{{item.session.agenda.get_href}}
-DESCRIPTION:{{item.timeslot.name|ics_esc}}\n{% if item.session.agenda_note %}
+DTSTAMP{% ics_date_time item.timeslot.modified|utc 'utc' %}{% if item.session.agenda %}
+URL:{{item.session.agenda.get_href}}{% endif %}
+DESCRIPTION:{% if item.timeslot.name %}{{item.timeslot.name|ics_esc}}\n{% endif %}{% if item.session.agenda_note %}
  Note: {{item.session.agenda_note|ics_esc}}\n{% endif %}{% for material in item.session.materials.all %}
  \n{{material.type}}{% if material.type.name != "Agenda" %}
   ({{material.title|ics_esc}}){% endif %}:
-  {{material.get_href}}\n{% endfor %}
-{% endif %}END:VEVENT
+  {{material.get_href}}\n{% endfor %}{% if item.timeslot.location.webex_url %}
+ Webex: {{ item.timeslot.location.webex_url }}\n{% endif %}{% if item.timeslot.location.video_stream_url %}
+ Meetecho: {{ item.timeslot.location.video_stream_url|format:item.session }}\n{% endif %}
+END:VEVENT
 {% endfor %}{% for meeting in ietfs %}BEGIN:VEVENT
 UID:ietf-{{ meeting.number }}
 SUMMARY:IETF {{ meeting.number }}{% if meeting.city %}

--- a/ietf/templates/meeting/upcoming.ics
+++ b/ietf/templates/meeting/upcoming.ics
@@ -1,4 +1,4 @@
-{% load humanize tz %}{% autoescape off %}{% load ietf_filters textfilters %}BEGIN:VCALENDAR
+{% load humanize tz %}{% autoescape off %}{% load ietf_filters %}BEGIN:VCALENDAR
 VERSION:2.0
 METHOD:PUBLISH
 PRODID:-//IETF//datatracker.ietf.org ical upcoming//EN
@@ -10,16 +10,14 @@ SUMMARY:{% if item.session.name %}{{item.session.group.acronym|lower}} - {{item.
 CLASS:PUBLIC
 DTSTART{% ics_date_time item.timeslot.local_start_time item.schedule.meeting.time_zone %}
 DTEND{% ics_date_time item.timeslot.local_end_time item.schedule.meeting.time_zone %}
-DTSTAMP{% ics_date_time item.timeslot.modified|utc 'utc' %}{% if item.session.agenda %}
-URL:{{item.session.agenda.get_href}}{% endif %}
-DESCRIPTION:{% if item.timeslot.name %}{{item.timeslot.name|ics_esc}}\n{% endif %}{% if item.session.agenda_note %}
+DTSTAMP{% ics_date_time item.timeslot.modified|utc 'utc' %}
+{% if item.session.agenda %}URL:{{item.session.agenda.get_href}}
+DESCRIPTION:{{item.timeslot.name|ics_esc}}\n{% if item.session.agenda_note %}
  Note: {{item.session.agenda_note|ics_esc}}\n{% endif %}{% for material in item.session.materials.all %}
  \n{{material.type}}{% if material.type.name != "Agenda" %}
   ({{material.title|ics_esc}}){% endif %}:
-  {{material.get_href}}\n{% endfor %}{% if item.timeslot.location.webex_url %}
- Webex: {{ item.timeslot.location.webex_url }}\n{% endif %}{% if item.timeslot.location.video_stream_url %}
- Meetecho: {{ item.timeslot.location.video_stream_url|format:item.session }}\n{% endif %}
-END:VEVENT
+  {{material.get_href}}\n{% endfor %}
+{% endif %}END:VEVENT
 {% endfor %}{% for meeting in ietfs %}BEGIN:VEVENT
 UID:ietf-{{ meeting.number }}
 SUMMARY:IETF {{ meeting.number }}{% if meeting.city %}


### PR DESCRIPTION
Orders rooms on the schedule editor by ascending, not descending, capacity. This was switched to descending in #4653 but @flynnliz requested the original order.

(This is not a revert of #4653, though. That PR also made capacity the highest priority factor in room ordering, which is kept here.)