### PR TITLE
fix: add internal static.ietf.org var for pdfized render

### DIFF
--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -57,3 +57,4 @@ SLIDE_STAGING_PATH = 'test/staging/'
 DE_GFM_BINARY = '/usr/local/bin/de-gfm'
 
 STATIC_IETF_ORG = "/_static"
+STATIC_IETF_ORG_INTERNAL = "http://localhost:80"

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -627,7 +627,7 @@ class DocumentInfo(models.Model):
             stylesheets.append(finders.find("ietf/css/document_html_txt.css"))
         else:
             text = self.htmlized()
-        stylesheets.append(f'{settings.STATIC_IETF_ORG}/fonts/noto-sans-mono/import.css')
+        stylesheets.append(f'{settings.STATIC_IETF_ORG_INTERNAL}/fonts/noto-sans-mono/import.css')
 
         cache = caches["pdfized"]
         cache_key = name.split(".")[0]

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -178,7 +178,10 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
 
+# Client-side static.ietf.org URL
 STATIC_IETF_ORG = "https://static.ietf.org"
+# Server-side static.ietf.org URL (used in pdfized)
+STATIC_IETF_ORG_INTERNAL = STATIC_IETF_ORG
 
 WSGI_APPLICATION = "ietf.wsgi.application"
 


### PR DESCRIPTION
Because the server can't access itself during the pdfized render, it needs the internal static.ietf.org endpoint in dev.

In prod, the value is identical as it is external in both cases.