### PR TITLE
refactor: Do not use canonical_name() for charters

### DIFF
--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -857,11 +857,7 @@ class Document(DocumentInfo):
                 if a:
                     name = a.name
             elif self.type_id == "charter":
-                from ietf.doc.utils_charter import charter_name_for_group # Imported locally to avoid circular imports
-                try:
-                    name = charter_name_for_group(self.chartered_group)
-                except Group.DoesNotExist:
-                    pass
+                raise RuntimeError("Don't call this!!")
             self._canonical_name = name
         return self._canonical_name
 

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -856,8 +856,6 @@ class Document(DocumentInfo):
                 a = self.docalias.filter(name__startswith="rfc").order_by('-name').first()
                 if a:
                     name = a.name
-            elif self.type_id == "charter":
-                raise RuntimeError("Don't call this!!")
             self._canonical_name = name
         return self._canonical_name
 

--- a/ietf/doc/tests_charter.py
+++ b/ietf/doc/tests_charter.py
@@ -88,10 +88,7 @@ class EditCharterTests(TestCase):
     settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['CHARTER_PATH']
 
     def write_charter_file(self, charter):
-        with (Path(settings.CHARTER_PATH) /
-              ("%s-%s.txt" % (charter.canonical_name(), charter.rev))
-        ).open("w") as f:
-            f.write("This is a charter.")
+        (Path(settings.CHARTER_PATH) / f"{charter.name}-{charter.rev}.txt").write_text("This is a charter.")
 
     def test_startstop_process(self):
         CharterFactory(group__acronym='mars')
@@ -509,8 +506,13 @@ class EditCharterTests(TestCase):
         self.assertEqual(charter.rev, next_revision(prev_rev))
         self.assertTrue("new_revision" in charter.latest_event().type)
 
-        with (Path(settings.CHARTER_PATH) / (charter.canonical_name() + "-" + charter.rev + ".txt")).open(encoding='utf-8') as f:
-            self.assertEqual(f.read(), "Windows line\nMac line\nUnix line\n" + utf_8_snippet.decode('utf-8'))
+        file_contents = (
+            Path(settings.CHARTER_PATH) / (charter.name + "-" + charter.rev + ".txt")
+        ).read_text("utf-8")
+        self.assertEqual(
+            file_contents,
+            "Windows line\nMac line\nUnix line\n" + utf_8_snippet.decode("utf-8"),
+        )
 
     def test_submit_initial_charter(self):
         group = GroupFactory(type_id='wg',acronym='mars',list_email='mars-wg@ietf.org')

--- a/ietf/doc/tests_charter.py
+++ b/ietf/doc/tests_charter.py
@@ -540,6 +540,24 @@ class EditCharterTests(TestCase):
         group = Group.objects.get(pk=group.pk)
         self.assertEqual(group.charter, charter)
 
+    def test_submit_charter_with_invalid_name(self):
+        self.client.login(username="secretary", password="secretary+password")
+        ietf_group = GroupFactory(type_id="wg")
+        for bad_name in ("charter-irtf-{}", "charter-randomjunk-{}", "charter-ietf-thisisnotagroup"):
+            url = urlreverse("ietf.doc.views_charter.submit", kwargs={"name": bad_name.format(ietf_group.acronym)})
+            r = self.client.get(url)
+            self.assertEqual(r.status_code, 404, f"GET of charter named {bad_name} should 404")
+            r = self.client.post(url, {})
+            self.assertEqual(r.status_code, 404, f"POST of charter named {bad_name} should 404")
+
+        irtf_group = GroupFactory(type_id="rg")
+        for bad_name in ("charter-ietf-{}", "charter-whatisthis-{}", "charter-irtf-thisisnotagroup"):
+            url = urlreverse("ietf.doc.views_charter.submit", kwargs={"name": bad_name.format(irtf_group.acronym)})
+            r = self.client.get(url)
+            self.assertEqual(r.status_code, 404, f"GET of charter named {bad_name} should 404")
+            r = self.client.post(url, {})
+            self.assertEqual(r.status_code, 404, f"POST of charter named {bad_name} should 404")
+
     def test_edit_review_announcement_text(self):
         area = GroupFactory(type_id='area')
         RoleFactory(name_id='ad',group=area,person=Person.objects.get(user__username='ad'))

