### PR TITLE
fix: Include time zone information in v1 api datetimes

### DIFF
--- a/ietf/api/__init__.py
+++ b/ietf/api/__init__.py
@@ -155,4 +155,4 @@ class ToOneField(tastypie.fields.ToOneField):
 
 class Serializer(tastypie.serializers.Serializer):
     def format_datetime(self, data):
-        return data.astimezone(datetime.timezone.utc).isoformat(timespec="seconds")
+        return data.astimezone(datetime.timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds") + "Z"

--- a/ietf/api/__init__.py
+++ b/ietf/api/__init__.py
@@ -12,12 +12,11 @@ from django.core.exceptions import ObjectDoesNotExist
 
 import debug                            # pyflakes:ignore
 
-import tastypie
 import tastypie.resources
+import tastypie.serializers
 from tastypie.api import Api
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError
-from tastypie.serializers import Serializer # pyflakes:ignore (we're re-exporting this)
 from tastypie.fields import ApiField
 
 _api_list = []
@@ -152,3 +151,8 @@ class ToOneField(tastypie.fields.ToOneField):
             dehydrated = self.dehydrate_related(fk_bundle, fk_resource, for_list=for_list)
             fk_resource._meta.cache.set(cache_key, dehydrated)
         return dehydrated
+
+
+class Serializer(tastypie.serializers.Serializer):
+    def format_datetime(self, data):
+        return data.astimezone(datetime.timezone.utc).isoformat(timespec="seconds")


### PR DESCRIPTION
This customizes the Tastypie serializer to change datetimes in the v1 API JSON to be of the format `"2023-03-24T09:36:43+00:00"`. That is, it adds the time zone offset and suppresses fractional seconds.

However, to my reading of [draft-ietf-sedate-datetime-extended](https://www.ietf.org/archive/id/draft-ietf-sedate-datetime-extended-08.html), a Z suffix is appropriate when UTC is used incidentally rather than because it is meaningful as a local time. I think that means that a Z would be better as our default, and in (any?) cases where we're serializing times that have a significant local time, we can override the default. I don't know whether there are any where we'd care.

To do this, we just change the `format_datetime()` method to return
```
        return data.astimezone(datetime.timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds") + "Z"
```