### PR TITLE
fix: Remove unused `Meeting.session_constraintnames`

### DIFF
--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -298,26 +298,6 @@ class Meeting(models.Model):
             self._proceedings_format_version = version  # save this for later
         return self._proceedings_format_version
 
-    @property
-    def session_constraintnames(self):
-        """Gets a list of the constraint names that should be used for this meeting
-
-        Anticipated that this will soon become a many-to-many relationship with ConstraintName
-        (see issue #2770). Making this a @property allows use of the .all(), .filter(), etc,
-        so that other code should not need changes when this is replaced.
-        """
-        try:
-            mtg_num = int(self.number)
-        except ValueError:
-            mtg_num = None  # should not come up, but this method should not fail
-        if mtg_num is None or mtg_num >= 106:
-            # These meetings used the old 'conflic?' constraint types labeled as though
-            # they were the new types.
-            slugs = ('chair_conflict', 'tech_overlap', 'key_participant')
-        else:
-            slugs = ('conflict', 'conflic2', 'conflic3')
-        return ConstraintName.objects.filter(slug__in=slugs)
-
     def base_url(self):
         return "/meeting/%s" % (self.number, )
 


### PR DESCRIPTION
Fixes #3389