### PR TITLE
chore(dev): fails to build a container in a GitHub Codespace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
             CELERY_APP: ietf
             CELERY_ROLE: worker
             UPDATE_REQUIREMENTS_FROM: requirements.txt
-            DEV_MODE: yes
+            DEV_MODE: "yes"
         command:
             - '--loglevel=INFO'
         depends_on:


### PR DESCRIPTION
Updates docker-compose to quote the `yes` value for the DEV_MODE property.  This change forces YAML 1.1 parsers to interpret the `yes` value as a string instead of implicitly treating it as a boolean.  

After making this change GitHub Codespaces can build the container 