### PR TITLE
fix: Shows requested reviews for doc fixes

### DIFF
--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -79,7 +79,7 @@ from ietf.mailtrigger.utils import gather_relevant_expansions
 from ietf.meeting.models import Session
 from ietf.meeting.utils import group_sessions, get_upcoming_manageable_sessions, sort_sessions, add_event_info_to_session_qs
 from ietf.review.models import ReviewAssignment
-from ietf.review.utils import can_request_review_of_doc, review_assignments_to_list_for_docs
+from ietf.review.utils import can_request_review_of_doc, review_assignments_to_list_for_docs, review_requests_to_list_for_docs
 from ietf.review.utils import no_review_from_teams_on_doc
 from ietf.utils import markup_txt, log, markdown
 from ietf.utils.draft import PlaintextDraft
@@ -498,6 +498,7 @@ def document_main(request, name, rev=None, document_html=False):
         started_iesg_process = doc.latest_event(type="started_iesg_process")
 
         review_assignments = review_assignments_to_list_for_docs([doc]).get(doc.name, [])
+        review_requests = review_requests_to_list_for_docs([doc]).get(doc.name, [])
         no_review_from_teams = no_review_from_teams_on_doc(doc, rev or doc.rev)
 
         exp_comment = doc.latest_event(IanaExpertDocEvent,type="comment")
@@ -613,6 +614,7 @@ def document_main(request, name, rev=None, document_html=False):
                                        actions=actions,
                                        presentations=presentations,
                                        review_assignments=review_assignments,
+                                       review_requests=review_requests,
                                        no_review_from_teams=no_review_from_teams,
                                        due_date=due_date,
                                        diff_revisions=diff_revisions

--- a/ietf/review/utils.py
+++ b/ietf/review/utils.py
@@ -79,6 +79,11 @@ def review_assignments_to_list_for_docs(docs):
 
     return extract_revision_ordered_review_assignments_for_documents_and_replaced(assignment_qs, doc_names)
 
+def review_requests_to_list_for_docs(docs):
+    review_requests_qs = ReviewRequest.objects.filter(Q(state_id='requested'))
+    doc_names = [d.name for d in docs]
+    return extract_revision_ordered_review_requests_for_documents_and_replaced(review_requests_qs, doc_names)
+
 def augment_review_requests_with_events(review_reqs):
     req_dict = { r.pk: r for r in review_reqs }
     for e in ReviewRequestDocEvent.objects.filter(review_request__in=review_reqs, type__in=["assigned_review_request", "closed_review_request"]).order_by("time"):

--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -351,6 +351,9 @@ href="{% url 'ietf.doc.views_draft.review_possibly_replaces' name=doc.name %}">E
                 {% for review_assignment in review_assignments %}
                     {% include "doc/review_assignment_summary.html" with current_doc_name=doc.name current_rev=doc.rev %}
                 {% endfor %}
+                {% for review_request in review_requests %}
+                    {% include "doc/review_request_summary.html" with current_doc_name=doc.name current_rev=doc.rev %}
+                {% endfor %}
                 {% if no_review_from_teams %}
                     {% for team in no_review_from_teams %}
                         {{ team.acronym.upper }}{% if not forloop.last %},{% endif %}

--- a/ietf/templates/doc/document_info.html
+++ b/ietf/templates/doc/document_info.html
@@ -349,10 +349,10 @@ href="{% url 'ietf.doc.views_draft.review_possibly_replaces' name=doc.name %}">E
             </td>
             <td>
                 {% for review_assignment in review_assignments %}
-                    {% include "doc/review_assignment_summary.html" with current_doc_name=doc.name current_rev=doc.rev %}
+                    {% include "doc/review_assignment_summary.html" with current_doc_name=doc.name current_rev=doc.rev review_assignment=review_assignment only %}
                 {% endfor %}
                 {% for review_request in review_requests %}
-                    {% include "doc/review_request_summary.html" with current_doc_name=doc.name current_rev=doc.rev %}
+                    {% include "doc/review_request_summary.html" with review_request=review_request only %}
                 {% endfor %}
                 {% if no_review_from_teams %}
                     {% for team in no_review_from_teams %}

--- a/ietf/templates/doc/review_assignment_summary.html
+++ b/ietf/templates/doc/review_assignment_summary.html
@@ -20,9 +20,9 @@
     {% else %}
         <a class="text-body-secondary"
            href="{% url 'ietf.doc.views_review.review_request' review_assignment.review_request.doc.name review_assignment.review_request.pk %}">
-            {{ review_assignment.review_request.team.acronym|upper }} {{ review_assignment.review_request.type.name }} Review</a>
+            {{ review_assignment.review_request.team.acronym|upper }} {{ review_assignment.review_request.type.name }} Review due {{ review_assignment.review_request.deadline|date:"Y-m-d" }}</a>
         <span class="badge rounded-pill ms-1 bg-secondary">
-            Incomplete, due {{ review_assignment.review_request.deadline|date:"Y-m-d" }}
+            Incomplete
         </span>
     {% endif %}
 </div>

--- a/ietf/templates/doc/review_request_summary.html
+++ b/ietf/templates/doc/review_request_summary.html
@@ -1,0 +1,9 @@
+<div class="review-request-summary">
+   <a class="text-body-secondary"
+      href="{% url 'ietf.doc.views_review.review_request' review_request.doc.name review_request.pk %}">
+      {{ review_request.team.acronym|upper }} {{ review_request.type.name }} Review due {{ review_request.deadline|date:"Y-m-d" }}
+      </a>
+   <span class="badge rounded-pill ms-1 bg-secondary">
+      Requested
+   </span>
+</div>


### PR DESCRIPTION
Adds requested reviews to the document information page. Moved the due date of the incomplete reviews out from the badge to the actual text. 

Fixes #4881.