### PR TITLE
fix: Server error from api_get_session_materials()

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -725,6 +725,15 @@ class CustomApiTests(TestCase):
         self.assertEqual(r.status_code, 200)
         jsondata = r.json()
         self.assertEqual(jsondata['success'], True)
+    
+    def test_api_get_session_matherials_no_agenda_meeting_url(self):
+        meeting = MeetingFactory(type_id='ietf')
+        session = SessionFactory(meeting=meeting)
+        url = urlreverse('ietf.meeting.views.api_get_session_materials', kwargs={'session_id': session.pk})
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+
+
 
 class DirectAuthApiTests(TestCase):
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1704,9 +1704,11 @@ def api_get_session_materials (request, session_id=None):
         })
     else:
         pass  # no action available if it's past cutoff
-
+    
+    agenda = session.agenda() 
+    agenda_url = agenda.get_href() if agenda is not None else None
     return JsonResponse({
-        "url": session.agenda().get_href(),
+        "url": agenda_url,
         "slides": {
             "decks": list(map(agenda_extract_slide, session.slides())),
             "actions": slides_actions,


### PR DESCRIPTION
Fixes #5877 

Guard with None added.
I checked the frontend reaction and it seems like JS will just create empty url instance that won’t be shown as URL. However I did no create test for that and I won’t be able to, so maybe further actions needed (maybe not)