--- a/ietf/doc/utils_charter.py
+++ b/ietf/doc/utils_charter.py
@@ -3,10 +3,11 @@
 
 
 import datetime
-import io
 import os
 import re
 import shutil
+
+from pathlib import Path
 
 from django.conf import settings
 from django.urls import reverse as urlreverse
@@ -62,10 +63,9 @@ def next_approved_revision(rev):
     return "%#02d" % (int(m.group('major')) + 1)
 
 def read_charter_text(doc):
-    filename = os.path.join(settings.CHARTER_PATH, '%s-%s.txt' % (doc.name, doc.rev))
+    filename = Path(settings.CHARTER_PATH) / f"{doc.name}-{doc.rev}.txt"
     try:
-        with io.open(filename, 'r') as f:
-            return f.read()
+        return filename.read_text()
     except IOError:
         return "Error: couldn't read charter text"
 

--- a/ietf/doc/utils_charter.py
+++ b/ietf/doc/utils_charter.py
@@ -62,7 +62,7 @@ def next_approved_revision(rev):
     return "%#02d" % (int(m.group('major')) + 1)
 
 def read_charter_text(doc):
-    filename = os.path.join(settings.CHARTER_PATH, '%s-%s.txt' % (doc.canonical_name(), doc.rev))
+    filename = os.path.join(settings.CHARTER_PATH, '%s-%s.txt' % (doc.name, doc.rev))
     try:
         with io.open(filename, 'r') as f:
             return f.read()
@@ -92,8 +92,8 @@ def change_group_state_after_charter_approval(group, by):
 def fix_charter_revision_after_approval(charter, by):
     # according to spec, 00-02 becomes 01, so copy file and record new revision
     try:
-        old = os.path.join(charter.get_file_path(), '%s-%s.txt' % (charter.canonical_name(), charter.rev))
-        new = os.path.join(charter.get_file_path(), '%s-%s.txt' % (charter.canonical_name(), next_approved_revision(charter.rev)))
+        old = os.path.join(charter.get_file_path(), '%s-%s.txt' % (charter.name, charter.rev))
+        new = os.path.join(charter.get_file_path(), '%s-%s.txt' % (charter.name, next_approved_revision(charter.rev)))
         shutil.copy(old, new)
     except IOError:
         log("There was an error copying %s to %s" % (old, new))
@@ -101,7 +101,7 @@ def fix_charter_revision_after_approval(charter, by):
     events = []
     e = NewRevisionDocEvent(doc=charter, by=by, type="new_revision")
     e.rev = next_approved_revision(charter.rev)
-    e.desc = "New version available: <b>%s-%s.txt</b>" % (charter.canonical_name(), e.rev)
+    e.desc = "New version available: <b>%s-%s.txt</b>" % (charter.name, e.rev)
     e.save()
     events.append(e)
 

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -899,7 +899,7 @@ def approve(request, name):
 
 
 def charter_with_milestones_txt(request, name, rev):
