### PR TITLE
fix: show htmlized views of draft revisions without DocHistory

### DIFF
--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -617,7 +617,9 @@ Man                    Expires September 22, 2015               [Page 3]
                 f.write(self.draft_text)
 
     def test_document_draft(self):
-        draft = WgDraftFactory(name='draft-ietf-mars-test',rev='01')
+        draft = WgDraftFactory(name='draft-ietf-mars-test',rev='01', create_revisions=range(0,2))
+
+
         HolderIprDisclosureFactory(docs=[draft])
         
         # Docs for testing relationships. Does not test 'possibly-replaces'. The 'replaced_by' direction
@@ -785,6 +787,7 @@ Man                    Expires September 22, 2015               [Page 3]
         self.assertEqual(len(q('#sidebar option[value="draft-ietf-mars-test-00"][selected="selected"]')), 1)
 
         rfc = WgRfcFactory()
+        rfc.save_with_history([DocEventFactory(doc=rfc)])
         (Path(settings.RFC_PATH) / rfc.get_base_name()).touch()
         r = self.client.get(urlreverse("ietf.doc.views_doc.document_html", kwargs=dict(name=rfc.canonical_name())))
         self.assertEqual(r.status_code, 200)

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -244,7 +244,7 @@ def document_main(request, name, rev=None, document_html=False):
         is_author = request.user.is_authenticated and doc.documentauthor_set.filter(person__user=request.user).exists()
         can_view_possibly_replaces = can_edit_replaces or is_author
 
-        rfc_number = name[3:] if name.startswith("") else None
+        rfc_number = name[3:] if name.startswith("rfc") else None
         draft_name = None
         for a in aliases:
             if a.startswith("draft"):
@@ -493,7 +493,7 @@ def document_main(request, name, rev=None, document_html=False):
             diff_revisions=get_diff_revisions(request, name, doc if isinstance(doc,Document) else doc.doc)
             simple_diff_revisions = [t[1] for t in diff_revisions]
             simple_diff_revisions.reverse()
-            if rev != doc.rev: 
+            if not doc.is_rfc() and rev != doc.rev: 
                 # No DocHistory was found matching rev - snapshot will be false
                 # and doc will be a Document object, not a DocHistory
                 snapshot = True
@@ -871,7 +871,7 @@ def document_html(request, name, rev=None):
     if not os.path.exists(doc.get_file_name()):
         raise Http404("File not found: %s" % doc.get_file_name())
 
-    return document_main(request, name=doc.name, rev=doc.rev if not doc.is_rfc() else None, document_html=True)
+    return document_main(request, name=doc.canonical_name(), rev=doc.rev if not doc.is_rfc() else None, document_html=True)
 
 def document_pdfized(request, name, rev=None, ext=None):
 


### PR DESCRIPTION
fixes #4933 