### PR TITLE
chore: Remove unused ajax_get_utc() view and related plumbing

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -5800,35 +5800,6 @@ class InterimTests(TestCase):
         self.assertContains(r, 'END:VEVENT')
 
 
-class AjaxTests(TestCase):
-    def test_ajax_get_utc(self):
-        # test bad queries
-        url = urlreverse('ietf.meeting.views.ajax_get_utc') + "?date=2016-1-1&time=badtime&timezone=UTC"
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
-        data = r.json()
-        self.assertEqual(data["error"], True)
-        url = urlreverse('ietf.meeting.views.ajax_get_utc') + "?date=2016-1-1&time=25:99&timezone=UTC"
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
-        data = r.json()
-        self.assertEqual(data["error"], True)
-        url = urlreverse('ietf.meeting.views.ajax_get_utc') + "?date=2016-1-1&time=10:00am&timezone=UTC"
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
-        data = r.json()
-        self.assertEqual(data["error"], True)
-        # test good query
-        url = urlreverse('ietf.meeting.views.ajax_get_utc') + "?date=2016-1-1&time=12:00&timezone=America/Los_Angeles"
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
-        data = r.json()
-        self.assertIn('timezone', data)
-        self.assertIn('time', data)
-        self.assertIn('utc', data)
-        self.assertNotIn('error', data)
-        self.assertEqual(data['utc'], '20:00')
-
 class IphoneAppJsonTests(TestCase):
     def test_iphone_app_json_interim(self):
         make_interim_test_data()

--- a/ietf/meeting/urls.py
+++ b/ietf/meeting/urls.py
@@ -113,7 +113,6 @@ type_ietf_only_patterns_id_optional = [
 urlpatterns = [
     # First patterns which start with unique strings
     url(r'^$', views.current_materials),
-    url(r'^ajax/get-utc/?$', views.ajax_get_utc),
     url(r'^interim/announce/?$', views.interim_announce),
     url(r'^interim/announce/(?P<number>[A-Za-z0-9._+-]+)/?$', views.interim_send_announcement),
     url(r'^interim/skip_announce/(?P<number>[A-Za-z0-9._+-]+)/?$', views.interim_skip_announcement),

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3029,43 +3029,6 @@ def delete_schedule(request, num, owner, name):
 # -------------------------------------------------
 # Interim Views
 # -------------------------------------------------
-
-
-def ajax_get_utc(request):
-    '''Ajax view that takes arguments time, timezone, date and returns UTC data'''
-    time = request.GET.get('time')
-    timezone = request.GET.get('timezone')
-    date = request.GET.get('date')
-    time_re = re.compile(r'^\d{2}:\d{2}$')
-    # validate input
-    if not time_re.match(time) or not date:
-        return HttpResponse(json.dumps({'error': True}),
-                            content_type='application/json')
-    hour, minute = time.split(':')
-    if not (int(hour) <= 23 and int(minute) <= 59):
-        return HttpResponse(json.dumps({'error': True}),
-                            content_type='application/json')
-    year, month, day = date.split('-')
-    dt = datetime.datetime(int(year), int(month), int(day), int(hour), int(minute))
-    tz = pytz.timezone(timezone)
-    aware_dt = tz.localize(dt, is_dst=None)
-    utc_dt = aware_dt.astimezone(pytz.utc)
-    utc = utc_dt.strftime('%H:%M')
-    # calculate utc day offset
-    naive_utc_dt = utc_dt.replace(tzinfo=None)
-    utc_day_offset = (naive_utc_dt.date() - dt.date()).days
-    html = "<span>{utc} UTC</span>".format(utc=utc)
-    if utc_day_offset != 0:
-        html = html + '<span class="day-offset"> {0:+d} Day</span>'.format(utc_day_offset)
-    context_data = {'timezone': timezone, 
-                    'time': time, 
-                    'utc': utc, 
-                    'utc_day_offset': utc_day_offset,
-                    'html': html}
-    return HttpResponse(json.dumps(context_data),
-                        content_type='application/json')
-
-
 def interim_announce(request):
     '''View which shows interim meeting requests awaiting announcement'''
     meetings = data_for_meetings_overview(Meeting.objects.filter(type='interim').order_by('date'), interim_status='scheda')

--- a/ietf/static/js/meeting-interim-request.js
+++ b/ietf/static/js/meeting-interim-request.js
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 const interimRequest = (function() {
     'use strict';
     return {
@@ -18,17 +20,14 @@ const interimRequest = (function() {
                 .on("blur", interimRequest.calculateEndTime);
             const timeInput = $('input[name$="-time"]');
             timeInput.on("blur", interimRequest.calculateEndTime);
-            timeInput.on("blur", interimRequest.updateInfo);
             $('input[name$="-end_time"]')
-                .prop('disabled', true)
-                .on("change", interimRequest.updateInfo);
+                .prop('disabled', true);
             interimRequest.timezone.on("change", interimRequest.timezoneChange);
             // init
             interimRequest.inPerson.each(interimRequest.toggleLocation);
             interimRequest.checkAddButton();
             interimRequest.initTimezone();
             timeInput.each(interimRequest.calculateEndTime);
-            timeInput.each(interimRequest.updateInfo);
             const remoteParticipations = $('select[id$="-remote_participation"]');
             remoteParticipations.on(
                 'change',
@@ -89,43 +88,6 @@ const interimRequest = (function() {
 
             $('.btn-delete')
                 .removeClass("d-none");
-        },
-
-        updateInfo: function () {
-            // makes ajax call to server and sets UTC field
-            const time = $(this)
-                .val();
-            if (!time) {
-                return;
-            }
-            const url = "/meeting/ajax/get-utc";
-            const fieldset = $(this)
-                .parents(".fieldset");
-            const date = fieldset.find("input[name$='-date']")
-                .val();
-            const timezone = interimRequest.timezone.val();
-            const name = $(this)
-                .attr("id") + "_utc";
-            const utc = fieldset.find("#" + name);
-            //console.log(name,utc.attr("id"));
-            $.ajax({
-                url: url,
-                type: 'GET',
-                cache: false,
-                async: true,
-                dataType: 'json',
-                data: {
-                    date: date,
-                    time: time,
-                    timezone: timezone
-                },
-                success: function (response) {
-                    if (!response.error && response.html) {
-                        utc.html(response.html);
-                    }
-                }
-            });
-            return false;
         },
 
         calculateEndTime: function () {

--- a/ietf/static/js/meeting-interim-request.js
+++ b/ietf/static/js/meeting-interim-request.js
@@ -1,5 +1,3 @@
-import { DateTime } from 'luxon'
-
 const interimRequest = (function() {
     'use strict';
     return {


### PR DESCRIPTION
Fixes #4883 - turns out the code using `ajax_get_utc()` had already been removed during the Bootstrap 5 conversion.