### PR TITLE
feat: Add "generate email" to action on nominees page (#4893)

### DIFF
--- a/ietf/nomcom/views.py
+++ b/ietf/nomcom/views.py
@@ -209,7 +209,7 @@ def private_index(request, year):
                     nominations.update(state='pending')
                     messages.success(request,'The selected nominations have been set as pending')
                 elif action == 'email':
-                    mailto = ','.join([np.nominee.email.name_and_email() for np in nominations])
+                    mailto = ','.join([np.nominee.email.email_address() for np in nominations])
             else:
                 messages.warning(request, "Please, select some nominations to work with")
 

--- a/ietf/nomcom/views.py
+++ b/ietf/nomcom/views.py
@@ -190,6 +190,7 @@ def private_index(request, year):
     nomcom = get_nomcom_by_year(year)
     all_nominee_positions = NomineePosition.objects.get_by_nomcom(nomcom).not_duplicated()
     is_chair = nomcom.group.has_role(request.user, "chair")
+    mailto = None
     if is_chair and request.method == 'POST':
         if nomcom.group.state_id != 'active':
             messages.warning(request, "This nomcom is not active. Request administrative assistance if Nominee state needs to change.")
@@ -207,6 +208,8 @@ def private_index(request, year):
                 elif action == "set_as_pending":
                     nominations.update(state='pending')
                     messages.success(request,'The selected nominations have been set as pending')
+                elif action == 'email':
+                    mailto = ','.join([np.nominee.email.name_and_email() for np in nominations])
             else:
                 messages.warning(request, "Please, select some nominations to work with")
 
@@ -278,6 +281,7 @@ def private_index(request, year):
                                'selected_position': selected_position and int(selected_position) or None,
                                'selected': 'index',
                                'is_chair': is_chair,
+                               'mailto': mailto,
                               })
 
 

--- a/ietf/templates/nomcom/private_index.html
+++ b/ietf/templates/nomcom/private_index.html
@@ -234,12 +234,21 @@
                         <option value="set_as_declined">
                             Set as declined
                         </option>
+                        <option value="email">
+                            Generate email list
+                        </option>
                     </select>
                 </div>
                 <button class="btn btn-warning"  type="submit" title="Run action">
                     Apply
                 </button>
             </form>
+            {% if mailto %}
+                <br>
+                <a class="btn btn-primary btn-sm"
+		   href="mailto:{{ mailto }}">Mail to selected nominees
+                </a>
+            {% endif %}
         {% endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes #4893

Django doesn't allow `HttpResponseRedirect` to a `mailto` URL, so this adds a button `[Mail to selected nominees]` at the bottom of the page, with the `mailto` href.