### PR TITLE
fix: Use more robust filename/rev matching for meeting materials

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -35,7 +35,7 @@ from django.utils.text import slugify
 
 import debug           # pyflakes:ignore
 
-from ietf.doc.models import Document
+from ietf.doc.models import Document, NewRevisionDocEvent
 from ietf.group.models import Group, Role, GroupFeatures
 from ietf.group.utils import can_manage_group
 from ietf.person.models import Person
@@ -613,12 +613,43 @@ class MeetingTests(BaseMeetingTestCase):
         shadow.document.save()
         # create the material we want to find for the test
         sp = SessionPresentationFactory(document__name='slides-115-junk-15',document__type_id='slides',document__states=[('reuse_policy','single')])
-        sp.document.uploaded_filename = '%s-%s.pdf'%(sp.document.name,sp.document.rev)
+        sp.document.uploaded_filename = f'{sp.document.name}-{sp.document.rev}.pdf'
         sp.document.save()
-        self.write_materials_file(sp.session.meeting, sp.document, 'Fake slide contents')
-        url = urlreverse("ietf.meeting.views.materials_document", kwargs=dict(document=sp.document.name,num=sp.session.meeting.number))
+        self.write_materials_file(sp.session.meeting, sp.document, 'Fake slide contents rev 00')
+
+        # create rev 01
+        sp.document.rev = '01'
+        sp.document.uploaded_filename = f'{sp.document.name}-{sp.document.rev}.pdf'
+        sp.document.save_with_history([
+            NewRevisionDocEvent.objects.create(
+                type="new_revision",
+                doc=sp.document,
+                rev=sp.document.rev,
+                by=Person.objects.get(name='(System)'),
+                desc=f'New version available: <b>{sp.document.name}-{sp.document.rev}.txt</b>',
+            )
+        ])
+        self.write_materials_file(sp.session.meeting, sp.document, 'Fake slide contents rev 01')
+        url = urlreverse(
+            "ietf.meeting.views.materials_document",
+            kwargs=dict(document=sp.document.name, num=sp.session.meeting.number),
+        )
         r = self.client.get(url)
-        self.assertContains(r, 'Fake slide contents', status_code=200)
+        self.assertContains(r, 'Fake slide contents rev 01', status_code=200,
+                            msg_prefix="Should return latest rev by default")
+        url = urlreverse(
+            "ietf.meeting.views.materials_document",
+            kwargs=dict(document=sp.document.name + '-00', num=sp.session.meeting.number),
+        )
+        r = self.client.get(url)
+        self.assertContains(r, 'Fake slide contents rev 00', status_code=200,
+                            msg_prefix="Should return existing version on request")
+        url = urlreverse(
+            "ietf.meeting.views.materials_document",
+            kwargs=dict(document=sp.document.name + '-02', num=sp.session.meeting.number),
+        )
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 404, "Should not find nonexistent version")
 
     def test_important_dates(self):
         meeting=MeetingFactory(type_id='ietf')

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -608,45 +608,69 @@ class MeetingTests(BaseMeetingTestCase):
     @override_settings(MEETING_MATERIALS_SERVE_LOCALLY=True)
     def test_materials_name_endswith_hyphen_number_number(self):
         # be sure a shadowed filename without the hyphen does not interfere
-        shadow = SessionPresentationFactory(document__name='slides-115-junk', document__type_id='slides', document__states=[('reuse_policy', 'single')])
-        shadow.document.uploaded_filename = f'{shadow.document.name}-{shadow.document.rev}.pdf'
+        shadow = SessionPresentationFactory(
+            document__name="slides-115-junk",
+            document__type_id="slides",
+            document__states=[("reuse_policy", "single")],
+        )
+        shadow.document.uploaded_filename = (
+            f"{shadow.document.name}-{shadow.document.rev}.pdf"
+        )
         shadow.document.save()
         # create the material we want to find for the test
-        sp = SessionPresentationFactory(document__name='slides-115-junk-15',document__type_id='slides',document__states=[('reuse_policy','single')])
-        sp.document.uploaded_filename = f'{sp.document.name}-{sp.document.rev}.pdf'
+        sp = SessionPresentationFactory(
+            document__name="slides-115-junk-15",
+            document__type_id="slides",
+            document__states=[("reuse_policy", "single")],
+        )
+        sp.document.uploaded_filename = f"{sp.document.name}-{sp.document.rev}.pdf"
         sp.document.save()
-        self.write_materials_file(sp.session.meeting, sp.document, 'Fake slide contents rev 00')
+        self.write_materials_file(
+            sp.session.meeting, sp.document, "Fake slide contents rev 00"
+        )
 
         # create rev 01
