### PR TITLE
fix: /meeting/materials splits out named sessions the same way /meeting/proceedings does

### DIFF
--- a/ietf/templates/meeting/group_materials.html
+++ b/ietf/templates/meeting/group_materials.html
@@ -5,118 +5,96 @@
 {% load tz %}
 <tr>
     <td>
-        {% if session.name %}
-            <div id="{{ session.name|slugify }}">{{ session.name }}</div>
+        {% if entry.name %}
+            <div id="{{ entry.name|slugify }}">{{ entry.name }}</div>
         {% else %}
-            <div id="{{ session.group.acronym }}">
-                <a href="{% url 'ietf.group.views.group_home' acronym=session.group.acronym %}">{{ session.group.acronym }}</a>
+            <div id="{{ entry.group.acronym }}">
+                <a href="{% url 'ietf.group.views.group_home' acronym=entry.group.acronym %}">{{ entry.group.acronym }}</a>
             </div>
-            {% if session.group.state.slug == "bof" %}
-                <span class="badge rounded-pill bg-success">{{ session.group.state.slug|upper }}</span>
+            {% if entry.group.state.slug == "bof" %}
+                <span class="badge rounded-pill bg-success">{{ entry.group.state.slug|upper }}</span>
             {% endif %}
         {% endif %}
     </td>
-    {% if session.all_meeting_sessions_cancelled %}
+    {% if entry.canceled %}
         <td colspan="{% if user|has_role:'Secretariat' or user_groups %}6{% else %}5{% endif %}">
             <span class="badge rounded-pill bg-danger">Session cancelled</span>
         </td>
     {% else %}
         <td>
