### PR TITLE
Improve parsing of hyphenated titles broken across lines

### DIFF
--- a/ietf/utils/draft.py
+++ b/ietf/utils/draft.py
@@ -1106,8 +1106,9 @@ class PlaintextDraft(Draft):
             title = match.group(1)
             title = title.strip()
             title = re.sub(r'(?s)\n\s*\<?draft-.*$','', title)
-            title = re.sub(r'\s*\n\s*', ' ', title)
-            title = re.sub(r' +', ' ', title)
+            title = re.sub(r'-\s*\n\s*', '-', title)  # replace line break preceded by hyphen with hyphen
+            title = re.sub(r'\s*\n\s*', ' ', title)  # replace other line breaks with single space
+            title = re.sub(r' +', ' ', title)  # collapse multiple spaces
             self._title = title
             return self._title
         self.errors["title"] = "Could not find the title on the first page."

--- a/ietf/utils/draft.py
+++ b/ietf/utils/draft.py
@@ -1103,15 +1103,18 @@ class PlaintextDraft(Draft):
         if not match:
             match = re.search(r'(?i)(.+\n|.+\n.+\n)(\s*status of this memo\s*\n)', self.pages[0])
         if match:
-            title = match.group(1)
-            title = title.strip()
-            title = re.sub(r'(?s)\n\s*\<?draft-.*$','', title)
-            title = re.sub(r'-\s*\n\s*', '-', title)  # replace line break preceded by hyphen with hyphen
-            title = re.sub(r'\s*\n\s*', ' ', title)  # replace other line breaks with single space
-            title = re.sub(r' +', ' ', title)  # collapse multiple spaces
-            self._title = title
+            self._title = self._fixup_title(match.group(1))
             return self._title
         self.errors["title"] = "Could not find the title on the first page."
+
+    @staticmethod
+    def _fixup_title(title):
+        title = title.strip()
+        title = re.sub(r'(?s)\n\s*\<?draft-.*$', '', title)
+        title = re.sub(r'-\s*\n\s*', '-', title)  # replace line break preceded by hyphen with hyphen
+        title = re.sub(r'\s*\n\s*', ' ', title)  # replace other line breaks with single space
+        title = re.sub(r' +', ' ', title)  # collapse multiple spaces
+        return title
 
     # ------------------------------------------------------------------
     def get_refs(self):

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -366,6 +366,25 @@ class PlaintextDraftTests(TestCase):
         self.assertEqual(getmeta(filename)['docdeststatus'],'Informational')
         shutil.rmtree(tempdir)
 
+    def test_fixup_title(self):
+        # testing the _fixup_title() helper instead of get_title() because it's difficult to
+        # set up the tests for the latter.
+        self.assertEqual(PlaintextDraft._fixup_title("  Simple title  "), "Simple title")
+        self.assertEqual(PlaintextDraft._fixup_title("  Title  with double spaces  "), "Title with double spaces")
+        self.assertEqual(
+            PlaintextDraft._fixup_title("  Longer title  \n  with a line break  "),
+            "Longer title with a line break",
+        )
+        self.assertEqual(
+            PlaintextDraft._fixup_title("  Hyphenated-title  \n  not split at hyphen  "),
+            "Hyphenated-title not split at hyphen",
+        )
+        self.assertEqual(
+            PlaintextDraft._fixup_title("  This hyphenated-  \n  title is split at hyphen  "),
+            "This hyphenated-title is split at hyphen",
+        )
+
+
 
 class XMLDraftTests(TestCase):
     def test_get_refs_v3(self):


### PR DESCRIPTION
This fixes #5691.

As noted in https://github.com/ietf-tools/datatracker/issues/5691#issuecomment-1563477805, this does not handle all cases of hyphens at line breaks correctly. I think this change will do the right thing for the more common case, though, so is a net improvement.