### PR TITLE
fix: /meeting/materials splits out named sessions the same way /meeting/proceedings does

### DIFF
--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -1105,6 +1105,9 @@ class Session(models.Model):
     def drafts(self):
         return list(self.materials.filter(type='draft'))
 
+    def materials_key(self):
+        return (self.group.acronym, self.name)
+
     # The utilities below are used in the proceedings and materials
     # templates, and should be moved there - then we could also query
     # out the needed information in a few passes and speed up those

--- a/ietf/meeting/templatetags/materials_filters.py
+++ b/ietf/meeting/templatetags/materials_filters.py
@@ -1,0 +1,47 @@
+# Copyright The IETF Trust 2023, All Rights Reserved
+from django import template
+
+import debug       # pyflakes:ignore
+import itertools
+
+register = template.Library()
+
+def _uniq(l):
+    # https://www.peterbe.com/plog/fastest-way-to-uniquify-a-list-in-python-3.6
+    l = list(dict.fromkeys(l))
+    # Filter out None return values from Session.agendas() etc.
+    # Listify the result, because the template calls length() on it.
+    return list(itertools.filterfalse(lambda x: not x, l))
+
+def _flatten(ll):
+    return [x for l in ll for x in l]
+
+@register.filter
+def all_meeting_sessions_cancelled(ss):
+    return set(s.current_status for s in ss) == {'canceled'}
+
+@register.filter
+def all_meeting_agendas(ss):
+    return _uniq([s.agenda() for s in ss])
+
+@register.filter
+def all_meeting_minutes(ss):
+    return _uniq([s.minutes() for s in ss])
+
+@register.filter
+def all_meeting_bluesheets(ss):
+    return _uniq(_flatten([s.bluesheets() for s in ss]))
+
+@register.filter
+def all_meeting_recordings(ss):
+    return _uniq(_flatten([s.recordings() for s in ss]))
+
+@register.filter
+def all_meeting_slides(ss):
+    return _uniq(_flatten([s.slides() for s in ss]))
+
+@register.filter
+def all_meeting_drafts(ss):
+    return _uniq(_flatten([s.drafts() for s in ss]))
+
+

--- a/ietf/meeting/templatetags/materials_filters.py
+++ b/ietf/meeting/templatetags/materials_filters.py
@@ -44,4 +44,6 @@ def all_meeting_slides(ss):
 def all_meeting_drafts(ss):
     return _uniq(_flatten([s.drafts() for s in ss]))
 
-
+@register.filter
+def timesort(ss):
+    return sorted(ss, key=lambda s: s.official_timeslotassignment().timeslot.time)

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -547,24 +547,12 @@ class MeetingTests(BaseMeetingTestCase):
         self.assertTrue(named_row)
 
         for material in (sp.document for sp in plain_session.sessionpresentation_set.all()):
-            if material.type_id == 'draft':
-                expected_url = urlreverse(
-                    'ietf.doc.views_doc.document_main',
-                    kwargs={'name': material.canonical_name()},
-                )
-            else:
-                expected_url = material.get_href(meeting)
+            expected_url = material.get_href(meeting)
             self.assertTrue(plain_row.find(f'a[href="{expected_url}"]'))
             self.assertFalse(named_row.find(f'a[href="{expected_url}"]'))
 
         for material in (sp.document for sp in named_session.sessionpresentation_set.all()):
-            if material.type_id == 'draft':
-                expected_url = urlreverse(
-                    'ietf.doc.views_doc.document_main',
-                    kwargs={'name': material.canonical_name()},
-                )
-            else:
-                expected_url = material.get_href(meeting)
+            expected_url = material.get_href(meeting)
             self.assertFalse(plain_row.find(f'a[href="{expected_url}"]'))
             self.assertTrue(named_row.find(f'a[href="{expected_url}"]'))
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -155,7 +155,7 @@ def materials(request, num=None):
     ).distinct().select_related('meeting__schedule', 'group__state', 'group__parent')).order_by('group__acronym')
 
     plenaries = sessions.filter(name__icontains='plenary')
-    ietf      = sessions.filter(group__parent__type__slug = 'area').exclude(group__acronym='edu')
+    ietf      = sessions.filter(group__parent__type__slug = 'area').exclude(group__acronym='edu').order_by('group__parent__acronym', 'group__acronym', 'name')
     irtf      = sessions.filter(group__parent__acronym = 'irtf')
     training  = sessions.filter(group__acronym__in=['edu','iaoc'], type_id__in=['regular', 'other', ])
     iab       = sessions.filter(group__parent__acronym = 'iab')