-    charter = get_object_or_404(Document, type="charter", docalias__name=name)
+    charter = get_object_or_404(Document, type="charter", name=name)
 
     revision_event = charter.latest_event(
         NewRevisionDocEvent, type="new_revision", rev=rev

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -580,11 +580,11 @@ def review_announcement_text(request, name):
 
             if request.GET.get("next", "") == "approve":
                 return redirect(
-                    "ietf.doc.views_charter.approve", name=charter.canonical_name()
+                    "ietf.doc.views_charter.approve", name=charter.name
                 )
 
             return redirect(
-                "ietf.doc.views_doc.document_writeup", name=charter.canonical_name()
+                "ietf.doc.views_doc.document_writeup", name=charter.name
             )
 
         if "regenerate_text" in request.POST:
@@ -678,11 +678,11 @@ def action_announcement_text(request, name):
 
             if request.GET.get("next", "") == "approve":
                 return redirect(
-                    "ietf.doc.views_charter.approve", name=charter.canonical_name()
+                    "ietf.doc.views_charter.approve", name=charter.name
                 )
 
             return redirect(
-                "ietf.doc.views_doc.document_writeup", name=charter.canonical_name()
+                "ietf.doc.views_doc.document_writeup", name=charter.name
             )
 
         if "regenerate_text" in request.POST:

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -835,30 +835,36 @@ def approve(request, name):
 def charter_with_milestones_txt(request, name, rev):
     charter = get_object_or_404(Document, type="charter", docalias__name=name)
 
-    revision_event = charter.latest_event(NewRevisionDocEvent, type="new_revision", rev=rev)
+    revision_event = charter.latest_event(
+        NewRevisionDocEvent, type="new_revision", rev=rev
+    )
     if not revision_event:
         return HttpResponseNotFound("Revision %s not found in database" % rev)
 
     # read charter text
     c = find_history_active_at(charter, revision_event.time) or charter
-    filename = '%s-%s.txt' % (c.canonical_name(), rev)
+    filename = "%s-%s.txt" % (c.canonical_name(), rev)
 
     charter_text = ""
 
     try:
-        with io.open(os.path.join(settings.CHARTER_PATH, filename), 'r') as f:
-            charter_text = force_str(f.read(), errors='ignore')
+        with io.open(os.path.join(settings.CHARTER_PATH, filename), "r") as f:
+            charter_text = force_str(f.read(), errors="ignore")
     except IOError:
         charter_text = "Error reading charter text %s" % filename
 
     milestones = historic_milestones_for_charter(charter, rev)
 
     # wrap the output nicely
-    wrapper = textwrap.TextWrapper(initial_indent="", subsequent_indent=" " * 11, width=80, break_long_words=False)
+    wrapper = textwrap.TextWrapper(
+        initial_indent="", subsequent_indent=" " * 11, width=80, break_long_words=False
+    )
     for m in milestones:
         m.desc_filled = wrapper.fill(m.desc)
 
-    return render(request, 'doc/charter/charter_with_milestones.txt',
-                  dict(charter_text=charter_text,
-                       milestones=milestones),
-                  content_type="text/plain; charset=%s"%settings.DEFAULT_CHARSET)
+    return render(
+        request,
+        "doc/charter/charter_with_milestones.txt",
+        dict(charter_text=charter_text, milestones=milestones),
+        content_type="text/plain; charset=%s" % settings.DEFAULT_CHARSET,
+    )

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -3,9 +3,7 @@
 
 
 import datetime
-import io
 import json
-import os
 import textwrap
 
 from pathlib import Path
@@ -832,6 +830,7 @@ def approve(request, name):
                   dict(charter=charter,
                        announcement=escape(announcement)))
 
+
 def charter_with_milestones_txt(request, name, rev):
     charter = get_object_or_404(Document, type="charter", docalias__name=name)
 
@@ -843,15 +842,12 @@ def charter_with_milestones_txt(request, name, rev):
 
     # read charter text
     c = find_history_active_at(charter, revision_event.time) or charter
-    filename = "%s-%s.txt" % (c.canonical_name(), rev)
-
-    charter_text = ""
-
+    filename = Path(settings.CHARTER_PATH) / f"{c.name}-{rev}.txt"
     try:
-        with io.open(os.path.join(settings.CHARTER_PATH, filename), "r") as f:
+        with filename.open() as f:
             charter_text = force_str(f.read(), errors="ignore")
     except IOError:
-        charter_text = "Error reading charter text %s" % filename
+        charter_text = f"Error reading charter text {filename.name}"
 
     milestones = historic_milestones_for_charter(charter, rev)
 

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -365,9 +365,6 @@ class UploadForm(forms.Form):
 
 @login_required
 def submit(request, name, option=None):
-    if not name.startswith("charter-"):
-        raise Http404
-
     # Charters are named "charter-<ietf|irtf>-<group acronym>"
     charter = Document.objects.filter(type="charter", name=name).first()
     if charter:

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -643,7 +643,7 @@ def review_announcement_text(request, name):
         ),
     )
 
-@role_required('Area Director','Secretariat')
+@role_required("Area Director", "Secretariat")
 def action_announcement_text(request, name):
     """Editing of action announcement text"""
     charter = get_object_or_404(Document, type="charter", name=name)
@@ -658,16 +658,18 @@ def action_announcement_text(request, name):
     if not existing:
         raise Http404
 
-    form = ActionAnnouncementTextForm(initial=dict(announcement_text=escape(existing.text)))
+    form = ActionAnnouncementTextForm(
+        initial=dict(announcement_text=escape(existing.text))
+    )
 
-    if request.method == 'POST':
+    if request.method == "POST":
         form = ActionAnnouncementTextForm(request.POST)
         if "save_text" in request.POST and form.is_valid():
