### PR TITLE
fix: Remove useless directives for Updates/Obsoletes

### DIFF
--- a/ietf/static/css/document_html_txt.scss
+++ b/ietf/static/css/document_html_txt.scss
@@ -1,4 +1,4 @@
-// Based on https://github.com/martinthomson/rfc-css/blob/ea8e9e34897bf6bdb6b1b7cf336f9aa25f576d76/rfc.css
+// Based on https://github.com/martinthomson/rfc-txt-html/blob/db4be92247979541cd26a32b7b2bf0e044ca098b/txt.css
 // (Version hash to make future merging easier.)
 
 :root {
@@ -45,13 +45,6 @@
   margin-bottom: var(--line);
   margin-left: 3ch;
 
-  section > p, section > dl.references > dd {
-  /* Really long lines can wrap when all else fails.
-   * This won't affect <pre> or <table>, or cases where soft-wrapping occurs.
-   * Mostly this exists so that long URLs wrap properly in Safari, which
-   * doesn't break words at '/' like other browsers. */
-  overflow-wrap: break-word;
-  }
 
 h1, h2, h3, h4, h5 {
   font-weight: bold;
@@ -133,7 +126,6 @@ blockquote {
 }
 #identifiers dd.obsoletes {
   padding-left: 10ch;
-  width: 37ch;
 }
 #identifiers dd.updates::before {
   content: "Updates:";
@@ -141,7 +133,6 @@ blockquote {
 }
 #identifiers dd.updates {
   padding-left: 8ch;
-  width: 39ch;
 }
 #identifiers dd:is(.updates, .obsoletes) a {
   margin: 0 0 0 1ch;
@@ -449,5 +440,14 @@ address .tel, address .email {
 }
 address .tel + .email {
   margin: 0;
+}
+
+/* haxx */
+section > p, section > dl.references > dd {
+  /* Really long lines can wrap when all else fails.
+   * This won't affect <pre> or <table>, or cases where soft-wrapping occurs.
+   * Mostly this exists so that long URLs wrap properly in Safari, which
+   * doesn't break words at '/' like other browsers. */
+  overflow-wrap: break-word;
 }
 }


### PR DESCRIPTION
These only unnecessarily narrow the space available. See RFC 8996 for an example of where that might matter.

I updated the link in the top of the file, which pointed at a different CSS file.  I checked the diff and the only difference is in the expanded margin/padding rules.

I also moved the haxx to the same location as the source file.  