### PR TITLE
fix: Do not add user to the top of queue after reject (fixes #4505)

### DIFF
--- a/ietf/doc/views_review.py
+++ b/ietf/doc/views_review.py
@@ -347,6 +347,7 @@ def assign_reviewer(request, name, request_id):
 
 class RejectReviewerAssignmentForm(forms.Form):
     message_to_secretary = forms.CharField(widget=forms.Textarea, required=False, help_text="Optional explanation of rejection, will be emailed to team secretary if filled in", strip=False)
+    wants_to_be_next = forms.BooleanField(label="I want to be assigned new document immediately", required=False)
 
 @login_required
 def reject_reviewer_assignment(request, name, assignment_id):
@@ -388,11 +389,12 @@ def reject_reviewer_assignment(request, name, assignment_id):
             )
 
             policy = get_reviewer_queue_policy(review_assignment.review_request.team)
-            policy.return_reviewer_to_rotation_top(review_assignment.reviewer.person)
+            policy.return_reviewer_to_rotation_top(review_assignment.reviewer.person, form.cleaned_data['wants_to_be_next'])
 
             msg = render_to_string("review/reviewer_assignment_rejected.txt", {
                 "by": request.user.person,
-                "message_to_secretary": form.cleaned_data.get("message_to_secretary")
+                "message_to_secretary": form.cleaned_data.get("message_to_secretary"),
+                "wants_to_be_next" : form.cleaned_data['wants_to_be_next']
             })
 
             email_review_assignment_change(request, review_assignment, "Reviewer assignment rejected", msg, by=request.user.person, notify_secretary=True, notify_reviewer=True, notify_requested_by=False)
@@ -438,7 +440,7 @@ def withdraw_reviewer_assignment(request, name, assignment_id):
         )            
 
         policy = get_reviewer_queue_policy(review_assignment.review_request.team)
-        policy.return_reviewer_to_rotation_top(review_assignment.reviewer.person)
+        policy.return_reviewer_to_rotation_top(review_assignment.reviewer.person, True)
         
         msg = "Review assignment withdrawn by %s"%request.user.person
 

--- a/ietf/review/policies.py
+++ b/ietf/review/policies.py
@@ -476,9 +476,10 @@ class RotateAlphabeticallyReviewerQueuePolicy(AbstractReviewerQueuePolicy):
         # As RotateAlphabetically does not keep a full rotation list,
         # returning someone to a particular order is complex.
         # Instead, the "assign me next" flag is set.
-        settings = self._reviewer_settings_for(reviewer_person)
-        settings.request_assignment_next = wants_to_be_next
-        settings.save()
+        if wants_to_be_next:
+            settings = self._reviewer_settings_for(reviewer_person)
+            settings.request_assignment_next = wants_to_be_next
+            settings.save()
 
     def _update_skip_next(self, rotation_pks, assignee_person):
         """Decrement skip_next for all users skipped
@@ -570,7 +571,10 @@ class LeastRecentlyUsedReviewerQueuePolicy(AbstractReviewerQueuePolicy):
         # Reviewer rotation for this policy ignores rejected/withdrawn
         # reviews, so it automatically adjusts the position of someone
         # who rejected a review and no further action is needed.
-        pass
+        if wants_to_be_next:
+            settings = self._reviewer_settings_for(reviewer_person)
+            settings.request_assignment_next = wants_to_be_next
+            settings.save()
 
 
 QUEUE_POLICY_NAME_MAPPING = {

--- a/ietf/review/policies.py
+++ b/ietf/review/policies.py
@@ -84,7 +84,7 @@ class AbstractReviewerQueuePolicy:
             rotation_list = self._filter_unavailable_reviewers(rotation_list)
         return rotation_list
 
-    def return_reviewer_to_rotation_top(self, reviewer_person):
+    def return_reviewer_to_rotation_top(self, reviewer_person, wants_to_be_next):
         """
         Return a reviewer to the top of the rotation, e.g. because they rejected a review,
         and should retroactively not have been rotated over.
@@ -472,12 +472,12 @@ class RotateAlphabeticallyReviewerQueuePolicy(AbstractReviewerQueuePolicy):
     
         return reviewers[next_reviewer_index:] + reviewers[:next_reviewer_index]
 
-    def return_reviewer_to_rotation_top(self, reviewer_person):
+    def return_reviewer_to_rotation_top(self, reviewer_person, wants_to_be_next):
         # As RotateAlphabetically does not keep a full rotation list,
         # returning someone to a particular order is complex.
         # Instead, the "assign me next" flag is set.
         settings = self._reviewer_settings_for(reviewer_person)
-        settings.request_assignment_next = True
+        settings.request_assignment_next = wants_to_be_next
         settings.save()
 
     def _update_skip_next(self, rotation_pks, assignee_person):
@@ -566,7 +566,7 @@ class LeastRecentlyUsedReviewerQueuePolicy(AbstractReviewerQueuePolicy):
         rotation_list += reviewers_with_assignment
         return rotation_list
 
-    def return_reviewer_to_rotation_top(self, reviewer_person):
+    def return_reviewer_to_rotation_top(self, reviewer_person, wants_to_be_next):
         # Reviewer rotation for this policy ignores rejected/withdrawn
         # reviews, so it automatically adjusts the position of someone
         # who rejected a review and no further action is needed.