-            t = form.cleaned_data['announcement_text']
+            t = form.cleaned_data["announcement_text"]
             if t != existing.text:
                 e = WriteupDocEvent(doc=charter, rev=charter.rev)
                 e.by = by
-                e.type = "changed_action_announcement" 
+                e.type = "changed_action_announcement"
                 e.desc = "%s action text was changed" % group.type.name
                 e.text = t
                 e.save()
@@ -675,25 +677,46 @@ def action_announcement_text(request, name):
                 existing.save()
 
             if request.GET.get("next", "") == "approve":
-                return redirect('ietf.doc.views_charter.approve', name=charter.canonical_name())
+                return redirect(
+                    "ietf.doc.views_charter.approve", name=charter.canonical_name()
+                )
 
-            return redirect('ietf.doc.views_doc.document_writeup', name=charter.canonical_name())
+            return redirect(
+                "ietf.doc.views_doc.document_writeup", name=charter.canonical_name()
+            )
 
         if "regenerate_text" in request.POST:
             e = default_action_text(group, charter, by)
             e.save()
-            form = ActionAnnouncementTextForm(initial=dict(announcement_text=escape(e.text)))
+            form = ActionAnnouncementTextForm(
+                initial=dict(announcement_text=escape(e.text))
+            )
 
         if "send_text" in request.POST and form.is_valid():
-            parsed_msg = send_mail_preformatted(request, form.cleaned_data['announcement_text'])
-            messages.success(request, "The email To: '%s' with Subject: '%s' has been sent." % (parsed_msg["To"],parsed_msg["Subject"],))
-            return redirect('ietf.doc.views_doc.document_writeup', name=charter.name)
+            parsed_msg = send_mail_preformatted(
+                request, form.cleaned_data["announcement_text"]
+            )
+            messages.success(
+                request,
+                "The email To: '%s' with Subject: '%s' has been sent."
+                % (
+                    parsed_msg["To"],
+                    parsed_msg["Subject"],
+                ),
+            )
+            return redirect("ietf.doc.views_doc.document_writeup", name=charter.name)
 
-    return render(request, 'doc/charter/action_announcement_text.html',
-                  dict(charter=charter,
-                       back_url=urlreverse('ietf.doc.views_doc.document_writeup', kwargs=dict(name=charter.name)),
-                       announcement_text_form=form,
-                  ))
+    return render(
+        request,
+        "doc/charter/action_announcement_text.html",
+        dict(
+            charter=charter,
+            back_url=urlreverse(
+                "ietf.doc.views_doc.document_writeup", kwargs=dict(name=charter.name)
+            ),
+            announcement_text_form=form,
+        ),
+    )
 
 class BallotWriteupForm(forms.Form):
     ballot_writeup = forms.CharField(widget=forms.Textarea, required=True, strip=False)

--- a/ietf/doc/views_charter.py
+++ b/ietf/doc/views_charter.py
@@ -437,7 +437,7 @@ def submit(request, name, option=None):
 
             # Save file on disk
             charter_filename = charter_filename.with_name(
-                f"{name}-{charter.rev}"
+                f"{name}-{charter.rev}.txt"
             )  # update rev
             with charter_filename.open("w", encoding="utf-8") as destination:
                 if form.cleaned_data["txt"]:

--- a/ietf/group/milestones.py
+++ b/ietf/group/milestones.py
@@ -369,7 +369,7 @@ def edit_milestones(request, acronym, group_type=None, milestone_set="current"):
                     email_milestones_changed(request, group, changes, states)
 
                 if milestone_set == "charter":
-                    return redirect('ietf.doc.views_doc.document_main', name=group.charter.canonical_name())
+                    return redirect('ietf.doc.views_doc.document_main', name=group.charter.name)
                 else:
                     return HttpResponseRedirect(group.about_url())
     else:

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -117,8 +117,9 @@ class GroupPagesTests(TestCase):
 
         chair = Email.objects.filter(role__group=group, role__name="chair")[0]
 
-        with (Path(settings.CHARTER_PATH) / ("%s-%s.txt" % (group.charter.canonical_name(), group.charter.rev))).open("w") as f:
-            f.write("This is a charter.")
+        (
+            Path(settings.CHARTER_PATH) / f"{group.charter.name}-{group.charter.rev}.txt"
+         ).write_text("This is a charter.")
 
         url = urlreverse('ietf.group.views.wg_summary_area', kwargs=dict(group_type="wg"))
         r = self.client.get(url)
