### PR TITLE
fix: explain what is not counted in the meeting request summary

### DIFF
--- a/ietf/templates/meeting/requests.html
+++ b/ietf/templates/meeting/requests.html
@@ -17,6 +17,7 @@
     </h1>
 
     <h2 class="mt-3">Requests Summary</h2>
+    <p class="mt-2"><em>This summary section focuses on sessions that have conflict lists to manage. It excludes requests from groups of type "team", such as those for the hackathon or for tutorials.</em></p>
     <div class="mt-2">
         <table class="table table-sm">
             <tbody>


### PR DESCRIPTION
Fixes #5720