### PR TITLE
feat: filter on meeting type

### DIFF
--- a/ietf/meeting/types.py
+++ b/ietf/meeting/types.py
@@ -1,12 +1,19 @@
 # Copyright The IETF Trust 2023, All Rights Reserved
+from typing import TYPE_CHECKING, Annotated
+
 import strawberry
 from strawberry import auto
+
 from . import models
+
+if TYPE_CHECKING:
+    from ietf.name.types import MeetingTypeName
 
 @strawberry.django.filters.filter(models.Meeting)
 class MeetingFilter:
     number: auto
     city: auto
+    type: auto
 
 @strawberry.django.type(
     models.Meeting,
@@ -15,3 +22,4 @@ class Meeting:
     id: auto
     number: auto
     city: auto
+    type: Annotated["MeetingTypeName", strawberry.lazy("ietf.name.types")]


### PR DESCRIPTION
Allows
```
query ietfMeetings {
  meetings(filters: {type: {pk: "ietf"}}) {
    number
    city
  }
}
```