### PR TITLE
fix: return .md files as Markdown documents without rendering

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -581,9 +581,8 @@ class MeetingTests(BaseMeetingTestCase):
                          kwargs=dict(num=meeting.number, document=session.minutes()))
 
         for accept, cont_type, content in [
-                ('text/html,text/plain,text/markdown',  'text/html',     '<li>\n<p>More work items underway</p>\n</li>'),
-                ('text/markdown,text/html,text/plain',  'text/markdown', '1. More work items underway'),
-                ('text/plain,text/markdown, text/html', 'text/plain',    '1. More work items underway'),
+                ('text/html,text/plain,text/markdown',  'text/markdown', '1. More work items underway'),
+                ('text/html,text/plain, */*',           'text/markdown', '1. More work items underway'),
                 ('text/html',                           'text/html',     '<li>\n<p>More work items underway</p>\n</li>'),
                 ('text/markdown',                       'text/markdown', '1. More work items underway'),
                 ('text/plain',                          'text/plain',    '1. More work items underway'),
@@ -622,9 +621,8 @@ class MeetingTests(BaseMeetingTestCase):
         filename = cont_disp_settings.get('filename', '').strip('"')
         if filename.endswith('.md'):
             for accept, cont_type, content in [
-                    ('text/html,text/plain,text/markdown',  'text/html',     '<li>\n<p>More work items underway</p>\n</li>'),
-                    ('text/markdown,text/html,text/plain',  'text/markdown', '1. More work items underway'),
-                    ('text/plain,text/markdown, text/html', 'text/plain',    '1. More work items underway'),
+                    ('text/html,text/plain,text/markdown',  'text/markdown', '1. More work items underway'),
+                    ('text/html,text/plain, */*',           'text/markdown', '1. More work items underway'),
                     ('text/html',                           'text/html',     '<li>\n<p>More work items underway</p>\n</li>'),
                     ('text/markdown',                       'text/markdown', '1. More work items underway'),
                     ('text/plain',                          'text/plain',    '1. More work items underway'),

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -275,11 +275,19 @@ def materials_document(request, document, num=None, ext=None):
         file_ext = os.path.splitext(filename)
         if len(file_ext) == 2 and file_ext[1] == '.md' and mtype == 'text/plain':
             sorted_accept = sort_accept_tuple(request.META.get('HTTP_ACCEPT'))
-            accept_keys = {x[0] for x in sorted_accept}
+            accept_keys = {x[0].strip() for x in sorted_accept}
 
             # for .md documents - return `text/markdown` unless explicitly asked for another format
             if 'text/markdown' in accept_keys or '*/*' in accept_keys:
                 content_type = content_type.replace('plain', 'markdown', 1)
+            else:
+                for atype in sorted_accept:
+                    if atype[0] == 'text/html':
+                        bytes = "<html>\n<head><base target=\"_blank\" /></head>\n<body>\n%s\n</body>\n</html>\n" % markdown.markdown(bytes.decode(encoding=chset))
+                        content_type = content_type.replace('plain', 'html', 1)
+                        break;
+                    elif atype[0] == 'text/plain':
+                        break;
 
         response = HttpResponse(bytes, content_type=content_type)
         response['Content-Disposition'] = 'inline; filename="%s"' % basename

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -275,16 +275,11 @@ def materials_document(request, document, num=None, ext=None):
         file_ext = os.path.splitext(filename)
         if len(file_ext) == 2 and file_ext[1] == '.md' and mtype == 'text/plain':
             sorted_accept = sort_accept_tuple(request.META.get('HTTP_ACCEPT'))
-            for atype in sorted_accept:
-                if atype[0] == 'text/markdown':
-                    content_type = content_type.replace('plain', 'markdown', 1)
-                    break;
-                elif atype[0] == 'text/html':
-                    bytes = "<html>\n<head><base target=\"_blank\" /></head>\n<body>\n%s\n</body>\n</html>\n" % markdown.markdown(bytes.decode(encoding=chset))
-                    content_type = content_type.replace('plain', 'html', 1)
-                    break;
-                elif atype[0] == 'text/plain':
-                    break;
+            accept_keys = {x[0] for x in sorted_accept}
+
+            # for .md documents - return `text/markdown` unless explicitly asked for another format
+            if 'text/markdown' in accept_keys or '*/*' in accept_keys:
+                content_type = content_type.replace('plain', 'markdown', 1)
 
         response = HttpResponse(bytes, content_type=content_type)
         response['Content-Disposition'] = 'inline; filename="%s"' % basename


### PR DESCRIPTION
This PR changes the default behavior for .md links for meeting materials to be returned as raw Markdown files instead of rendered documents.
See discussion in #5516 
Closes #5516 