### PR TITLE
chore: Upgrade to Django 4.1

### DIFF
--- a/ietf/review/policies.py
+++ b/ietf/review/policies.py
@@ -183,9 +183,12 @@ class AbstractReviewerQueuePolicy:
             role__group=review_req.team
         ).exclude( person_id__in=rejecting_reviewer_ids )
 
-        one_assignment = (review_req.reviewassignment_set
-                          .exclude(state__slug__in=('rejected', 'no-response'))
-                          .first())
+        one_assignment = None
+        if review_req.pk is not None:
+            # cannot use reviewassignment_set relation until review_req has been created
+            one_assignment = (review_req.reviewassignment_set
+                              .exclude(state__slug__in=('rejected', 'no-response'))
+                              .first())
         if one_assignment:
             field.initial = one_assignment.reviewer_id
 

--- a/ietf/review/utils.py
+++ b/ietf/review/utils.py
@@ -382,7 +382,8 @@ def assign_review_request_to_reviewer(request, review_req, reviewer, add_skip=Fa
     # with a different view on a ReviewAssignment.
     log.assertion('reviewer is not None')
 
-    if review_req.reviewassignment_set.filter(reviewer=reviewer).exists():
+    # cannot reference reviewassignment_set relation until pk exists
+    if review_req.pk is not None and review_req.reviewassignment_set.filter(reviewer=reviewer).exists():
         return
 
     # Note that assigning a review no longer unassigns other reviews

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -716,13 +716,13 @@ CACHE_MIDDLEWARE_KEY_PREFIX = ''
 # This setting is possibly overridden further down, after the import of settings_local
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': '127.0.0.1:11211',
         'VERSION': __version__,
         'KEY_PREFIX': 'ietf:dt',
     },
     'sessions': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': '127.0.0.1:11211',
         # No release-specific VERSION setting.
         'KEY_PREFIX': 'ietf:dt',

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -209,7 +209,7 @@ class TemplateChecksTestCase(TestCase):
         errors = []
         for path, template in self.templates.items():
             origin = str(template.origin).replace(settings.BASE_DIR, '')
-            for node in template:
+            for node in template.nodelist:
                 for child in node.get_nodes_by_type(node_type):
                     errors += func(child, origin, *args, **kwargs)
         if errors:

--- a/patch/django-cookie-delete-with-all-settings.patch
+++ b/patch/django-cookie-delete-with-all-settings.patch
@@ -11,7 +11,7 @@
  
 --- django/http/response.py.orig	2020-08-13 11:16:04.060627793 +0200
 +++ django/http/response.py	2020-08-13 11:54:03.482476973 +0200
-@@ -261,20 +261,28 @@
+@@ -279,20 +279,28 @@
          value = signing.get_cookie_signer(salt=key + salt).sign(value)
          return self.set_cookie(key, value, **kwargs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ coverage>=4.5.4,<5.0    # Coverage 5.x moves from a json database to SQLite.  Mo
 decorator>=5.1.1
 types-decorator>=5.1.1
 defusedxml>=0.7.1    # for TastyPie when using xml; not a declared dependency
-Django<4.1
+Django<4.2
 django-analytical>=3.1.0
 django-bootstrap5>=21.3
 django-celery-beat>=2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pyquery>=1.4.3
 python-dateutil>=2.8.2
 types-python-dateutil>=2.8.2
 python-magic==0.4.18    # Versions beyond the yanked .19 and .20 introduce form failures
-python-memcached>=1.59    # for django.core.cache.backends.memcached
+pymemcache>=4.0.0  # for django.core.cache.backends.memcached.PyMemcacheCache 
 python-mimeparse>=1.6    # from TastyPie
 pytz==2022.2.1   # Pinned as changes need to be vetted for their effect on Meeting fields
 requests>=2.27.1


### PR DESCRIPTION
Easier upgrade than the last few. Major change is changing the memcache backend, necessitated by the removal of the one we had been using. As far as I can tell, this is transparent as far as configuration, but I'm not sure how to test to confirm this explicitly.