### PR TITLE
fix: optimize queries for DocumentChangesFeed

### DIFF
--- a/ietf/doc/feeds.py
+++ b/ietf/doc/feeds.py
@@ -45,7 +45,7 @@ class DocumentChangesFeed(Feed):
         return "History of change entries for %s." % obj.display_name()
 
     def items(self, obj):
-        events = obj.docevent_set.all().order_by("-time","-id")
+        events = obj.docevent_set.all().order_by("-time","-id").select_related("by", "newrevisiondocevent", "submissiondocevent")
         augment_events_with_revision(obj, events)
         return events
 


### PR DESCRIPTION
Anecdote:

For `/feed/document-changes/draft-ietf-roll-useofrplinfo`, this cuts the number of queries from 1037 to 7, and reduces the overall time it takes to render the view to 31% of the current code in main.

Several other places pass a list instead of a queryset into `augment_events_with_revision`. If they can be modified to pass a queryset, they'll see a similar performance increase.