### PR TITLE
refactor: Replace is_rfc() tests

### DIFF
--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -317,12 +317,9 @@ def get_previous_url(name, rev=None):
     previous_url = ''
     if condition in ('historic version', 'current version'):
         doc = history if history else document
-        if found_rev:
-            doc.is_rfc = lambda: False
         previous_url = doc.get_href()
     elif condition == 'version dochistory not found':
         document.rev = found_rev
-        document.is_rfc = lambda: False
         previous_url = document.get_href()
     return previous_url
 
@@ -335,7 +332,7 @@ def rfcdiff_latest_json(request, name, rev=None):
         raise Http404
     elif condition in ('historic version', 'current version'):
         doc = history if history else document
-        if not found_rev and doc.is_rfc():
+        if not found_rev and doc.type_id == "rfc":
             response['content_url'] = doc.get_href()
             response['name']=doc.canonical_name()
             if doc.name != doc.canonical_name():
@@ -345,7 +342,6 @@ def rfcdiff_latest_json(request, name, rev=None):
                 response['previous'] = f'{doc.name}-{prev_rev}'
                 response['previous_url'] = get_previous_url(doc.name, prev_rev)
         else:
-            doc.is_rfc = lambda: False
             response['content_url'] = doc.get_href()
             response['rev'] = doc.rev
             response['name'] = doc.name
@@ -371,7 +367,6 @@ def rfcdiff_latest_json(request, name, rev=None):
         response['name'] = document.name
         response['rev'] = found_rev
         document.rev = found_rev
-        document.is_rfc = lambda: False
         response['content_url'] = document.get_href()
         # not sure what to do if non-numeric values come back, so at least log it
         log.assertion('found_rev.isdigit()')

--- a/ietf/doc/forms.py
+++ b/ietf/doc/forms.py
@@ -148,7 +148,7 @@ class AddDownrefForm(forms.Form):
             raise forms.ValidationError("Please provide a referenced RFC and a referencing Internet-Draft")
 
         rfc = self.cleaned_data['rfc']
-        if not rfc.document.is_rfc():
+        if rfc.type_id != "rfc":
             raise forms.ValidationError("Cannot find the RFC: " + rfc.name)
         return rfc
 

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -245,7 +245,7 @@ class DocumentInfo(models.Model):
                     format = settings.DOC_HREFS[self.type_id]
             elif self.type_id in settings.DOC_HREFS:
                 self.is_meeting_related = False
-                if self.is_rfc():
+                if self.type_id == "rfc":
                     format = settings.DOC_HREFS['rfc']
                 else:
                     format = settings.DOC_HREFS[self.type_id]
@@ -382,9 +382,6 @@ class DocumentInfo(models.Model):
                 return state.name
         else:
             return state.name
-
-    def is_rfc(self):
-        return self.type_id == "rfc"
 
     def author_list(self):
         best_addresses = []
