### PR TITLE
fix: make some scripts to be Python 3 compatible

### DIFF
--- a/bin/add-old-drafts-from-archive.py
+++ b/bin/add-old-drafts-from-archive.py
@@ -27,7 +27,7 @@ system = Person.objects.get(name="(System)")
 expired = State.objects.get(type='draft',slug='expired')
 
 names = set()
-print 'collecting draft names ...'
+print('collecting draft names ...')
 versions = 0
 for p in Path(settings.INTERNET_DRAFT_PATH).glob('draft*.txt'):
     n = str(p).split('/')[-1].split('-')
@@ -46,7 +46,7 @@ for p in Path(settings.INTERNET_DRAFT_PATH).glob('draft*.txt'):
         names.add('-'.join(n[:-1]))
 
 count=0
-print 'iterating through names ...'
+print('iterating through names ...')
 for name in sorted(names):
     if not Document.objects.filter(name=name).exists():
         paths = list(Path(settings.INTERNET_DRAFT_PATH).glob('%s-??.txt'%name))
@@ -64,10 +64,10 @@ for name in sorted(names):
                 try:
                     draft = PlaintextDraft(text, txt_file.name, name_from_source=True)
                 except Exception as e:
-                    print name, rev, "Can't parse", p,":",e
+                    print(name, rev, "Can't parse", p,":",e)
                     continue
             if draft.errors and draft.errors.keys()!=['draftname',]:
-                print "Errors - could not process", name, rev, datetime.datetime.fromtimestamp(p.stat().st_mtime, datetime.timezone.utc), draft.errors, draft.get_title().encode('utf8')
+                print("Errors - could not process", name, rev, datetime.datetime.fromtimestamp(p.stat().st_mtime, datetime.timezone.utc), draft.errors, draft.get_title().encode('utf8'))
             else:
                 time = datetime.datetime.fromtimestamp(p.stat().st_mtime, datetime.timezone.utc)
                 if not doc:
@@ -148,4 +148,4 @@ for name in sorted(names):
                 doc.time = time
                 doc.rev = rev
                 doc.save_with_history(events)
-                print "Added",name, rev
+                print("Added",name, rev)

--- a/test/check_database_constraints.py
+++ b/test/check_database_constraints.py
@@ -41,48 +41,48 @@ from django.db import models
 cursor = db.connection.cursor()
 
 def check_foreign_key(model, field):
-    print "Checking foreign key", model._meta.db_table+"."+field.column
-    print "    points to:", field.rel.to._meta.db_table+"."+field.rel.field_name
+    print("Checking foreign key", model._meta.db_table+"."+field.column)
+    print("    points to:", field.rel.to._meta.db_table+"."+field.rel.field_name)
     sql = "SELECT src.%s,src.%s FROM %s AS src LEFT OUTER JOIN %s as dst on src.%s=dst.%s WHERE src.%s IS NOT NULL AND dst.%s IS NULL;" % (model._meta.pk.column, field.column, model._meta.db_table, field.rel.to._meta.db_table, field.column, field.rel.get_related_field().column, field.column, field.rel.get_related_field().column)
-    #print sql
+    #print(sql)
     cursor.execute(sql)
     rows = cursor.fetchall()
     if len(rows) == 0:
-        print "    OK, no hanging rows found"
+        print("    OK, no hanging rows found")
     else:
-        print "    ERROR, found", len(rows), "hanging rows"
+        print("    ERROR, found", len(rows), "hanging rows")
         for row in rows[0:20]:
-            print "   ", row
-        print "    Use the following SQL to debug:"
-        print sql
+            print("   ", row)
+        print("    Use the following SQL to debug:")
+        print(sql)
 
 def check_not_null(model, field):
-    print "Checking NULL values", model._meta.db_table+"."+field.column
+    print("Checking NULL values", model._meta.db_table+"."+field.column)
     sql = "SELECT x.%s,x.%s FROM %s as x WHERE x.%s IS NULL" % (model._meta.pk.column, field.column, model._meta.db_table, field.column)
     cursor.execute(sql)
     rows = cursor.fetchall()
     if len(rows) == 0:
