### PR TITLE
chore: Restart celery worker on source changes

### DIFF
--- a/dev/celery/Dockerfile
+++ b/dev/celery/Dockerfile
@@ -17,4 +17,7 @@ COPY requirements.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt
 RUN rm -rf /tmp/pip-tmp
 
+# Add watchmedo utility for dev containers
+RUN pip3 --disable-pip-version-check --no-cache-dir install watchdog[watchmedo]
+
 ENTRYPOINT [ "/docker-init.sh" ]

--- a/dev/celery/docker-init.sh
+++ b/dev/celery/docker-init.sh
@@ -88,7 +88,13 @@ fi
 trap 'trap "" TERM; cleanup' TERM
 # start celery in the background so we can trap the TERM signal
 if [[ -n "${DEV_MODE}" ]]; then
-  watchmedo auto-restart --patterns='*.py' --recursive -- celery --app="${CELERY_APP:-ietf}" "${CELERY_OPTS[@]}" "$@" &
+  watchmedo auto-restart \
+            --patterns '*.py' \
+            --directory 'ietf' \
+            --recursive \
+            --debounce-interval 5 \
+            -- \
+            celery --app="${CELERY_APP:-ietf}" "${CELERY_OPTS[@]}" "$@" &
   celery_pid=$!
 else
   celery --app="${CELERY_APP:-ietf}" "${CELERY_OPTS[@]}" "$@" &

--- a/dev/celery/docker-init.sh
+++ b/dev/celery/docker-init.sh
@@ -15,6 +15,8 @@
 #
 #   DEBUG_TERM_TIMING - if non-empty, writes debug messages during shutdown after a TERM signal
 #
+#   DEV_MODE - if non-empty, restart celery worker on Python file change
+#
 WORKSPACEDIR="/workspace"
 CELERY_ROLE="${CELERY_ROLE:-worker}"
 
@@ -85,6 +87,12 @@ fi
 
 trap 'trap "" TERM; cleanup' TERM
 # start celery in the background so we can trap the TERM signal
-celery --app="${CELERY_APP:-ietf}" "${CELERY_OPTS[@]}" "$@" &
-celery_pid=$!
+if [[ -n "${DEV_MODE}" ]]; then
+  watchmedo auto-restart --patterns='*.py' --recursive -- celery --app="${CELERY_APP:-ietf}" "${CELERY_OPTS[@]}" "$@" &
+  celery_pid=$!
+else
+  celery --app="${CELERY_APP:-ietf}" "${CELERY_OPTS[@]}" "$@" &
+  celery_pid=$!
+fi
+
 wait "${celery_pid}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
             CELERY_APP: ietf
             CELERY_ROLE: worker
             UPDATE_REQUIREMENTS_FROM: requirements.txt
+            DEV_MODE: yes
         command:
             - '--loglevel=INFO'
         depends_on:


### PR DESCRIPTION
On a development installation, uses the `watchmedo` utility from https://pypi.org/project/watchdog/ to restart the celery worker when the Python code changes.

Does not change operation for production.