### PR TITLE
fix: Only consider ietf meetings as "next" for agenda_ical or agenda_json

### DIFF
--- a/ietf/meeting/helpers.py
+++ b/ietf/meeting/helpers.py
@@ -36,12 +36,14 @@ from ietf.utils.pipe import pipe
 from ietf.utils.text import xslugify
 
 
-def get_meeting(num=None,type_in=['ietf',],days=28):
+def get_meeting(num=None, type_in=('ietf',), days=28):
     meetings = Meeting.objects
-    if type_in:
+    if type_in is not None:
         meetings = meetings.filter(type__in=type_in)
-    if num == None:
-        meetings = meetings.filter(date__gte=timezone.now()-datetime.timedelta(days=days)).order_by('date')
+    if num is None:
+        meetings = meetings.filter(
+            date__gte=timezone.now() - datetime.timedelta(days=days)
+        ).order_by('date')
     else:
         meetings = meetings.filter(number=num)
     if meetings.exists():

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -341,24 +341,36 @@ class MeetingTests(BaseMeetingTestCase):
 
     def test_agenda_ical_next_meeting_type(self):
         # start with no upcoming IETF meetings, just an interim
-        MeetingFactory(type_id='interim', date=date_today() + datetime.timedelta(days=15))
-        r = self.client.get(urlreverse('ietf.meeting.views.agenda_ical', kwargs={}))
-        self.assertEqual(r.status_code, 404, 'Should not return an interim meeting as next meeting')
+        MeetingFactory(
+            type_id="interim", date=date_today() + datetime.timedelta(days=15)
+        )
+        r = self.client.get(urlreverse("ietf.meeting.views.agenda_ical", kwargs={}))
+        self.assertEqual(
+            r.status_code, 404, "Should not return an interim meeting as next meeting"
+        )
         # create an IETF meeting after the interim - it should be found as "next"
-        ietf_meeting = MeetingFactory(type_id='ietf', date=date_today() + datetime.timedelta(days=30))
-        SessionFactory(meeting=ietf_meeting, name='Session at IETF meeting')
-        r = self.client.get(urlreverse('ietf.meeting.views.agenda_ical', kwargs={}))
+        ietf_meeting = MeetingFactory(
+            type_id="ietf", date=date_today() + datetime.timedelta(days=30)
+        )
+        SessionFactory(meeting=ietf_meeting, name="Session at IETF meeting")
+        r = self.client.get(urlreverse("ietf.meeting.views.agenda_ical", kwargs={}))
         self.assertContains(r, "Session at IETF meeting", status_code=200)
 
     def test_agenda_json_next_meeting_type(self):
         # start with no upcoming IETF meetings, just an interim
-        MeetingFactory(type_id='interim', date=date_today() + datetime.timedelta(days=15))
-        r = self.client.get(urlreverse('ietf.meeting.views.agenda_json', kwargs={}))
-        self.assertEqual(r.status_code, 404, 'Should not return an interim meeting as next meeting')
+        MeetingFactory(
+            type_id="interim", date=date_today() + datetime.timedelta(days=15)
+        )
+        r = self.client.get(urlreverse("ietf.meeting.views.agenda_json", kwargs={}))
+        self.assertEqual(
+            r.status_code, 404, "Should not return an interim meeting as next meeting"
+        )
         # create an IETF meeting after the interim - it should be found as "next"
-        ietf_meeting = MeetingFactory(type_id='ietf', date=date_today() + datetime.timedelta(days=30))
-        SessionFactory(meeting=ietf_meeting, name='Session at IETF meeting')
-        r = self.client.get(urlreverse('ietf.meeting.views.agenda_json', kwargs={}))
+        ietf_meeting = MeetingFactory(
+            type_id="ietf", date=date_today() + datetime.timedelta(days=30)
+        )
+        SessionFactory(meeting=ietf_meeting, name="Session at IETF meeting")
+        r = self.client.get(urlreverse("ietf.meeting.views.agenda_json", kwargs={}))
         self.assertContains(r, "Session at IETF meeting", status_code=200)
 
     @override_settings(PROCEEDINGS_V1_BASE_URL='https://example.com/{meeting.number}')

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -341,16 +341,25 @@ class MeetingTests(BaseMeetingTestCase):
 
     def test_agenda_ical_next_meeting_type(self):
         # start with no upcoming IETF meetings, just an interim