@@ -264,8 +265,9 @@ class GroupPagesTests(TestCase):
         group = CharterFactory().group
         draft = WgDraftFactory(group=group)
 
-        with (Path(settings.CHARTER_PATH) / ("%s-%s.txt" % (group.charter.canonical_name(), group.charter.rev))).open("w") as f:
-            f.write("This is a charter.")
+        (
+            Path(settings.CHARTER_PATH) / f"{group.charter.name}-{group.charter.rev}.txt"
+        ).write_text("This is a charter.")
 
         milestone = GroupMilestone.objects.create(
             group=group,
@@ -674,8 +676,9 @@ class GroupEditTests(TestCase):
         self.assertTrue(len(q('form .is-invalid')) > 0)
         
         # edit info
-        with (Path(settings.CHARTER_PATH) / ("%s-%s.txt" % (group.charter.canonical_name(), group.charter.rev))).open("w") as f:
-            f.write("This is a charter.")
+        (
+            Path(settings.CHARTER_PATH) / f"{group.charter.name}-{group.charter.rev}.txt"
+        ).write_text("This is a charter.")
         area = group.parent
         ad = Person.objects.get(name="Areað Irector")
         state = GroupStateName.objects.get(slug="bof")
@@ -717,7 +720,9 @@ class GroupEditTests(TestCase):
         self.assertEqual(group.list_archive, "archive.mars")
         self.assertEqual(group.description, '')
 
-        self.assertTrue((Path(settings.CHARTER_PATH) / ("%s-%s.txt" % (group.charter.canonical_name(), group.charter.rev))).exists())
+        self.assertTrue(
+            (Path(settings.CHARTER_PATH) / f"{group.charter.name}-{group.charter.rev}.txt").exists()
+        )
         self.assertEqual(len(outbox), 2)
         self.assertTrue('Personnel change' in outbox[0]['Subject'])
         for prefix in ['ad1','ad2','aread','marschairman','marsdelegate']:

--- a/ietf/group/utils.py
+++ b/ietf/group/utils.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-import io
-import os
+from pathlib import Path
 
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
@@ -55,15 +54,14 @@ def get_charter_text(group):
         if (h.rev > c.rev and not (c_appr and not h_appr)) or (h_appr and not c_appr):
             c = h
 
-    filename = os.path.join(c.get_file_path(), "%s-%s.txt" % (c.canonical_name(), c.rev))
+    filename = Path(c.get_file_path()) / f"{c.name}-{c.rev}.txt"
     try:
-        with io.open(filename, 'rb') as f:
-            text = f.read()
-            try:
-                text = text.decode('utf8')
-            except UnicodeDecodeError:
-                text = text.decode('latin1')
-            return text
+        text = filename.read_bytes()
+        try:
+            text = text.decode('utf8')
+        except UnicodeDecodeError:
+            text = text.decode('latin1')
+        return text
     except IOError:
         return 'Error Loading Group Charter'
 

--- a/ietf/secr/utils/group.py
+++ b/ietf/secr/utils/group.py
@@ -3,10 +3,8 @@
 
 
 # Python imports
-from pathlib import Path
 
 # Django imports
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 # Datatracker imports

--- a/ietf/secr/utils/group.py
+++ b/ietf/secr/utils/group.py
@@ -3,8 +3,7 @@
 
 
 # Python imports
-import io
-import os
+from pathlib import Path
 
 # Django imports
 from django.conf import settings
@@ -14,27 +13,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from ietf.group.models import Group
 from ietf.ietfauth.utils import has_role
 
-
-
-
-def current_nomcom():
-    qs = Group.objects.filter(acronym__startswith='nomcom',state__slug="active").order_by('-time')
-    if qs.count():
-        return qs[0]
-    else:
-        return None
-
-def get_charter_text(group):
-    '''
-    Takes a group object and returns the text or the group's charter as a string
-    '''
-    charter = group.charter
-    path = os.path.join(settings.CHARTER_PATH, '%s-%s.txt' % (charter.canonical_name(), charter.rev))
-    f = io.open(path,'r')
-    text = f.read()
-    f.close()
-
-    return text
 
 def get_my_groups(user,conclude=False):
     '''

--- a/ietf/templates/doc/charter/action_announcement_text.html
+++ b/ietf/templates/doc/charter/action_announcement_text.html
@@ -21,7 +21,7 @@
         </button>
         {% if user|has_role:"Secretariat" %}
             <a class="btn btn-primary"
-               href="{% url 'ietf.doc.views_charter.approve' name=charter.canonical_name %}">
+               href="{% url 'ietf.doc.views_charter.approve' name=charter.name %}">
                 Charter approval page
             </a>
         {% endif %}

--- a/ietf/templates/doc/charter/approve.html
+++ b/ietf/templates/doc/charter/approve.html
@@ -2,16 +2,16 @@
 {# Copyright The IETF Trust 2015, All Rights Reserved #}
 {% load origin %}
 {% load django_bootstrap5 %}
-{% block title %}Approve {{ charter.canonical_name }}{% endblock %}
+{% block title %}Approve {{ charter.name }}{% endblock %}
 {% block content %}
     {% origin %}
-    <h1>Approve {{ charter.canonical_name }}-{{ charter.rev }}</h1>
+    <h1>Approve {{ charter.name }}-{{ charter.rev }}</h1>
     <form class="mt-3" method="post">
         {% csrf_token %}
         <pre class="border p-3">{{ announcement }}</pre>
         <button type="submit" class="btn btn-primary">Send announcement, close ballot &amp; update revision</button>
         <a class="btn btn-warning"
-           href="{% url "ietf.doc.views_charter.action_announcement_text" name=charter.canonical_name %}?next=approve">
+           href="{% url "ietf.doc.views_charter.action_announcement_text" name=charter.name %}?next=approve">
             Edit/regenerate announcement
         </a>
         <a class="btn btn-secondary float-end"

--- a/ietf/templates/doc/charter/change_ad.html
+++ b/ietf/templates/doc/charter/change_ad.html
@@ -2,20 +2,20 @@
 {# Copyright The IETF Trust 2015, All Rights Reserved #}
 {% load origin %}
 {% load django_bootstrap5 %}
-{% block title %}Change responsible AD for {{ charter.canonical_name }}-{{ charter.rev }}{% endblock %}
+{% block title %}Change responsible AD for {{ charter.name }}-{{ charter.rev }}{% endblock %}
 {% block content %}
     {% origin %}
     <h1>
         Change responsible AD
         <br>
-        <small class="text-muted">{{ charter.canonical_name }}-{{ charter.rev }}</small>
+        <small class="text-muted">{{ charter.name }}-{{ charter.rev }}</small>
     </h1>
     <form class="mt-3" enctype="multipart/form-data" method="post">
         {% csrf_token %}
         {% bootstrap_form form %}
         <button type="submit" class="btn btn-primary">Submit</button>
         <a class="btn btn-secondary float-end"
-           href="{% url "ietf.doc.views_doc.document_main" name=charter.canonical_name %}">
+           href="{% url "ietf.doc.views_doc.document_main" name=charter.name %}">
             Back
         </a>
     </form>

--- a/ietf/templates/group/edit_milestones.html
+++ b/ietf/templates/group/edit_milestones.html
@@ -14,8 +14,8 @@
         <a class="btn btn-primary" href="{{ group.about_url }}">{{ group.acronym }} {{ group.type.name }}</a>
         {% if group.charter %}
             <a class="btn btn-primary"
-               href="{% url "ietf.doc.views_doc.document_main" name=group.charter.canonical_name %}">
-                {{ group.charter.canonical_name }}
+               href="{% url "ietf.doc.views_doc.document_main" name=group.charter.name %}">
+                {{ group.charter.name }}
             </a>
         {% endif %}
         {% if can_change_uses_milestone_dates %}
@@ -106,7 +106,7 @@
             </div>
         </div>
         <a class="btn btn-secondary float-end"
-           href="{% if milestone_set == "charter" %}{% url "ietf.doc.views_doc.document_main" name=group.charter.canonical_name %}{% else %}{{ group.about_url }}{% endif %}">
+           href="{% if milestone_set == "charter" %}{% url "ietf.doc.views_doc.document_main" name=group.charter.name %}{% else %}{{ group.about_url }}{% endif %}">
             Cancel
         </a>
         <button class="btn btn-primary hidden"


### PR DESCRIPTION
Removes the special case for `charter` type documents from `canonical_name()`. Uses of `canonical_name()` are replaced with `charter.name` or the equivalent. Prevents creation of charter `Document` instances with names not matching the expected format.