--- a/ietf/review/tests_policies.py
+++ b/ietf/review/tests_policies.py
@@ -115,7 +115,7 @@ class _Wrapper(TestCase):
             return (ReviewerSettings.objects.filter(team=self.team, person=person).first()
                     or ReviewerSettings(team=self.team, person=person))
 
-        def test_return_reviewer_to_rotation_top(self):
+        def test_return_reviewer_to_rotation_top(self, reviewer, wants_to_be_next):
             # Subclass must implement this
             raise NotImplementedError
 
@@ -507,9 +507,9 @@ class RotateAlphabeticallyReviewerQueuePolicyTest(_Wrapper.ReviewerQueuePolicyTe
         rotation = self.policy.default_reviewer_rotation_list()
         self.assertEqual(rotation, available_reviewers[2:] + available_reviewers[:1])
 
-    def test_return_reviewer_to_rotation_top(self):
+    def test_return_reviewer_to_rotation_top(self, person, wants_to_be_next):
         reviewer = self.append_reviewer()
-        self.policy.return_reviewer_to_rotation_top(reviewer)
+        self.policy.return_reviewer_to_rotation_top(reviewer, wants_to_be_next)
         self.assertTrue(ReviewerSettings.objects.get(person=reviewer).request_assignment_next)
 
     def test_update_policy_state_for_assignment(self):
@@ -723,9 +723,9 @@ class LeastRecentlyUsedReviewerQueuePolicyTest(_Wrapper.ReviewerQueuePolicyTestC
         self.assertEqual(self.policy.default_reviewer_rotation_list(),
                          available_reviewers[2:] + [first_reviewer, second_reviewer])
 
-    def test_return_reviewer_to_rotation_top(self):
+    def test_return_reviewer_to_rotation_top(self, reviewer, wants_to_be_next):
         # Should do nothing, this is implicit in this policy, no state change is needed.
-        self.policy.return_reviewer_to_rotation_top(self.append_reviewer())
+        self.policy.return_reviewer_to_rotation_top(self.append_reviewer(), wants_to_be_next)
 
     def test_assign_reviewer_updates_skip_next_without_add_skip(self):
         """Skipping reviewers with add_skip=False should update skip_counts properly"""

--- a/ietf/review/tests_policies.py
+++ b/ietf/review/tests_policies.py
@@ -115,7 +115,7 @@ class _Wrapper(TestCase):
             return (ReviewerSettings.objects.filter(team=self.team, person=person).first()
                     or ReviewerSettings(team=self.team, person=person))
 
-        def test_return_reviewer_to_rotation_top(self, reviewer, wants_to_be_next):
+        def test_return_reviewer_to_rotation_top(self):
             # Subclass must implement this
             raise NotImplementedError
 
@@ -507,10 +507,12 @@ class RotateAlphabeticallyReviewerQueuePolicyTest(_Wrapper.ReviewerQueuePolicyTe
         rotation = self.policy.default_reviewer_rotation_list()
         self.assertEqual(rotation, available_reviewers[2:] + available_reviewers[:1])
 
-    def test_return_reviewer_to_rotation_top(self, person, wants_to_be_next):
+    def test_return_reviewer_to_rotation_top(self):
         reviewer = self.append_reviewer()
-        self.policy.return_reviewer_to_rotation_top(reviewer, wants_to_be_next)
-        self.assertTrue(ReviewerSettings.objects.get(person=reviewer).request_assignment_next)
+        self.policy.return_reviewer_to_rotation_top(reviewer, False)
+        self.assertFalse(self.reviewer_settings_for(reviewer).request_assignment_next)
+        self.policy.return_reviewer_to_rotation_top(reviewer, True)
+        self.assertTrue(self.reviewer_settings_for(reviewer).request_assignment_next)
 
     def test_update_policy_state_for_assignment(self):
         # make a bunch of reviewers
@@ -723,9 +725,12 @@ class LeastRecentlyUsedReviewerQueuePolicyTest(_Wrapper.ReviewerQueuePolicyTestC
         self.assertEqual(self.policy.default_reviewer_rotation_list(),
                          available_reviewers[2:] + [first_reviewer, second_reviewer])
 
-    def test_return_reviewer_to_rotation_top(self, reviewer, wants_to_be_next):
-        # Should do nothing, this is implicit in this policy, no state change is needed.
-        self.policy.return_reviewer_to_rotation_top(self.append_reviewer(), wants_to_be_next)
+    def test_return_reviewer_to_rotation_top(self):
+        reviewer = self.append_reviewer()
+        self.policy.return_reviewer_to_rotation_top(reviewer, False)
+        self.assertFalse(self.reviewer_settings_for(reviewer).request_assignment_next)
+        self.policy.return_reviewer_to_rotation_top(reviewer, True)
+        self.assertTrue(self.reviewer_settings_for(reviewer).request_assignment_next)
 
     def test_assign_reviewer_updates_skip_next_without_add_skip(self):
         """Skipping reviewers with add_skip=False should update skip_counts properly"""

--- a/ietf/templates/review/reviewer_assignment_rejected.txt
+++ b/ietf/templates/review/reviewer_assignment_rejected.txt
@@ -3,4 +3,9 @@
 Explanation:
 
 {{ message_to_secretary }}
-{% endif %}{% endautoescape %}
+
+{% endif %}
+{% if wants_to_be_next %}
+User requested to be next in queue.
+{% endif %}
+{% endautoescape %}


### PR DESCRIPTION
Added a checkbox in the reject review dialog to ask whether user wants to be added to the top of the queue or not. Default is off.