### PR TITLE
fix: Set has_onsite_tool correctly in no_session() view

### DIFF
--- a/ietf/secr/sreq/views.py
+++ b/ietf/secr/sreq/views.py
@@ -730,6 +730,7 @@ def no_session(request, acronym):
         requested_duration=datetime.timedelta(0),
         type_id='regular',
         purpose_id='regular',
+        has_onsite_tool=group.features.acts_like_wg,
     )
     SchedulingEvent.objects.create(
         session=session,


### PR DESCRIPTION
This will set the `has_onsite_tool` flag correctly when reporting that a group will not be meeting. This is needed in case the `Session` is later changed to one that will meet.