### PR TITLE
chore(dev): fix internal static proxy + add /pgadmin to reverse-proxy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,7 @@
     },
     
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [3000, 5432, 5433, 8000],
+    "forwardPorts": [3000, 5432, 8000],
     
     "portsAttributes": {
         "3000": {
@@ -76,10 +76,6 @@
         },
         "5432": {
             "label": "PostgreSQL",
-            "onAutoForward": "silent"
-        },
-        "5433": {
-            "label": "pgAdmin",
             "onAutoForward": "silent"
         },
         "8000": {

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -15,11 +15,5 @@ services:
         # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
         network_mode: service:db
 
-    pgadmin:
-        network_mode: service:db
-
-    static:
-        network_mode: service:db
-
 volumes:
     datatracker-vscode-ext:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,9 @@ services:
             - PGADMIN_DEFAULT_EMAIL=dev@ietf.org
             - PGADMIN_DEFAULT_PASSWORD=dev
             - PGADMIN_CONFIG_LOGIN_BANNER="Login with dev@ietf.org / dev"
-            - PGADMIN_LISTEN_PORT=5433
             - PGADMIN_DISABLE_POSTFIX=True
             - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+            - SCRIPT_NAME=/pgadmin
         volumes:
             - ./docker/configs/pgadmin-servers.json:/pgadmin4/servers.json
 

--- a/docker/configs/nginx-502.html
+++ b/docker/configs/nginx-502.html
@@ -23,7 +23,6 @@
                 background-color: #222;
                 border-radius: 10px;
                 padding: 10px 50px;
-                display: inline-block;
             }
             i {
                 font-size: 64px;
@@ -53,6 +52,9 @@
             <p>Is the datatracker server running?</p>
             <p class="mt">Using <strong>VS Code</strong>, open the <strong>Run and Debug</strong> tab on the left and click the <i>&#x2023;</i> symbol (Run Server) to start the server.</p>
             <p>Otherwise, run the command <code>ietf/manage.py runserver 0.0.0.0:8001</code> from the terminal.</p>
+        </div>
+        <div class="mt">
+            <p>You can manage the database at <a href="/pgadmin">/pgadmin</a>.</p>
         </div>
         <p class="mt">For more information, check out the <a href="https://github.com/ietf-tools/datatracker/blob/main/docker/README.md" target="_blank">Datatracker Development in Docker</a> guide.</p>
     </body>

--- a/docker/configs/nginx-proxy.conf
+++ b/docker/configs/nginx-proxy.conf
@@ -8,7 +8,14 @@ server {
     server_name _;
 
     location /_static/ {
-        proxy_pass http://localhost:80/;
+        proxy_pass http://static/;
+    }
+
+    location /pgadmin/ {
+        proxy_set_header X-Script-Name /pgadmin;
+        proxy_set_header Host $host;
+        proxy_pass http://pgadmin;
+        proxy_redirect off;
     }
 
     location / {

--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -57,4 +57,4 @@ SLIDE_STAGING_PATH = 'test/staging/'
 DE_GFM_BINARY = '/usr/local/bin/de-gfm'
 
 STATIC_IETF_ORG = "/_static"
-STATIC_IETF_ORG_INTERNAL = "http://localhost:80"
+STATIC_IETF_ORG_INTERNAL = "http://static"


### PR DESCRIPTION
Fixes #5806

and adds /pgadmin to the reverse-proxy rather than exposing it on a separate port.