@@ -994,7 +991,7 @@ class Document(DocumentInfo):
 
         This is the rfc publication date for RFCs, and the new-revision date for other documents.
         """
-        if self.is_rfc():
+        if self.type_id == "rfc":
             # As of Sept 2022, in ietf.sync.rfceditor.update_docs_from_rfc_index() `published_rfc` events are
             # created with a timestamp whose date *in the PST8PDT timezone* is the official publication date
             # assigned by the RFC editor.

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -556,7 +556,7 @@ def consensus(doc):
 @register.filter
 def std_level_to_label_format(doc):
     """Returns valid Bootstrap classes to label a status level badge."""
-    if doc.is_rfc():
+    if doc.type_id == "rfc":
         if doc.related_that("obs"):
             return "obs"
         else:

--- a/ietf/doc/utils_search.py
+++ b/ietf/doc/utils_search.py
@@ -93,7 +93,7 @@ def fill_in_document_table_attributes(docs, have_telechat_date=False):
         # emulate canonical name which is used by a lot of the utils
         # d.canonical_name = wrap_value(rfc_aliases[d.pk] if d.pk in rfc_aliases else d.name)
 
-        if d.is_rfc() and d.latest_event_cache["published_rfc"]:
+        if d.type_id == "rfc" and d.latest_event_cache["published_rfc"]:
             d.latest_revision_date = d.latest_event_cache["published_rfc"].time
         elif d.latest_event_cache["new_revision"]:
             d.latest_revision_date = d.latest_event_cache["new_revision"].time

--- a/ietf/doc/views_ballot.py
+++ b/ietf/doc/views_ballot.py
@@ -953,7 +953,13 @@ def approve_downrefs(request, name):
 
     login = request.user.person
 
-    downrefs_to_rfc = [rel for rel in doc.relateddocument_set.all() if rel.is_downref() and not rel.is_approved_downref() and rel.target.document.is_rfc()]
+    downrefs_to_rfc = [
+        rel
+        for rel in doc.relateddocument_set.all()
+        if rel.is_downref()
+        and not rel.is_approved_downref()
+        and rel.target.document.type_id == "rfc"
+    ]
 
     downrefs_to_rfc_qs = RelatedDocument.objects.filter(pk__in=[r.pk for r in downrefs_to_rfc])        
 

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -240,7 +240,7 @@ def document_main(request, name, rev=None, document_html=False):
 
 
     # specific document types
-    if doc.is_rfc():
+    if doc.type_id == "rfc":
         split_content = request.COOKIES.get("full_draft", settings.USER_PREFERENCE_DEFAULTS["full_draft"]) == "off"
         if request.GET.get('include_text') == "0":
             split_content = True
@@ -988,7 +988,7 @@ def document_html(request, name, rev=None):
     doc = found.documents.get()
     rev = found.matched_rev
 
-    if not requested_rev and doc.is_rfc(): # Someone asked for /doc/html/8989
+    if not requested_rev and doc.type_id == "rfc": # Someone asked for /doc/html/8989
         if not name.startswith('rfc'):
             return redirect('ietf.doc.views_doc.document_html', name=doc.canonical_name())
 
@@ -998,7 +998,12 @@ def document_html(request, name, rev=None):
     if not os.path.exists(doc.get_file_name()):
         raise Http404("File not found: %s" % doc.get_file_name())
 
-    return document_main(request, name=doc.name if requested_rev else doc.canonical_name(), rev=doc.rev if requested_rev or not doc.is_rfc() else None, document_html=True)
+    return document_main(
+        request,
+        name=doc.name if requested_rev else doc.canonical_name(),
+        rev=doc.rev if requested_rev or doc.type_id != "rfc" else None,
+        document_html=True,
+    )
 
 def document_pdfized(request, name, rev=None, ext=None):
 
@@ -1221,7 +1226,7 @@ def document_bibtex(request, name, rev=None):
                 doc = h
                 break
 
-    if doc.is_rfc():
+    if doc.type_id == "rfc":
         # This needs to be replaced with a lookup, as the mapping may change
         # over time.  Probably by updating ietf/sync/rfceditor.py to add the
         # as a DocAlias, and use a method on Document to retrieve it.

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -534,7 +534,7 @@ def group_documents_txt(request, acronym, group_type=None):
 
     rows = []
     for d in itertools.chain(docs, docs_related):
-        if d.is_rfc():
+        if d.type_id == "rfc":
             name = str(d.rfc_number)
         else:
             name = "%s-%s" % (d.name, d.rev)

--- a/ietf/iesg/views.py
+++ b/ietf/iesg/views.py
@@ -151,7 +151,7 @@ def agenda_json(request, date=None):
                 if doc.type_id == "draft":
                     docinfo['rev'] = doc.rev
                     docinfo['intended-std-level'] = str(doc.intended_std_level)
-                    if doc.is_rfc():
+                    if doc.type_id == "rfc":
                         docinfo['rfc-number'] = doc.rfc_number
 
                     iana_state = doc.get_state("draft-iana-review")

--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -11,7 +11,7 @@
         <th scope="row">{% if document_html %}Document type{% else %}Type{% endif %}</th>
         <td class="edit"></td>
         <td>
-            {% if doc.is_rfc %}
+            {% if doc.type_id == "rfc" %}
                 <span class="text-success">RFC
                     {% if not document_html %}
                     - {{ doc.std_level }}
@@ -19,7 +19,7 @@
                         <span class="badge rounded-pill badge-{% if not snapshot %}{{ doc|std_level_to_label_format }}{% else %}draft{% endif %}">{{ doc.std_level }}</span>
                     {% endif %}
                 </span>
-                {% if doc.is_rfc %}
+                {% if doc.type_id == "rfc" %}
                     {% if document_html %}<br>{% else %}({% endif %}{{ doc.pub_date|date:"F Y" }}{% if not document_html %}){% endif %}
                 {% else %}
                     <span class="text-muted">(Publication date unknown)</span>
@@ -132,7 +132,7 @@
         </td>
     </tr>
     {% endif %}
-    {% if not doc.is_rfc %}
+    {% if doc.type_id != "rfc" %}
         {% if replaces or not document_html and can_edit_stream_info %}
             <tr>
                 <td></td>
@@ -265,7 +265,7 @@
             {% endif %}
         </td>
     </tr>
-    {% if not doc.is_rfc and not snapshot %}
+    {% if doc.type_id != "rfc" and not snapshot %}
         <tr>
             <td></td>
             <th scope="row">
@@ -341,7 +341,7 @@
             </tr>
         {% endif %}
     {% endfor %}
-        {% if not doc.is_rfc %}{# do not show reviews or conflict_reviews for RFCs, even if present #}
+        {% if doc.type_id != "rfc" %}{# do not show reviews or conflict_reviews for RFCs, even if present #}
             {% if review_assignments or can_request_review %}
                 <tr>
                     <td></td>

--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -19,7 +19,7 @@
                         <span class="badge rounded-pill badge-{% if not snapshot %}{{ doc|std_level_to_label_format }}{% else %}draft{% endif %}">{{ doc.std_level }}</span>
                     {% endif %}
                 </span>
-                {% if doc.type_id == "rfc" %}
+                {% if doc.pub_date %}
                     {% if document_html %}<br>{% else %}({% endif %}{{ doc.pub_date|date:"F Y" }}{% if not document_html %}){% endif %}
                 {% else %}
                     <span class="text-muted">(Publication date unknown)</span>

--- a/ietf/templates/doc/idnits2-state.txt
+++ b/ietf/templates/doc/idnits2-state.txt
@@ -1,5 +1,5 @@
 {% load ietf_filters %}{% filter linebreaks_lf %}{% comment %}
-{% endcomment %}Doc-tag: {{doc.name}};datatracker{% if doc.is_rfc %}
+{% endcomment %}Doc-tag: {{doc.name}};datatracker{% if doc.type_id == "rfc" %}
 Doc-rfcnum: {{doc.rfc_number}}{% endif %}
 Doc-created: {{doc.created|date:"Y-m-d"}};datatracker{% if doc.deststatus %}
 Doc-deststatus: {{doc.deststatus}};datatracker{% endif %}

--- a/ietf/utils/management/commands/check_draft_event_revision_integrity.py
+++ b/ietf/utils/management/commands/check_draft_event_revision_integrity.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             doc =  getattr(obj, docattr)
             time = getattr(obj, timeattr)
             if not obj.rev:
-                if not doc.is_rfc():
+                if doc.type_id != "rfc":
                     self.stdout.write("Bad revision number: %-52s: '%s'" % (doc.name, obj.rev))
                 continue
             rev = int(obj.rev.lstrip('0') or '0')


### PR DESCRIPTION
Mostly these become `type_id` checks. In one case, the check for `is_rfc()` was a bug that's fixed here.