-        sp.document.rev = '01'
-        sp.document.uploaded_filename = f'{sp.document.name}-{sp.document.rev}.pdf'
-        sp.document.save_with_history([
-            NewRevisionDocEvent.objects.create(
-                type="new_revision",
-                doc=sp.document,
-                rev=sp.document.rev,
-                by=Person.objects.get(name='(System)'),
-                desc=f'New version available: <b>{sp.document.name}-{sp.document.rev}.txt</b>',
-            )
-        ])
-        self.write_materials_file(sp.session.meeting, sp.document, 'Fake slide contents rev 01')
+        sp.document.rev = "01"
+        sp.document.uploaded_filename = f"{sp.document.name}-{sp.document.rev}.pdf"
+        sp.document.save_with_history(
+            [
+                NewRevisionDocEvent.objects.create(
+                    type="new_revision",
+                    doc=sp.document,
+                    rev=sp.document.rev,
+                    by=Person.objects.get(name="(System)"),
+                    desc=f"New version available: <b>{sp.document.name}-{sp.document.rev}.txt</b>",
+                )
+            ]
+        )
+        self.write_materials_file(
+            sp.session.meeting, sp.document, "Fake slide contents rev 01"
+        )
         url = urlreverse(
             "ietf.meeting.views.materials_document",
             kwargs=dict(document=sp.document.name, num=sp.session.meeting.number),
         )
         r = self.client.get(url)
-        self.assertContains(r, 'Fake slide contents rev 01', status_code=200,
-                            msg_prefix="Should return latest rev by default")
+        self.assertContains(
+            r,
+            "Fake slide contents rev 01",
+            status_code=200,
+            msg_prefix="Should return latest rev by default",
+        )
         url = urlreverse(
             "ietf.meeting.views.materials_document",
-            kwargs=dict(document=sp.document.name + '-00', num=sp.session.meeting.number),
+            kwargs=dict(document=sp.document.name + "-00", num=sp.session.meeting.number),
         )
         r = self.client.get(url)
-        self.assertContains(r, 'Fake slide contents rev 00', status_code=200,
-                            msg_prefix="Should return existing version on request")
+        self.assertContains(
+            r,
+            "Fake slide contents rev 00",
+            status_code=200,
+            msg_prefix="Should return existing version on request",
+        )
         url = urlreverse(
             "ietf.meeting.views.materials_document",
-            kwargs=dict(document=sp.document.name + '-02', num=sp.session.meeting.number),
+            kwargs=dict(document=sp.document.name + "-02", num=sp.session.meeting.number),
         )
         r = self.client.get(url)
         self.assertEqual(r.status_code, 404, "Should not find nonexistent version")

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -213,8 +213,8 @@ def _get_materials_doc(meeting, name):
     if doc is not None and doc.get_related_meeting() == meeting:
         return doc, None
     # try parsing a rev number
-    if '-' in name:
-        docname, rev = name.rsplit('-', 1)
+    if "-" in name:
+        docname, rev = name.rsplit("-", 1)
         if len(rev) == 2 and rev.isdigit():
             doc = Document.objects.get(name=docname)  # may raise Document.DoesNotExist
             if doc.get_related_meeting() == meeting and rev in doc.revisions():

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -223,7 +223,6 @@ def _get_materials_doc(meeting, name):
 
 @cache_page(1 * 60)
 def materials_document(request, document, num=None, ext=None):
-    debug.show('document')
     meeting=get_meeting(num,type_in=['ietf','interim'])
     num = meeting.number
     # This view does not allow the use of DocAliases. Right now we are probably only creating one (identity) alias, but that may not hold in the future.

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -213,10 +213,12 @@ def _get_materials_doc(meeting, name):
     if doc is not None and doc.get_related_meeting() == meeting:
         return doc, None
     # try parsing a rev number
-    name, rev = name.rsplit('-', 1)
-    doc = Document.objects.filter(name=name).first()
-    if doc is not None and doc.get_related_meeting() == meeting:
-        return doc, rev
+    if '-' in name:
+        docname, rev = name.rsplit('-', 1)
+        if len(rev) == 2 and rev.isdigit():
+            doc = Document.objects.get(name=docname)  # may raise Document.DoesNotExist
+            if doc.get_related_meeting() == meeting and rev in doc.revisions():
+                return doc, rev
     # give up
     raise Document.DoesNotExist
 


### PR DESCRIPTION
Fixes #4731.

Note that this does away with a series of moderately complex regex checks in the revision matching. I don't know the motivation behind those checks, but it seems to me that the `get_related_meeting()` check should be adequate to distinguish whether a document is suitable to be returned by this method.