### PR TITLE
fix: move meeting management items from base menu Documents tab to Meetings tab (fixes #3897 and #4005)

### DIFF
--- a/ietf/templates/base/menu.html
+++ b/ietf/templates/base/menu.html
@@ -145,14 +145,6 @@
                     </a>
                 </li>
             {% endfor %}
-            {% for g in user|matman_groups %}
-                <li>
-                    <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
-                       href="{% url "ietf.group.views.meetings" g.acronym %}">
-                        {{ g.acronym }} {{ g.type.slug }} meetings
-                    </a>
-                </li>
-            {% endfor %}
         {% endif %}
         {% if user|has_role:"Review Team Secretary" %}
             {% if flavor == 'top' %}
@@ -270,18 +262,41 @@
             Important dates
         </a>
     </li>
-    <li>
-        <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
-           href="{% url 'ietf.secr.sreq.views.main' %}">
-            Request a session
-        </a>
-    </li>
-    <li>
-        <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
-           href="{% url 'ietf.meeting.views.meeting_requests' %}">
-            Session requests
-        </a>
-    </li>
+    {% if user|has_role:"WG Chair,WG Secretary,RG Chair,IAB Group Chair,Area Director,Secretariat,Team Chair,IRTF Chair,Program Chair,Program Lead,Program Secretary,EDWG Chair" %}
+        <li>
+            <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+               href="{% url 'ietf.secr.sreq.views.main' %}">
+                Request a session
+            </a>
+        </li>
+    {% endif %}
+    {% if user|has_role:"WG Chair,RG Chair" %}
+        <li>
+            <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+               href="{% url 'ietf.meeting.views.interim_request' %}">
+                Request an interim meeting
+            </a>
+        </li>
+    {% endif %}
+        <li>
+            <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+               href="{% url 'ietf.meeting.views.meeting_requests' %}">
+                Session requests
+            </a>
+        </li>
+    {% if user|has_role:"WG Chair,RG Chair" %}
+        {% if flavor == 'top' %}<li><hr class="dropdown-divider"></li>{% endif %}
+        <li {% if flavor == 'top' %}class="dropdown-header"{% else %}class="nav-item fw-bolder"{% endif %}>Manage</li>
+            {% for g in user|matman_groups %}
+                <li>
+                    <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+                       href="{% url "ietf.group.views.meetings" g.acronym %}">
+                        {{ g.acronym }} {{ g.type.slug }} meetings
+                    </a>
+                </li>
+            {% endfor %}
+    {% endif %}
+
     {% if flavor == 'top' %}
         {% if flavor == 'top' %}
             <li><hr class="dropdown-divider">


### PR DESCRIPTION
Rearranges elements of the optional Manage block in Documents so that they appear in Meetings instead. This is for things like "xxxx wg meetings". Also, put role restrictions around whether "Request a session" and "Request an interim meeting" appear under the Meetings tab.
