### PR TITLE
fix: Handle integrity violations when confirming email address

### DIFF
--- a/ietf/templates/registration/confirm_new_email.html
+++ b/ietf/templates/registration/confirm_new_email.html
@@ -13,9 +13,15 @@
         <a class="btn btn-primary my-3"
            href="{% url "ietf.ietfauth.views.profile" %}">Edit profile</a>
     {% elif new_email_obj %}
-        <p class="alert alert-success my-3">
-            Your account {{ username }} has been updated to include the email address {{ email|linkify }}.
-        </p>
+        {% if already_confirmed %} 
+            <p class="alert alert-info my-3">
+                Your account {{ username }} already includes the email address {{ email|linkify }}.
+            </p>
+        {% else %}
+            <p class="alert alert-success my-3">
+                Your account {{ username }} has been updated to include the email address {{ email|linkify }}.
+            </p>
+        {% endif %}
         <a class="btn btn-primary my-3"
            href="{% url "ietf.ietfauth.views.profile" %}">Edit profile</a>
     {% else %}


### PR DESCRIPTION
This avoids server errors when an email confirmation link is used more than once or when the confirmed email address is in use for another User.

The latter case is mostly prevented by the user edit views, but can come up if there are concurrent attempts to add the same address to two different Users.