### PR TITLE
fix: Don't disable mouse hover UI functionality on touch screens

### DIFF
--- a/ietf/static/js/ietf.js
+++ b/ietf/static/js/ietf.js
@@ -141,10 +141,8 @@ $(document)
                     attachTo.append(menu.join(""));
                 }
 
-                if (!("ontouchstart" in document.documentElement)) {
-                    $("ul.nav li.dropdown, ul.nav li.dropend")
-                        .on("mouseenter mouseleave", dropdown_hover);
-                }
+                $("ul.nav li.dropdown, ul.nav li.dropend")
+                    .on("mouseenter mouseleave", dropdown_hover);
             }
         });
     });


### PR DESCRIPTION
Because devices can have both touch and mouse input.