### PR TITLE
fix: display last year reviews in the profile

### DIFF
--- a/ietf/person/models.py
+++ b/ietf/person/models.py
@@ -25,6 +25,7 @@ from django.utils.text import slugify
 from simple_history.models import HistoricalRecords
 
 import debug                            # pyflakes:ignore
+import datetime
 
 from ietf.name.models import ExtResourceName
 from ietf.person.name import name_parts, initials, plain_name
@@ -202,7 +203,6 @@ class Person(models.Model):
 
     def expired_drafts(self):
         from ietf.doc.models import Document
-
         return (
             Document.objects.filter(
                 documentauthor__person=self,
@@ -213,6 +213,16 @@ class Person(models.Model):
             .distinct()
             .order_by("-time")
         )
+
+    def completed_reviews(self):
+        from ietf.doc.models import Document
+        # should also filter on time
+        # states__slug='completed' does not seem to work
+        completed_reviews = list(Document.objects.filter(documentauthor__person=self, type='review', states__slug='active'))
+        year_ago = timezone.now() - datetime.timedelta(weeks=52)
+        last_reviews = [ r for r in completed_reviews if r.time >= year_ago ]
+        last_reviews.sort(key=lambda d: d.time)
+        return last_reviews
 
     def save(self, *args, **kwargs):
         created = not self.pk

--- a/ietf/templates/person/profile.html
+++ b/ietf/templates/person/profile.html
@@ -165,6 +165,21 @@
             <div id="chart-{{ forloop.counter }}">
             </div>
         {% endif %}
+        <h2 class="mt-5" id="reviews-{{ forloop.counter }}">
+            Directorate Reviews In The Last Year <small class="text-muted">({{ person.completed_reviews|length }})</small>
+        </h2>
+        {% if person.completed_reviews|length > 0 %}
+            <ul>
+                {% for doc in person.completed_reviews %}
+                    <li>
+                        <a href="{{ doc.get_absolute_url }}">{{ doc.title }}</a> on {{ doc.time}}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            {{ person.first_name }} has not done any review in the last year.
+        {% endif %}
+
     {% endfor %}
 {% endblock %}
 {% block js %}


### PR DESCRIPTION
Replacing #4768 to use the recent feat/postgres

 Fixes #4706 : display a limited amount of directorate reviews.

Goal is to give some recognitions (or even incentives) to active directorate reviewers.

As discussed with @cjbc @jgscudder @AndrewAlston and a few others