### PR TITLE
fix: Clarify no-action-needed (#5918)

### DIFF
--- a/ietf/templates/submit/manual_post_request.txt
+++ b/ietf/templates/submit/manual_post_request.txt
@@ -2,6 +2,8 @@
 Hi,
 
 Manual posting has been requested for the following Internet-Draft.
+The IETF Secretariat will handle this request; no further action is
+required at this time.
 
 {% if errors %}The problems found during automated submission were: {% for err in errors.values %}
   - {{ err }}{% endfor %}


### PR DESCRIPTION
When a draft is submitted for manual processing, clarify that no action is needed; the Secretariat has the next steps.

#5918 says the "status" link also needs clarification, but I didn't find what to change.
