### PR TITLE
feat: Allow password reset with non username email address

### DIFF
--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -563,6 +563,21 @@ class IetfAuthTests(TestCase):
         self.assertIn(active_address, to)
         self.assertNotIn(person.user.username, to)
 
+    def test_reset_password_without_username(self):
+        """Reset password using non-username email address"""
+        url = urlreverse('ietf.ietfauth.views.password_reset')
+        person = PersonFactory()
+        secondary_address = EmailFactory(person=person).address
+        inactive_secondary_address = EmailFactory(person=person, active=False).address
+        empty_outbox()
+        r = self.client.post(url, { 'username': secondary_address})
+        self.assertContains(r, 'We have sent you an email with instructions', status_code=200)
+        self.assertEqual(len(outbox), 1)
+        to = outbox[0].get('To')
+        self.assertIn(person.user.username, to)
+        self.assertIn(secondary_address, to)
+        self.assertNotIn(inactive_secondary_address, to)
+
     def test_review_overview(self):
         review_req = ReviewRequestFactory()
         assignment = ReviewAssignmentFactory(review_request=review_req,reviewer=EmailFactory(person__user__username='reviewer'))

--- a/ietf/ietfauth/views.py
+++ b/ietf/ietfauth/views.py
@@ -463,6 +463,12 @@ def password_reset(request):
             # We still report that the action succeeded, so we're not leaking the existence of user
             # email addresses.
             user = User.objects.filter(username__iexact=submitted_username, person__isnull=False).first()
+            if not user:
+                # try to find user ID from the email address
+                email = Email.objects.filter(address=submitted_username).first()
+                if email and email.person and email.person.user:
+                    user = email.person.user
+
             if user and user.person.email_set.filter(active=True).exists():
                 data = {
                     'username': user.username,


### PR DESCRIPTION
This change allows password reset with any email address associated with the account.
The password reset will only be sent to the active email addresses associated with the account.

Fixes #5057