### PR TITLE
fix: Avoid unwanted whitespace when action_holder_badge is empty

### DIFF
--- a/ietf/templates/doc/drafts_in_iesg_process.html
+++ b/ietf/templates/doc/drafts_in_iesg_process.html
@@ -55,7 +55,7 @@
                                 <br>
                                 Action holder{{ doc.documentactionholder_set.all|pluralize }}:
                                 {% for action_holder in doc.documentactionholder_set.all %}
-                                    {% person_link action_holder.person title=action_holder.role_for_doc %} {{ action_holder|action_holder_badge }}{% if not forloop.last %},{% endif %}
+                                    {% person_link action_holder.person title=action_holder.role_for_doc %}{% if action_holder|action_holder_badge %} {{ action_holder|action_holder_badge }}{% endif %}{% if not forloop.last %},{% endif %}
                                 {% endfor %}
                             {% endif %}
                             {% if doc.note %}


### PR DESCRIPTION
Cleans up case of unwanted whitespace as mentioned in #3744 