### PR TITLE
fix: Always label agenda session headers with day in meeting time zone

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -263,7 +263,7 @@ const meetingEvents = computed(() => {
         key: `sesshd-${item.id}`,
         displayType: 'session-head',
         timeslot: itemTimeSlot,
-        name: `${item.adjustedStart.toFormat('cccc')} ${item.slotName}`,
+        name: `${item.adjustedStart.setZone(agendaStore.meeting.timezone).toFormat('cccc')} ${item.slotName}`,
         cssClasses: 'agenda-table-display-session-head' + (isLive ? ' agenda-table-live' : '')
       })
     }

--- a/playwright/helpers/meeting.js
+++ b/playwright/helpers/meeting.js
@@ -121,6 +121,7 @@ let lastSessionId = 25000
 let lastRecordingId = 150000
 function createEvent ({
   name = '',
+  slotName = '',
   startDateTime,
   duration = '1h',
   area,
@@ -152,6 +153,7 @@ function createEvent ({
     acronym: group.keyword,
     duration: typeof duration === 'string' ? ms(duration) / 1000 : duration,
     name: eventName,
+    slotName: slotName,
     startDateTime: startDateTime.toISO({ includeOffset: false, suppressMilliseconds: true }),
     status,
     type,
@@ -514,7 +516,7 @@ module.exports = {
         _.times(8, () => { // 8 lanes per session time
           const { area, ...group } = daySessions.pop()
           schedule.push(createEvent({
-            name: 'Session I',
+            slotName: 'Session I',
             startDateTime: curDay.set({ hour: 10 }),
             duration: '2h',
             type: 'regular',
@@ -543,7 +545,7 @@ module.exports = {
         _.times(8, () => { // 8 lanes per session time
           const { area, ...group } = daySessions.pop()
           schedule.push(createEvent({
-            name: 'Session II',
+            slotName: 'Session II',
             startDateTime: curDay.set({ hour: 13, minute: 30 }),
             duration: '1h',
             type: 'regular',
@@ -574,7 +576,7 @@ module.exports = {
           _.times(8, () => { // 8 lanes per session time
             const { area, ...group } = daySessions.pop()
             schedule.push(createEvent({
-              name: 'Session III',
+              slotName: 'Session III',
               startDateTime: curDay.set({ hour: 15 }),
               duration: '2h',
               type: 'regular',

--- a/playwright/tests/meeting/agenda.spec.js
+++ b/playwright/tests/meeting/agenda.spec.js
@@ -138,6 +138,7 @@ test.describe('past - desktop', () => {
         .setLocale(BROWSER_LOCALE)
         .toFormat('DD \'at\' T ZZZZ')
       await expect(page.locator('.agenda h6').first()).toContainText(localDateTime)
+      await expect(page.locator('.agenda .agenda-table-display-session-head .agenda-table-cell-name').first()).toContainText('Monday Session I')
       // Switch to UTC
       await tzUtcBtnLocator.click()
       await expect(tzUtcBtnLocator).toHaveClass(/n-button--primary-type/)
@@ -148,10 +149,12 @@ test.describe('past - desktop', () => {
         .toFormat('DD \'at\' T ZZZZ')
       await expect(page.locator('.agenda h6').first()).toContainText(utcDateTime)
       await expect(page.locator('.agenda .agenda-timezone-ddn')).toContainText('UTC')
+      await expect(page.locator('.agenda .agenda-table-display-session-head .agenda-table-cell-name').first()).toContainText('Monday Session I')
       // Switch back to meeting timezone
       await tzMeetingBtnLocator.click()
       await expect(tzMeetingBtnLocator).toHaveClass(/n-button--primary-type/)
       await expect(page.locator('.agenda .agenda-timezone-ddn')).toContainText('Tokyo')
+      await expect(page.locator('.agenda .agenda-table-display-session-head .agenda-table-cell-name').first()).toContainText('Monday Session I')
     })
   })
 


### PR DESCRIPTION
Fixes #3323 (the part left in [this comment](https://github.com/ietf-tools/datatracker/issues/3323#issuecomment-1452901215))