### PR TITLE
chore: add nginx reverse proxy to dev environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -66,7 +66,7 @@
     },
     
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [3000, 5432, 5433, 8000, 8001],
+    "forwardPorts": [3000, 5432, 5433, 8000],
     
     "portsAttributes": {
         "3000": {
@@ -82,12 +82,12 @@
             "onAutoForward": "silent"
         },
         "8000": {
-            "label": "Datatracker",
+            "label": "NGINX",
             "onAutoForward": "notify"
         },
         "8001": {
-            "label": "Static",
-            "onAutoForward": "silent"
+            "label": "Datatracker",
+            "onAutoForward": "ignore"
         }
     },
     

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -18,5 +18,8 @@ services:
     pgadmin:
         network_mode: service:db
 
+    static:
+        network_mode: service:db
+
 volumes:
     datatracker-vscode-ext:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "program": "${workspaceFolder}/ietf/manage.py",
             "args": [
                 "runserver",
-                "0.0.0.0:8000",
+                "0.0.0.0:8001",
                 "--settings=settings_local"
             ],
             "django": true,
@@ -30,7 +30,7 @@
             "program": "${workspaceFolder}/ietf/manage.py",
             "args": [
                 "runserver",
-                "0.0.0.0:8000",
+                "0.0.0.0:8001",
                 "--settings=settings_local_vite"
             ],
             "django": true,
@@ -48,7 +48,7 @@
             "program": "${workspaceFolder}/ietf/manage.py",
             "args": [
                 "runserver",
-                "0.0.0.0:8000",
+                "0.0.0.0:8001",
                 "--settings=settings_local_debug"
             ],
             "django": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,6 @@ services:
     static:
         image: ghcr.io/ietf-tools/static:latest
         restart: unless-stopped
-        ports:
-            - 8001:80
 
     mq:
         image: rabbitmq:3-alpine

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -30,6 +30,13 @@ COPY docker/scripts/app-setup-python.sh /tmp/library-scripts/docker-setup-python
 RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-python.sh && chmod +x /tmp/library-scripts/docker-setup-python.sh
 RUN bash /tmp/library-scripts/docker-setup-python.sh "none" "/usr/local" "${PIPX_HOME}" "${USERNAME}"
 
+# Setup nginx
+COPY docker/scripts/app-setup-nginx.sh /tmp/library-scripts/docker-setup-nginx.sh
+RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-nginx.sh && chmod +x /tmp/library-scripts/docker-setup-nginx.sh
+RUN bash /tmp/library-scripts/docker-setup-nginx.sh
+COPY docker/configs/nginx-proxy.conf /etc/nginx/sites-available/default
+COPY docker/configs/nginx-502.html /var/www/html/502.html
+
 # Remove library scripts for final image
 RUN rm -rf /tmp/library-scripts
 

--- a/docker/configs/nginx-502.html
+++ b/docker/configs/nginx-502.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Datatracker DEV</title>
+        <style>
+            body {
+                background-color: #111;
+                color: #FFF;
+                font-family: Arial, Helvetica, sans-serif;
+                text-align: center;
+                padding: 50px;
+                font-size: 16px;
+            }
+            img {
+                height: 80px;
+            }
+            h1 {
+                color: #CCC;
+            }
+            div {
+                background-color: #222;
+                border-radius: 10px;
+                padding: 10px 50px;
+                display: inline-block;
+            }
+            i {
+                font-size: 64px;
+                line-height: 16px;
+                vertical-align: text-bottom;
+                margin-right: 5px;
+            }
+            code {
+                background-color: #444;
+                padding: 3px 6px;
+                border-radius: 5px;
+                margin: 0 5px;
+            }
+            .mt {
+                margin-top: 15px;
+            }
+            a {
+                color: #31CCEC;
+            }
+        </style>
+    </head>
+    <body>
+        <img src="/_static/logos/ietf-inverted.svg" alt="IETF" />
+        <h1>Datatracker</h1>
+        <h2>Could not connect to dev server.</h2>
+        <div>
+            <p>Is the datatracker server running?</p>
+            <p class="mt">Using <strong>VS Code</strong>, open the <strong>Run and Debug</strong> tab on the left and click the <i>&#x2023;</i> symbol (Run Server) to start the server.</p>
+            <p>Otherwise, run the command <code>ietf/manage.py runserver 0.0.0.0:8001</code> from the terminal.</p>
+        </div>
+        <p class="mt">For more information, check out the <a href="https://github.com/ietf-tools/datatracker/blob/main/docker/README.md" target="_blank">Datatracker Development in Docker</a> guide.</p>
+    </body>
+</html>