-        interim_meeting = MeetingFactory(type_id='interim', date=date_today() + datetime.timedelta(days=15))
+        MeetingFactory(type_id='interim', date=date_today() + datetime.timedelta(days=15))
         r = self.client.get(urlreverse('ietf.meeting.views.agenda_ical', kwargs={}))
         self.assertEqual(r.status_code, 404, 'Should not return an interim meeting as next meeting')
         # create an IETF meeting after the interim - it should be found as "next"
         ietf_meeting = MeetingFactory(type_id='ietf', date=date_today() + datetime.timedelta(days=30))
-        SessionFactory(meeting=ietf_meeting)
+        SessionFactory(meeting=ietf_meeting, name='Session at IETF meeting')
         r = self.client.get(urlreverse('ietf.meeting.views.agenda_ical', kwargs={}))
-        self.assertContains(r, f"ietf-{ietf_meeting.number}", status_code=200)
-        r = self.client.get(urlreverse('ietf.meeting.views.agenda_ical', kwargs={'num': ietf_meeting.number}))
-        self.assertContains(r, f"ietf-{ietf_meeting.number}", status_code=200)
+        self.assertContains(r, "Session at IETF meeting", status_code=200)
+
+    def test_agenda_json_next_meeting_type(self):
+        # start with no upcoming IETF meetings, just an interim
+        MeetingFactory(type_id='interim', date=date_today() + datetime.timedelta(days=15))
+        r = self.client.get(urlreverse('ietf.meeting.views.agenda_json', kwargs={}))
+        self.assertEqual(r.status_code, 404, 'Should not return an interim meeting as next meeting')
+        # create an IETF meeting after the interim - it should be found as "next"
+        ietf_meeting = MeetingFactory(type_id='ietf', date=date_today() + datetime.timedelta(days=30))
+        SessionFactory(meeting=ietf_meeting, name='Session at IETF meeting')
+        r = self.client.get(urlreverse('ietf.meeting.views.agenda_json', kwargs={}))
+        self.assertContains(r, "Session at IETF meeting", status_code=200)
 
     @override_settings(PROCEEDINGS_V1_BASE_URL='https://example.com/{meeting.number}')
     def test_agenda_redirects_for_old_meetings(self):

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2041,7 +2041,7 @@ def should_include_assignment(filter_params, assignment):
     hidden = len(set(filter_params['hide']).intersection(assignment.filter_keywords)) > 0
     return shown and not hidden
 
-def agenda_ical(request, num=None, name=None, acronym=None, session_id=None):
+def agenda_ical(request, num=None, acronym=None, session_id=None):
     """Agenda ical view
 
     By default, all agenda items will be shown. A filter can be specified in 
@@ -2060,7 +2060,7 @@ def agenda_ical(request, num=None, name=None, acronym=None, session_id=None):
     Hiding (by wg or type) takes priority over showing.
     """
     meeting = get_meeting(num, type_in=None)
-    schedule = get_schedule(meeting, name)
+    schedule = get_schedule(meeting)
     updated = meeting.updated()
 
     if schedule is None and acronym is None and session_id is None:

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2044,7 +2044,10 @@ def should_include_assignment(filter_params, assignment):
 def agenda_ical(request, num=None, acronym=None, session_id=None):
     """Agenda ical view
 
-    By default, all agenda items will be shown. A filter can be specified in 
+    If num is None, looks for the next IETF meeting. Otherwise, uses the requested meeting
+    regardless of its type.
+
+    By default, all agenda items will be shown. A filter can be specified in
     the querystring. It has the format
     
       ?show=...&hide=...&showtypes=...&hidetypes=...
@@ -2059,7 +2062,12 @@ def agenda_ical(request, num=None, acronym=None, session_id=None):
 
     Hiding (by wg or type) takes priority over showing.
     """
-    meeting = get_meeting(num, type_in=None)
+    if num is None:
+        meeting = get_ietf_meeting()
+        if meeting is None:
+            raise Http404
+    else:
+        meeting = get_meeting(num, type_in=None)  # get requested meeting, whatever its type
     schedule = get_schedule(meeting)
     updated = meeting.updated()
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2107,7 +2107,12 @@ def agenda_ical(request, num=None, acronym=None, session_id=None):
 
 @cache_page(15 * 60)
 def agenda_json(request, num=None):
-    meeting = get_meeting(num, type_in=['ietf','interim'])
+    if num is None:
+        meeting = get_ietf_meeting()
+        if meeting is None:
+            raise Http404
+    else:
+        meeting = get_meeting(num, type_in=None)  # get requested meeting, whatever its type
 
     sessions = []
     locations = set()


### PR DESCRIPTION
Fixes #4629