### PR TITLE
fix: use v59.0 options for WeasyPrint

### DIFF
--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -644,7 +644,7 @@ class DocumentInfo(models.Model):
                     stylesheets=stylesheets,
                     font_config=font_config,
                     presentational_hints=True,
-                    optimize_size=("fonts", "images"),
+                    optimize_images=True,
                 )
             except AssertionError:
                 pdf = None


### PR DESCRIPTION
`optimize_size` has been deprecated and split into different options.

(Some of them may be interesting for you, see [documentation](https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#weasyprint.DEFAULT_OPTIONS) and [changelog](https://doc.courtbouillon.org/weasyprint/stable/changelog.html#version-59-0b1)!)