### PR TITLE
fix: Avoid creating a .yml-r file

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -41,8 +41,9 @@ done
 rm -rf .parcel-cache __pycache__
 
 # Create extended docker-compose definition
-cp docker-compose.extend.yml docker-compose.extend-custom.yml
-sed -i -r -e "s/CUSTOM_PORT/$CUSTOM_PORT/" docker-compose.extend-custom.yml
+sed -e "s/CUSTOM_PORT/$CUSTOM_PORT/" \
+	<docker-compose.extend.yml docker-compose.extend-custom.yml \
+	>docker-compose.extend-custom.yml
 cd ..
 
 # Set UID/GID mappings

--- a/docker/run
+++ b/docker/run
@@ -42,7 +42,7 @@ rm -rf .parcel-cache __pycache__
 
 # Create extended docker-compose definition
 sed -e "s/CUSTOM_PORT/$CUSTOM_PORT/" \
-	<docker-compose.extend.yml docker-compose.extend-custom.yml \
+	<docker-compose.extend.yml \
 	>docker-compose.extend-custom.yml
 cd ..
 


### PR DESCRIPTION
These seem to be created if initial setup fails. Ignore them.

Not sure if this is something you want or not.