-        print "    OK"
+        print("    OK")
     else:
-        print "    ERROR, found", len(rows), "NULL rows"
+        print("    ERROR, found", len(rows), "NULL rows")
         for row in rows[0:20]:
-            print "   ", row
-        print "    Use the following SQL to debug:"
-        print sql
+            print("   ", row)
+        print("    Use the following SQL to debug:")
+        print(sql)
 
 def check_unique(model,field):
-    print "Checking unique values", model._meta.db_table+"."+field.column
+    print("Checking unique values", model._meta.db_table+"."+field.column)
     sql = "SELECT %s FROM %s GROUP BY %s HAVING COUNT(*)>1" % (field.column, model._meta.db_table, field.column)
     cursor.execute(sql)
     rows = cursor.fetchall()
     if len(rows) == 0:
-        print "    OK"
+        print("    OK")
     else:
-        print "    ERROR, found non-unique rows"
+        print("    ERROR, found non-unique rows")
         for row in rows[0:20]:
-            print "   ", row
-        print "    Use the following SQL to debug:"
-        print sql
+            print("   ", row)
+        print("    Use the following SQL to debug:")
+        print(sql)
 
 APPS = ['announcements','idrfc','idtracker','iesg','ietfauth','ipr','liaisons','proceedings','redirects']
 all_models = []
@@ -90,7 +90,7 @@ for app_label in APPS:
     all_models.extend(models.get_models(models.get_app(app_label)))
 
 for model in all_models:
-    print "\n\nChecking %s (table %s)" % (model._meta.object_name, model._meta.db_table)
+    print("\n\nChecking %s (table %s)" % (model._meta.object_name, model._meta.db_table))
     for f in model._meta.fields:
         if isinstance(f, ForeignKey):
             check_foreign_key(model,f)

--- a/test/find_non_ascii.py
+++ b/test/find_non_ascii.py
@@ -41,17 +41,17 @@ from django.db import models
 cursor = db.connection.cursor()
 
 def check_non_ascii(model, field):
-    #print "    Checking", field.column
+    #print("    Checking", field.column)
     sql = "SELECT src.%s,src.%s FROM %s AS src WHERE src.%s RLIKE '[^\\t-~]+'" % (model._meta.pk.column, field.column, model._meta.db_table, field.column)
     #print sql
     cursor.execute(sql)
     rows = cursor.fetchall()
     if len(rows) > 0:
-        print "    NON-ASCII: %s.%s (%d rows)" % (model._meta.db_table,field.column, len(rows))
+        print("    NON-ASCII: %s.%s (%d rows)" % (model._meta.db_table,field.column, len(rows)))
         #for row in rows[0:20]:
-        #    print "   ", row
-        #print "    Use the following SQL to debug:"
-        #print sql
+        #    print("   ", row)
+        #print("    Use the following SQL to debug:")
+        #print(sql)
 
 APPS = ['announcements', 'idrfc','idtracker','iesg','ietfauth','ipr','liaisons','proceedings','redirects']
 all_models = []
@@ -59,7 +59,7 @@ for app_label in APPS:
     all_models.extend(models.get_models(models.get_app(app_label)))
 
 for model in all_models:
-    print "\nChecking %s (table %s)" % (model._meta.object_name, model._meta.db_table)
+    print("\nChecking %s (table %s)" % (model._meta.object_name, model._meta.db_table))
     for f in model._meta.fields:
         if isinstance(f, CharField) or isinstance(f, TextField):
             check_non_ascii(model,f)


### PR DESCRIPTION
Since `print` is a keyword in Python 2, these Python scripts use it without parentheses which works but this does not work in Python 3 since `print` is now a function, so use parentheses to make the scripts compatible with Python 3 without dropping Python 2 support.