### PR TITLE
fix(doc): Replace iconography for position's email status with text label

### DIFF
--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1232,7 +1232,6 @@ class BallotContentTests(TestCase):
         self.assertEqual(len(heading), 1)
         # <div.h5> is followed by a panel with the message of interest, so use next()
         next = heading.next()
-        print(f"looking for {expected} in:\n{next}")
         self.assertEqual(
             len(next.find(
                 f'*[title="{expected}"]'

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1231,8 +1231,10 @@ class BallotContentTests(TestCase):
         heading = q(f'div.h5[id$="_{slugify(balloter.plain_name())}"]')
         self.assertEqual(len(heading), 1)
         # <div.h5> is followed by a panel with the message of interest, so use next()
+        next = heading.next()
+        print(f"looking for {expected} in:\n{next}")
         self.assertEqual(
-            len(heading.next().find(
+            len(next.find(
                 f'*[title="{expected}"]'
             )),
             1,
@@ -1409,6 +1411,6 @@ class BallotContentTests(TestCase):
             ballot_id=ballot.pk,
         )
         q = PyQuery(content)
-        self._assertBallotMessage(q, balloters[0], 'No email send requests for this discuss')
-        self._assertBallotMessage(q, balloters[1], 'No ballot position send log available')
+        self._assertBallotMessage(q, balloters[0], 'No discuss send log available')
+        self._assertBallotMessage(q, balloters[1], 'No comment send log available')
         self._assertBallotMessage(q, old_balloter, 'No ballot position send log available')

--- a/ietf/templates/doc/document_ballot_content.html
+++ b/ietf/templates/doc/document_ballot_content.html
@@ -108,18 +108,27 @@
                                 <div>
                                     <b>{{ p.pos.name }}</b>
                                     ({{ p.discuss_time|date:"Y-m-d" }}{% if not p.for_current_revision and p.get_dochistory.rev %}{% if p.discuss_time %} {% endif %}for -{{ p.get_dochistory.rev }}{% endif %})
+                                    {# TODO: This logic is in place for discusses/ballots/comments, consider centralizing somewhere #}
                                     {% if p.send_email %}
-                                        <i class="bi bi-envelope float-end"
-                                              title="Email requested to be sent for this discuss"></i>
+                                        <span class="badge rounded-pill text-bg-success float-end"
+                                              title="Email requested to be sent for this discuss">
+                                            <i class="bi bi-envelope-fill"></i> Sent
+                                        </span>
                                     {% elif p.any_email_sent == True %}
-                                        <i class="bi bi-envelope float-end"
-                                              title="Email requested to be sent for earlier discuss"></i>
+                                        <span class="badge rounded-pill text-bg-secondary float-end"
+                                              title="Email requested to be sent for earlier discuss">
+                                            <i class="bi bi-envelope-fill"></i> Sent for earlier
+                                        </span>
                                     {% elif p.any_email_sent == False %}
-                                        <i class="bi bi-chat float-end"
-                                              title="No email send requests for this discuss"></i>
+                                        <span class="badge rounded-pill text-bg-danger float-end"
+                                              title="No email send requests for this discuss">
+                                            <i class="bi bi-envelope-fill"></i> Not sent
+                                        </span>
                                     {% else %}
-                                        <i class="bi bi-chat float-end"
-                                              title="No email send requests for this discuss"></i>
+                                        <span class="badge rounded-pill text-bg-light float-end"
+                                              title="No discuss send log available">
+                                            <i class="bi bi-envelope-fill"></i> Unknown
+                                        </span>
                                     {% endif %}
                                 </div>
                             </div>
@@ -135,17 +144,25 @@
                                     <b>Comment</b>
                                     ({{ p.comment_time|date:"Y-m-d" }}{% if not p.for_current_revision and p.get_dochistory.rev %}{% if p.comment_time %} {% endif %}for -{{ p.get_dochistory.rev }}{% endif %})
                                     {% if p.send_email %}
-                                        <i class="bi bi-envelope-check float-end"
-                                              title="Email requested to be sent for this comment"></i>
+                                        <span class="badge rounded-pill text-bg-success float-end"
+                                              title="Email requested to be sent for this comment">
+                                            <i class="bi bi-envelope-fill"></i> Sent
+                                        </span>
                                     {% elif p.any_email_sent == True %}
-                                        <i class="bi bi-envelope-plus float-end"
-                                              title="Email requested to be sent for earlier comment"></i>
+                                        <span class="badge rounded-pill text-bg-secondary float-end"
+                                              title="Email requested to be sent for earlier comment">
+                                            <i class="bi bi-envelope-fill"></i> Sent for earlier
+                                        </span>
                                     {% elif p.any_email_sent == False %}
-                                        <i class="bi bi-envelope-dash float-end"
-                                              title="No email send requests for this comment"></i>
+                                        <span class="badge rounded-pill text-bg-danger float-end"
+                                              title="No email send requests for this comment">
+                                            <i class="bi bi-envelope-fill"></i> Not sent
+                                        </span>
                                     {% else %}
-                                        <i class="bi bi-envelope-exclamation float-end"
-                                              title="No ballot position send log available"></i>
+                                        <span class="badge rounded-pill text-bg-light float-end"
+                                              title="No comment send log available">
+                                            <i class="bi bi-envelope-fill"></i> Unknown
+                                        </span>
                                     {% endif %}
                                 </div>
                             </div>
@@ -188,17 +205,27 @@
                                     ({{ p.comment_time|date:"Y-m-d" }}{% if not p.for_current_revision and p.get_dochistory.rev %}{% if p.comment_time %} {% endif %}for -{{ p.get_dochistory.rev }}{% endif %})
                                 {% endif %}
                                 {% if p.send_email %}
-                                    <i class="bi bi-envelope float-end"
-                                          title="Email requested to be sent for this ballot position"></i>
+                                    <span class="badge rounded-pill text-bg-success float-end"
+                                          title="Email requested to be sent for this ballot position">
+                                        <i class="bi bi-envelope-fill"></i> Sent
+                                    </span>
                                 {% elif p.any_email_sent == True %}
-                                    <i class="bi bi-envelope float-end"
-                                          title="Email requested to be sent for earlier ballot position"></i>
+                                    <span class="badge rounded-pill text-bg-secondary float-end"
+                                            title="Email requested to be sent for earlier ballot position">
+                                        <i class="bi bi-envelope-fill"></i> Sent for earlier
+                                    </span>
                                 {% elif p.any_email_sent == False %}
-                                    <i class="bi bi-chat float-end"
-                                          title="No email send requests for this ballot position"></i>
+                                    <span class="badge rounded-pill text-bg-danger float-end"
+                                          title="No email send requests for this ballot position">
+                                        <i class="bi bi-envelope-fill"></i> Not sent
+                                    </span>
                                 {% else %}
-                                    <i class="bi bi-envelope-slash float-end"
-                                          title="No ballot position send log available"></i>
+                                    <!-- <i class="bi bi-envelope-slash float-end"
+                                          title="No ballot position send log available"></i> -->
+                                    <span class="badge rounded-pill text-bg-light float-end"
+                                          title="No ballot position send log available">
+                                        <i class="bi bi-envelope-fill"></i> Unknown
+                                    </span>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
Positions within a ballot, discuss, or comment within DT may-or-may-not have an email notification associated with them. This is at the discretion of the submitter, and is indicated within DT to viewers of the thread.

Previously, this was indicated via an icon+tooltip on the specific position, using an icon which was less-than-readable (especially on low-DPI/small displays).

This change replaces that iconography with a text pill, while retaining the previous tooltip for additional information.

Closes #3855.