-            {% if session.all_meeting_agendas %}
-                {% for agenda in session.all_meeting_agendas %}
-                    {% if session.all_meeting_agendas|length == 1 %}
-                        {% if agenda.time > old %}
-                            <i class="small bi bi-bell"
-                                  title="Last Update: {{ agenda.time|utc|date:"Y-m-d H:i:s" }} UTC"></i>
-                        {% endif %}
-                        <a href="{{ session.all_meeting_agendas.0|meeting_href:session.meeting }}">Agenda</a>
-                        <br>
-                    {% else %}
-                        <a href="{{ agenda|meeting_href:session.meeting }}">
-                            Agenda {{ agenda.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}
-                        </a>
-                        <br>
-                    {% endif %}
-                {% endfor %}
-            {% else %}
+            {% for agenda in entry.agendas %}
+                {% if entry.agendas|length == 1 and agenda.time > old %}
+                    <i class="small bi bi-bell"
+                       title="Last Update: {{ agenda.time|utc|date:"Y-m-d H:i:s" }} UTC"></i>
+                {% endif %}
+                <a href="{{ agenda.material|meeting_href:meeting }}">
+                    Agenda {% if agenda.time %}{{agenda.time|date:"D G:i"}}{% endif %}
+                </a>
+                <br>
+            {% empty %}
                 {% if show_agenda == "True" %}<span class="badge rounded-pill bg-warning">No agenda</span>{% endif %}
-            {% endif %}
+            {% endfor %}
         </td>
         <td>
-            {% if session.all_meeting_minutes %}
-                {% if session.all_meeting_minutes|length == 1 %}
-                    <a href="{{ session.all_meeting_minutes.0|meeting_href:session.meeting }}">Minutes</a>
-                    <br>
-                {% else %}
-                    {% for minutes in session.all_meeting_minutes %}
-                        <a href="{{ minutes|meeting_href:session.meeting }}">
-                            Minutes {{ minutes.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}
-                        </a>
-                        <br>
-                    {% endfor %}
-                {% endif %}
-            {% else %}
+            {% for minutes in entry.minutes %}
+                <a href="{{ minutes.material|meeting_href:meeting }}">
+                    Minutes {% if minutes.time %}{{minutes.time|date:"D G:i"}}{% endif %}
+                </a>
+                <br>
+            {% empty %}
                 {% if show_agenda == "True" %}<span class="badge rounded-pill bg-warning">No minutes</span>{% endif %}
-            {% endif %}
-            {% if session.type_id == 'regular' and show_agenda == "True" %}
-                {% if session.all_meeting_bluesheets %}
-                    {% if session.all_meeting_bluesheets|length == 1 %}
-                        <a href="{{ session.all_meeting_bluesheets.0|meeting_href:session.meeting }}">Bluesheets</a>
-                        <br>
-                    {% else %}
-                        {% for bluesheets in session.all_meeting_bluesheets %}
-                            <a href="{{ bluesheets|meeting_href:session.meeting }}">
-                                Bluesheets
-                                <br>
-                                <span class="small float-end">{{ bluesheets.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}</span>
-                            </a>
-                            <br>
-                        {% endfor %}
-                    {% endif %}
-                {% else %}
+            {% endfor %}
+            {% if entry.session.type_id == 'regular' and show_agenda == "True" %}
+                {% for bluesheet in entry.bluesheets %}
+                    <a href="{{ bluesheet.material|meeting_href:meeting }}">
+                      Bluesheets
+		      {% if bluesheet.time %}
+		      <br><span class="small float-end">{{ bluesheet.time|date:"D G:i" }}</span>
+		      {% endif %}
+                    </a>
+                    <br>
+                {% empty %}
                     <span class="badge rounded-pill bg-warning">No bluesheets</span>
-                {% endif %}
+                {% endfor %}
             {% endif %}
         </td>
         <td>
-            {% with session.all_meeting_slides as slides %}
-                {% for slide in slides %}
+                {% for slide in entry.slides %}
                     {% if slide.time > old %}
                         <i class="small bi bi-bell"
                               title="Last Update: {{ slide.time|utc|date:"Y-m-d H:i:s" }} UTC"></i>
                     {% endif %}
-                    <a href="{{ slide|meeting_href:session.meeting }}">{{ slide.title|clean_whitespace }}</a>
+                    <a href="{{ slide.material|meeting_href:meeting }}">{{ slide.material.title|clean_whitespace }}</a>
                     <br>
                 {% empty %}
                     <span class="badge rounded-pill bg-warning">No slides</span>
                 {% endfor %}
-            {% endwith %}
         </td>
         <td>
-            {% with session.all_meeting_drafts as drafts %}
-                {% for draft in drafts %}
+                {% for draft in entry.drafts %}
                     {% if draft.time > old %}
                         <i class="small bi bi-bell"
                               title="Last Update: {{ draft.time|utc|date:"Y-m-d H:i:s" }} UTC"></i>
                     {% endif %}
-                    <a href="{{ draft.get_href }}">{{ draft.name }}</a>
+                    <a href="{% url "ietf.doc.views_doc.document_main" name=draft.material.canonical_name %}">
+                        {{ draft.material.canonical_name }}
+                    </a>
                     <br>
                 {% empty %}
                     <span class="badge rounded-pill bg-warning">No Internet-Drafts</span>
                 {% endfor %}
-            {% endwith %}
         </td>
         <td>
-            {% if session.last_update %}
-                {{ session.last_update|utc|date:"Y-m-d" }}
+            {% if entry.last_update %}
+                {{ entry.last_update|utc|date:"Y-m-d" }}
                 <br>
-                <small class="text-muted">{{ session.last_update|utc|date:"H:i:s" }}&nbsp;UTC</small>
+                <small class="text-muted">{{ entry.last_update|utc|date:"H:i:s" }}&nbsp;UTC</small>
             {% endif %}
         </td>
         {% if user|has_role:"Secretariat" or user_groups %}
             <td>
-                {% if user|has_role:"Secretariat" or session.group in user_groups %}
-                    <div class="float-end">{% include "meeting/edit_materials_button.html" %}</div>
+                {% if user|has_role:"Secretariat" or entry.group in user_groups %}
+                    <div class="float-end">{% include "meeting/edit_materials_button.html" with session=entry.session only %}</div>
                 {% endif %}
             </td>
         {% endif %}

--- a/ietf/templates/meeting/materials.html
+++ b/ietf/templates/meeting/materials.html
@@ -52,17 +52,16 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in plenaries %}
+                        {% for entry in plenaries %}
                             {% include "meeting/group_materials.html" %}
                         {% endfor %}
                     </tbody>
                 </table>
             {% endif %}
             <!-- Working groups -->
-            {% regroup ietf|dictsort:"group.parent.acronym" by group.parent.name as areas %}
-            {% for sessions in areas %}
-                <h2 class="mt-4" id="{{ sessions.list.0.group.parent.acronym }}">
-                    {{ sessions.list.0.group.parent.acronym|upper }} <small>{{ sessions.grouper }}</small>
+            {% for area, meeting_groups, not_meeting_groups in ietf_areas %}
+                <h2 class="mt-4" id="{{ area.acronym }}">
+                    {{ area.acronym|upper }} <small>{{ area.name }}</small>
                 </h2>
                 <table class="table table-sm table-striped tablesorter">
                     <thead>
@@ -79,10 +78,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in sessions.list|dictsort:"group.acronym" %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% for entry in meeting_groups %}
+                            {% include "meeting/group_materials.html" %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -110,11 +107,8 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for session in training %}
-                                {% ifchanged %}
-                                    {# TODO: Find a better way to represent purposed sessions in both materials and proceedings #}
-                                    {% include "meeting/group_materials.html" %}
-                                {% endifchanged %}
+                            {% for entry in training %}
+                                {% include "meeting/group_materials.html" %}
                             {% endfor %}
                         </tbody>
                     </table>
@@ -152,10 +146,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in iab %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% for entry in iab %}
+                            {% include "meeting/group_materials.html" %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -192,10 +184,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in irtf|dictsort:"group.acronym" %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% for entry in irtf %}
+                            {% include "meeting/group_materials.html" %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -231,10 +221,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in other|dictsort:"group.acronym" %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% for entry in other %}
+                            {% include "meeting/group_materials.html" %}
                         {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
fixes #5653