--- a/ietf/templates/meeting/group_materials.html
+++ b/ietf/templates/meeting/group_materials.html
@@ -1,8 +1,9 @@
 {# Copyright The IETF Trust 2015-2019, All Rights Reserved #}
 {% load origin %}
 {% origin %}
-{% load ietf_filters proceedings_filters managed_groups %}
+{% load ietf_filters proceedings_filters materials_filters managed_groups %}
 {% load tz %}
+{% with sessions.0 as session %}
 <tr>
     <td>
         {% if session.name %}
@@ -16,70 +17,76 @@
             {% endif %}
         {% endif %}
     </td>
-    {% if session.all_meeting_sessions_cancelled %}
+    {% if sessions|all_meeting_sessions_cancelled %}
         <td colspan="{% if user|has_role:'Secretariat' or user_groups %}6{% else %}5{% endif %}">
             <span class="badge rounded-pill bg-danger">Session cancelled</span>
         </td>
     {% else %}
         <td>
-            {% if session.all_meeting_agendas %}
-                {% for agenda in session.all_meeting_agendas %}
-                    {% if session.all_meeting_agendas|length == 1 %}
+            {% with sessions|all_meeting_agendas as agendas %}
+                {% if agendas %}
+                    {% if agendas|length == 1 %}
                         {% if agenda.time > old %}
                             <i class="small bi bi-bell"
                                   title="Last Update: {{ agenda.time|utc|date:"Y-m-d H:i:s" }} UTC"></i>
                         {% endif %}
-                        <a href="{{ session.all_meeting_agendas.0|meeting_href:session.meeting }}">Agenda</a>
+                        <a href="{{ agendas.0|meeting_href:session.meeting }}">Agenda</a>
                         <br>
                     {% else %}
-                        <a href="{{ agenda|meeting_href:session.meeting }}">
-                            Agenda {{ agenda.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}
-                        </a>
-                        <br>
-                    {% endif %}
-                {% endfor %}
-            {% else %}
-                {% if show_agenda == "True" %}<span class="badge rounded-pill bg-warning">No agenda</span>{% endif %}
-            {% endif %}
-        </td>
-        <td>
-            {% if session.all_meeting_minutes %}
-                {% if session.all_meeting_minutes|length == 1 %}
-                    <a href="{{ session.all_meeting_minutes.0|meeting_href:session.meeting }}">Minutes</a>
-                    <br>
-                {% else %}
-                    {% for minutes in session.all_meeting_minutes %}
-                        <a href="{{ minutes|meeting_href:session.meeting }}">
-                            Minutes {{ minutes.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}
-                        </a>
-                        <br>
-                    {% endfor %}
-                {% endif %}
-            {% else %}
-                {% if show_agenda == "True" %}<span class="badge rounded-pill bg-warning">No minutes</span>{% endif %}
-            {% endif %}
-            {% if session.type_id == 'regular' and show_agenda == "True" %}
-                {% if session.all_meeting_bluesheets %}
-                    {% if session.all_meeting_bluesheets|length == 1 %}
-                        <a href="{{ session.all_meeting_bluesheets.0|meeting_href:session.meeting }}">Bluesheets</a>
-                        <br>
-                    {% else %}
-                        {% for bluesheets in session.all_meeting_bluesheets %}
-                            <a href="{{ bluesheets|meeting_href:session.meeting }}">
-                                Bluesheets
-                                <br>
-                                <span class="small float-end">{{ bluesheets.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}</span>
+                        {% for agenda in agendas %}
+                            <a href="{{ agenda|meeting_href:session.meeting }}">
+                                Agenda {{ agenda.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}
                             </a>
                             <br>
                         {% endfor %}
                     {% endif %}
                 {% else %}
-                    <span class="badge rounded-pill bg-warning">No bluesheets</span>
+                    {% if show_agenda == "True" %}<span class="badge rounded-pill bg-warning">No agenda</span>{% endif %}
                 {% endif %}
+            {% endwith %}
+        </td>
+        <td>
+            {% with sessions|all_meeting_minutes as minutess %}
+                {% if minutess %}
+                    {% if minutess|length == 1 %}
+                        <a href="{{ minutess.0|meeting_href:session.meeting }}">Minutes</a>
+                        <br>
+                    {% else %}
+                        {% for minutes in minutess %}
+                            <a href="{{ minutes|meeting_href:session.meeting }}">
+                                Minutes {{ minutes.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}
+                            </a>
+                            <br>
+                        {% endfor %}
+                    {% endif %}
+                {% else %}
+                    {% if show_agenda == "True" %}<span class="badge rounded-pill bg-warning">No minutes</span>{% endif %}
+                {% endif %}
+            {% endwith %}
+            {% if session.type_id == 'regular' and show_agenda == "True" %}
+                {% with sessions|all_meeting_bluesheets as bluesheets %}
+                    {% if bluesheets %}
+                        {% if bluesheets|length == 1 %}
+                            <a href="{{ bluesheets.0|meeting_href:session.meeting }}">Bluesheets</a>
+                            <br>
+                        {% else %}
+                            {% for bluesheet in bluesheets %}
+                                <a href="{{ bluesheet|meeting_href:session.meeting }}">
+                                    Bluesheets
+                                    <br>
+                                    <span class="small float-end">{{ bluesheet.sessionpresentation_set.first.session.official_timeslotassignment.timeslot.time|date:"D G:i" }}</span>
+                                </a>
+                                <br>
+                            {% endfor %}
+                        {% endif %}
+                    {% else %}
+                        <span class="badge rounded-pill bg-warning">No bluesheets</span>
+                    {% endif %}
+                {% endwith %}
             {% endif %}
         </td>
         <td>
-            {% with session.all_meeting_slides as slides %}
+            {% with sessions|all_meeting_slides as slides %}
                 {% for slide in slides %}
                     {% if slide.time > old %}
                         <i class="small bi bi-bell"
@@ -93,7 +100,7 @@
             {% endwith %}
         </td>
         <td>
-            {% with session.all_meeting_drafts as drafts %}
+            {% with sessions|all_meeting_drafts as drafts %}
                 {% for draft in drafts %}
                     {% if draft.time > old %}
                         <i class="small bi bi-bell"
@@ -122,3 +129,4 @@
         {% endif %}
     {% endif %}
 </tr>
+{% endwith %}

--- a/ietf/templates/meeting/group_materials.html
+++ b/ietf/templates/meeting/group_materials.html
@@ -3,7 +3,7 @@
 {% origin %}
 {% load ietf_filters proceedings_filters materials_filters managed_groups %}
 {% load tz %}
-{% with sessions.0 as session %}
+{% with sessions=sessions|timesort session=sessions.0 %}
 <tr>
     <td>
         {% if session.name %}

--- a/ietf/templates/meeting/materials.html
+++ b/ietf/templates/meeting/materials.html
@@ -52,17 +52,18 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in plenaries %}
-                            {% include "meeting/group_materials.html" %}
+                        {% regroup plenaries by materials_key as named_sessions %}
+                        {% for ns in named_sessions %}
+                            {% include "meeting/group_materials.html" with sessions=ns.list %}
                         {% endfor %}
                     </tbody>
                 </table>
             {% endif %}
             <!-- Working groups -->
-            {% regroup ietf|dictsort:"group.parent.acronym" by group.parent.name as areas %}
-            {% for sessions in areas %}
-                <h2 class="mt-4" id="{{ sessions.list.0.group.parent.acronym }}">
-                    {{ sessions.list.0.group.parent.acronym|upper }} <small>{{ sessions.grouper }}</small>
+            {% regroup ietf by group.parent.name as areas %}
+            {% for area in areas %}
+                <h2 class="mt-4" id="{{ area.acronym }}">
+                    {{ area.list.0.group.parent.acronym|upper }} <small>{{ area.grouper }}</small>
                 </h2>
                 <table class="table table-sm table-striped tablesorter">
                     <thead>
@@ -79,10 +80,9 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in sessions.list|dictsort:"group.acronym" %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% regroup area.list by materials_key as named_sessions %}
+                        {% for ns in named_sessions %}
+                            {% include "meeting/group_materials.html" with sessions=ns.list %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -110,11 +110,9 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for session in training %}
-                                {% ifchanged %}
-                                    {# TODO: Find a better way to represent purposed sessions in both materials and proceedings #}
-                                    {% include "meeting/group_materials.html" %}
-                                {% endifchanged %}
+                            {% regroup training by materials_key as named_sessions %}
+                            {% for ns in named_sessions %}
+                                {% include "meeting/group_materials.html" with sessions=ns.list %}
                             {% endfor %}
                         </tbody>
                     </table>
@@ -152,10 +150,9 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in iab %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% regroup iab by materials_key as named_sessions %}
+                        {% for ns in named_sessions %}
+                            {% include "meeting/group_materials.html" with sessions=ns.list %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -192,10 +189,9 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in irtf|dictsort:"group.acronym" %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% regroup irtf by materials_key as named_sessions %}
+                        {% for ns in named_sessions %}
+                            {% include "meeting/group_materials.html" with sessions=ns.list %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -231,10 +227,9 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for session in other|dictsort:"group.acronym" %}
-                            {% ifchanged session.group.acronym %}
-                                {% include "meeting/group_materials.html" %}
-                            {% endifchanged %}
+                        {% regroup other by materials_key as named_sessions %}
+                        {% for ns in named_sessions %}
+                            {% include "meeting/group_materials.html" with sessions=ns.list %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/ietf/templates/meeting/materials.html
+++ b/ietf/templates/meeting/materials.html
@@ -62,7 +62,7 @@
             <!-- Working groups -->
             {% regroup ietf by group.parent.name as areas %}
             {% for area in areas %}
-                <h2 class="mt-4" id="{{ area.acronym }}">
+                <h2 class="mt-4" id="{{ area.list.0.group.parent.acronym }}">
                     {{ area.list.0.group.parent.acronym|upper }} <small>{{ area.grouper }}</small>
                 </h2>
                 <table class="table table-sm table-striped tablesorter">


### PR DESCRIPTION
This is an alternative to #5715, which groups sessions in the template versus in the python view. In terms of complexity, it's about the same, but is a little more performant.

Note that these branches contain the same unit test, because it's testing the same condition.

At most one of these PRs should be adopted.