### PR TITLE
fix: case sensitivity for Subscribed.email

### DIFF
--- a/ietf/ietfauth/views.py
+++ b/ietf/ietfauth/views.py
@@ -125,8 +125,8 @@ def create_account(request):
             send_account_creation_email(request, to_email)
 
             # The following is what to revert to should that lowered barrier prove problematic
-            # existing = Subscribed.objects.filter(email=to_email).first()
-            # ok_to_create = ( Allowlisted.objects.filter(email=to_email).exists()
+            # existing = Subscribed.objects.filter(email__iexact=to_email).first()
+            # ok_to_create = ( Allowlisted.objects.filter(email__iexact=to_email).exists()
             #     or existing and (existing.time + TimeDelta(seconds=settings.LIST_ACCOUNT_DELAY)) < DateTime.now() )
             # if ok_to_create:
             #     send_account_creation_email(request, to_email)

--- a/ietf/mailinglists/management/commands/import_mailman_listinfo.py
+++ b/ietf/mailinglists/management/commands/import_mailman_listinfo.py
@@ -77,7 +77,7 @@ def import_mailman_listinfo(verbosity=0):
             to_add = members - known
             for addr in to_remove:
                     note("  Removing subscription: %s" % (addr))
-                    old = Subscribed.objects.get(email=addr)
+                    old = Subscribed.objects.get(email=addr) # Intentionally leaving this as case-sensitive in postgres
                     old.lists.remove(mmlist)
                     if old.lists.count() == 0:
                         note("    Removing address with no subscriptions: %s" % (addr))
@@ -90,7 +90,7 @@ def import_mailman_listinfo(verbosity=0):
                     continue
                 note("  Adding subscription: %s" % (addr))
                 try:
-                    new, created = Subscribed.objects.get_or_create(email=addr)
+                    new, created = Subscribed.objects.get_or_create(email=addr) # Intentionally leaving this as case-sensitive in postgres
                 except MultipleObjectsReturned as e:
                     sys.stderr.write("    **  Error handling %s in %s: %s\n" % (addr, name, e))
                     continue


### PR DESCRIPTION
Note that the Subscribed objects are not currently _used_. They used to be used as part of allowing account creation, but that logic is currently commented out (but updated with this PR in case we bring it back).