### PR TITLE
fix: Use session.order_in_meeting() in the agenda

### DIFF
--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -124,7 +124,7 @@ def preprocess_assignments_for_agenda(assignments_queryset, meeting, extra_prefe
             # check before blindly assigning to meeting just in case.
             if a.session.meeting.pk == meeting.pk:
                 a.session.meeting = meeting
-            a.session.order_number = None
+            a.session.order_number = a.session.order_in_meeting() if a.session.group else None
 
             if a.session.group and a.session.group not in groups:
                 groups.append(a.session.group)
@@ -133,12 +133,6 @@ def preprocess_assignments_for_agenda(assignments_queryset, meeting, extra_prefe
     for a in assignments:
         if a.session and a.session.group:
             sessions_for_groups[(a.session.group, a.session.type_id)].append(a)
-
-    for a in assignments:
-        if a.session and a.session.group:
-
-            l = sessions_for_groups.get((a.session.group, a.session.type_id), [])
-            a.session.order_number = l.index(a) + 1 if a in l else 0
 
     timeslot_by_session_pk = {a.session_id: a.timeslot for a in assignments}
 


### PR DESCRIPTION
Updates the `preprocess_assignments_for_agenda()` helper method to use `order_in_meeting()` to assign `session.order_number`. This is more stable and agrees with what the `session_details()` meeting view and the `group.views.meetings()` view do.

FYI, for the preliminary IETF-116 agenda, the following sessions change number. The data being diffed are `[group acronym, session name, order_number]` from the JSON data used to construct the agenda display. `<` are "before" and `>` are after. Most changes are to breaks/etc that do not have meetecho sessions anyway.
```
13,14c13,14
< "[\"secretariat\",\"Continental Breakfast\",1]"
< "[\"secretariat\",\"IETF Registration\",2]"
---
> "[\"secretariat\",\"Continental Breakfast\",2]"
> "[\"secretariat\",\"IETF Registration\",3]"
23c23
< "[\"secretariat\",\"Break\",2]"
---
> "[\"secretariat\",\"Break\",4]"
32c32
< "[\"secretariat\",\"Beverage and Snack Break\",3]"
---
> "[\"secretariat\",\"Beverage and Snack Break\",5]"
41c41
< "[\"secretariat\",\"Beverage Break\",4]"
---
> "[\"secretariat\",\"Beverage Break\",6]"
49,51c49,51
< "[\"secretariat\",\"New Participants Dinner\",1]"
< "[\"secretariat\",\"Continental Breakfast\",5]"
< "[\"secretariat\",\"IETF Registration\",3]"
---
> "[\"secretariat\",\"New Participants Dinner\",7]"
> "[\"secretariat\",\"Continental Breakfast\",8]"
> "[\"secretariat\",\"IETF Registration\",9]"
60c60
< "[\"secretariat\",\"Break\",6]"
---
> "[\"secretariat\",\"Break\",10]"
69c69
< "[\"secretariat\",\"Beverage and Snack Break\",7]"
---
> "[\"secretariat\",\"Beverage and Snack Break\",11]"
78c78
< "[\"secretariat\",\"Beverage Break\",8]"
---
> "[\"secretariat\",\"Beverage Break\",12]"
87,88c87,88
< "[\"secretariat\",\"Continental Breakfast\",9]"
< "[\"secretariat\",\"IETF Registration\",4]"
---
> "[\"secretariat\",\"Continental Breakfast\",13]"
> "[\"secretariat\",\"IETF Registration\",14]"
97c97
< "[\"secretariat\",\"Break\",10]"
---
> "[\"secretariat\",\"Break\",15]"
107c107
< "[\"secretariat\",\"Beverage Break\",11]"
---
> "[\"secretariat\",\"Beverage Break\",16]"
116,119c116,119
< "[\"secretariat\",\"Beverage and Snack Break\",12]"
< "[\"ietf\",\"IETF Plenary\",1]"
< "[\"secretariat\",\"Continental Breakfast\",13]"
< "[\"secretariat\",\"IETF Registration\",5]"
---
> "[\"secretariat\",\"Beverage and Snack Break\",17]"
> "[\"ietf\",\"IETF Plenary\",2]"
> "[\"secretariat\",\"Continental Breakfast\",18]"
> "[\"secretariat\",\"IETF Registration\",19]"
128,129c128,129
< "[\"secretariat\",\"Break\",14]"
< "[\"ietf\",\"Host Speaker Series: Quantum Internet\",2]"
---
> "[\"secretariat\",\"Break\",20]"
> "[\"ietf\",\"Host Speaker Series: Quantum Internet\",3]"
138c138
< "[\"secretariat\",\"Beverage Break\",15]"
---
> "[\"secretariat\",\"Beverage Break\",21]"
147c147
< "[\"secretariat\",\"Beverage and Snack Break\",16]"
---
> "[\"secretariat\",\"Beverage and Snack Break\",22]"
156,158c156,158
< "[\"ietf\",\"IETF 116 Social Event at Osanbashi Pier - Hosted by WIDE\",3]"
< "[\"secretariat\",\"Continental Breakfast\",17]"
< "[\"secretariat\",\"IETF Registration\",6]"
---
> "[\"ietf\",\"IETF 116 Social Event at Osanbashi Pier - Hosted by WIDE\",4]"
> "[\"secretariat\",\"Continental Breakfast\",23]"
> "[\"secretariat\",\"IETF Registration\",24]"
167c167
< "[\"secretariat\",\"Beverage and Snack Break\",18]"
---
> "[\"secretariat\",\"Beverage and Snack Break\",25]"
```