### PR TITLE
chore: Remove temporary pin on pydantic

### DIFF
--- a/ietf/secr/sreq/tests.py
+++ b/ietf/secr/sreq/tests.py
@@ -146,7 +146,7 @@ class SessionRequestTestCase(TestCase):
         self.assertRedirects(r, redirect_url)
 
         # Check whether updates were stored in the database
-        sessions = Session.objects.filter(meeting=meeting, group=mars)
+        sessions = Session.objects.filter(meeting=meeting, group=mars).order_by("id")  # order to match edit() view
         self.assertEqual(len(sessions), 2)
         session = sessions[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,4 +72,3 @@ Unidecode>=1.3.4
 weasyprint>=59
 xml2rfc>=3.12.4
 xym>=0.6,<1.0
-pydantic<2 # Temporary pin until inflect can catch up.


### PR DESCRIPTION
Pin is not needed since inflect 6.0.5. As of inflect 6.1.0, pydantic 2.0 is supported.