--- a/docker/configs/nginx-proxy.conf
+++ b/docker/configs/nginx-proxy.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8000 default_server;
+    listen [::]:8000 default_server;
+    
+    root /var/www/html;
+    index index.html index.htm index.nginx-debian.html;
+
+    server_name _;
+
+    location /_static/ {
+        proxy_pass http://localhost:80/;
+    }
+
+    location / {
+        error_page 502 /502.html;
+        proxy_pass http://localhost:8001/;
+    }
+
+    location /502.html {
+        root /var/www/html;
+        internal;
+    }
+}

--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -56,4 +56,4 @@ SLIDE_STAGING_PATH = 'test/staging/'
 
 DE_GFM_BINARY = '/usr/local/bin/de-gfm'
 
-STATIC_IETF_ORG = "http://localhost:8001"
+STATIC_IETF_ORG = "/_static"

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -21,6 +21,11 @@ sudo chown dev:dev "/assets"
 echo "Fix chromedriver /dev/shm permissions..."
 sudo chmod 1777 /dev/shm
 
+# Run nginx
+
+echo "Starting nginx..."
+sudo nginx
+
 # Build node packages that requrie native compilation
 echo "Compiling native node packages..."
 yarn rebuild

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -40,37 +40,27 @@ cp $WORKSPACEDIR/docker/configs/settings_postgresqldb.py $WORKSPACEDIR/ietf/sett
 
 if [ ! -f "$WORKSPACEDIR/ietf/settings_local.py" ]; then
     echo "Setting up a default settings_local.py ..."
-    cp $WORKSPACEDIR/docker/configs/settings_local.py $WORKSPACEDIR/ietf/settings_local.py
-
 else
-    echo "Using existing ietf/settings_local.py file"
-    if ! cmp -s $WORKSPACEDIR/docker/configs/settings_local.py $WORKSPACEDIR/ietf/settings_local.py; then
-        echo "NOTE: Differences detected compared to docker/configs/settings_local.py!"
-        echo "We'll assume you made these deliberately."
-    fi
+    echo "Renaming existing ietf/settings_local.py to ietf/settings_local.py.bak"
+    mv -f $WORKSPACEDIR/ietf/settings_local.py $WORKSPACEDIR/ietf/settings_local.py.bak
 fi
+cp $WORKSPACEDIR/docker/configs/settings_local.py $WORKSPACEDIR/ietf/settings_local.py
 
 if [ ! -f "$WORKSPACEDIR/ietf/settings_local_debug.py" ]; then
     echo "Setting up a default settings_local_debug.py ..."
-    cp $WORKSPACEDIR/docker/configs/settings_local_debug.py $WORKSPACEDIR/ietf/settings_local_debug.py
 else
-    echo "Using existing ietf/settings_local_debug.py file"
-    if ! cmp -s $WORKSPACEDIR/docker/configs/settings_local_debug.py $WORKSPACEDIR/ietf/settings_local_debug.py; then
-        echo "NOTE: Differences detected compared to docker/configs/settings_local_debug.py!"
-        echo "We'll assume you made these deliberately."
-    fi
+    echo "Renaming existing ietf/settings_local_debug.py to ietf/settings_local_debug.py.bak"
+    mv -f $WORKSPACEDIR/ietf/settings_local.py $WORKSPACEDIR/ietf/settings_local.py.bak
 fi
+cp $WORKSPACEDIR/docker/configs/settings_local_debug.py $WORKSPACEDIR/ietf/settings_local_debug.py
 
 if [ ! -f "$WORKSPACEDIR/ietf/settings_local_vite.py" ]; then
     echo "Setting up a default settings_local_vite.py ..."
-    cp $WORKSPACEDIR/docker/configs/settings_local_vite.py $WORKSPACEDIR/ietf/settings_local_vite.py
 else
-    echo "Using existing ietf/settings_local_vite.py file"
-    if ! cmp -s $WORKSPACEDIR/docker/configs/settings_local_vite.py $WORKSPACEDIR/ietf/settings_local_vite.py; then
-        echo "NOTE: Differences detected compared to docker/configs/settings_local_vite.py!"
-        echo "We'll assume you made these deliberately."
-    fi
+    echo "Renaming existing ietf/settings_local_vite.py to ietf/settings_local_vite.py.bak"
+    mv -f $WORKSPACEDIR/ietf/settings_local_vite.py $WORKSPACEDIR/ietf/settings_local_vite.py.bak
 fi
+cp $WORKSPACEDIR/docker/configs/settings_local_vite.py $WORKSPACEDIR/ietf/settings_local_vite.py
 
 # Create data directories
 

--- a/docker/scripts/app-setup-nginx.sh
+++ b/docker/scripts/app-setup-nginx.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+apt-get update -y
+apt-get install -y nginx


### PR DESCRIPTION
Makes the static container proxied via nginx in the app container rather than exposing it to the host. Also adds a fallback page if the django server is not running:

<img width="820" alt="image" src="https://github.com/ietf-tools/datatracker/assets/15522395/c94c8662-11c5-45e4-b369-9b5fdc6b3be6">
