### PR TITLE
feat: render charters on about page using markdown

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -166,6 +166,7 @@ def fill_in_charter_info(group, include_drafts=False):
         group.charter_text = get_charter_text(group)
     else:
         group.charter_text = "Not chartered yet."
+    group.charter_html = markdown.markdown(group.charter_text)
 
 def extract_last_name(role):
     return role.person.name_parts()[3]

--- a/ietf/templates/group/group_about.html
+++ b/ietf/templates/group/group_about.html
@@ -379,8 +379,7 @@ height: 100vh;
             {% if group.state_id == "proposed" %}proposed{% endif %}
             {{ group.type.desc.title }}
         </h2>
-        {# the linebreaks filter adds <p>, no surrounding <p> necessary: #}
-        {{ group.charter_text|urlize_ietf_docs|linkify|linebreaks }}
+        {{ group.charter_html }}
     {% else %}
         <h2 class="mt-3">
             {% if requested_close or group.state_id == "conclude" %}Final{% endif %}

--- a/ietf/templates/group/group_about_rendertest.html
+++ b/ietf/templates/group/group_about_rendertest.html
@@ -40,15 +40,15 @@
 {% block js %}
     <script>
         $(document).ready(function() {
-            $('input[name=widthconstraint]').trigger("change", function() {
+            $('input[name=widthconstraint]').on("change", function() {
                 if ($(this).is(':checked')) {
                     $('.rightcontent').css('max-width','700px')
                 } else {
                     $('.rightcontent').css('max-width','')
                 }
             });
-            $('input[name=widthconstraint').prop('checked', true);
-            $('.rightcontent').css('max-width','700px')
+            $('input[name=widthconstraint').prop('checked', false);
+            $('.rightcontent').css('max-width','')
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Remember the `/group/<acronym>/about/rendertest` view for a before/after comparison. (This PR fixes a js issue in that view).

The last time we pressed people to look at rendertest, I don't think we were using `nl2br`, so some of the really old charters with strange linebreaks in their text files will still just look strange, but overall, using it will likely produce the least surprise.

cc: @larseggert