### PR TITLE
fix: Create relationships between draft and rfc Documents

### DIFF
--- a/ietf/doc/migrations/0007_create_rfc_documents.py
+++ b/ietf/doc/migrations/0007_create_rfc_documents.py
@@ -24,7 +24,7 @@ def forward(apps, schema_editor):
     assert set(found_by_name) == set(found_by_state), "mismatch between rfcs identified by state and docalias"
     
     # As of 2023-06-15, there is one Document with two rfc aliases: rfc6312 and rfc6342 are the same Document. This 
-    # was due to a publication error. We'll handle that specially.
+    # was due to a publication error. Because we go alias-by-alias, no special handling is needed in this migration.
     
     for rfc_alias in rfc_docaliases.order_by("name"):
         assert rfc_alias.docs.count() == 1, f"DocAlias {rfc_alias} is linked to more than 1 Document"

--- a/ietf/doc/migrations/0009_move_rfc_docaliases.py
+++ b/ietf/doc/migrations/0009_move_rfc_docaliases.py
@@ -14,14 +14,17 @@ def forward(apps, schema_editor):
 
     for rfc_alias in DocAlias.objects.filter(name__startswith="rfc"):
         rfc = Document.objects.get(name=rfc_alias.name)
-        if not rfc_alias.docs.filter(pk=rfc.pk).exists():
+        aliased_doc = rfc_alias.docs.get()  # implicitly confirms only one value in rfc_alias.docs
+        if aliased_doc != rfc:
             # If the DocAlias was not already pointing at the rfc, it was pointing at the draft
             # it came from. Create the relationship between draft and rfc Documents.
+            assert aliased_doc.type_id == "draft", f"Alias for {rfc.name} should be pointing at a draft"
             RelatedDocument.objects.create(
-                source=rfc_alias.docs.first(),  # the draft Document
-                target=rfc_alias,  # alias that will point to the rfc Document
+                source=aliased_doc,
+                target=rfc_alias,
                 relationship_id="became-rfc",
             )
+            # Now move the alias from the draft to the rfc 
             rfc_alias.docs.set([rfc])
 
 


### PR DESCRIPTION
Links `rfc` Document and the `DocAlias` for its progenitor draft with a `became-rfc` relationship.