### PR TITLE
feat!: Use postgresql instead of mysqldb

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -75,14 +75,10 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'NAME': 'ietf_utf8',
-        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'datatracker',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'USER': 'ietf',
-        #'PASSWORD': 'ietf',
-        'OPTIONS': {
-            'sql_mode': 'STRICT_TRANS_TABLES',
-            'init_command': 'SET storage_engine=MyISAM; SET names "utf8"'
-        },
+        #'PASSWORD': 'somepassword',
     },
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The underlying database is now postgresql.