### PR TITLE
feat: add the IAB to the group menu

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -1338,6 +1338,16 @@ def group_menu_data(request):
 #        groups_by_parent[g.parent_id].append({ 'acronym': g.acronym, 'name': escape(g.name), 'url': url })
         groups_by_parent[g.parent_id].append({ 'acronym': g.acronym, 'name': escape(g.name), 'type': escape(g.type.verbose_name or g.type.name), 'url': url })
 
+    iab = Group.objects.get(acronym="iab")
+    groups_by_parent[iab.pk].insert(
+        0,
+        {
+            "acronym": iab.acronym,
+            "name": iab.name,
+            "type": "Top Level Group",
+            "url": urlreverse("ietf.group.views.group_home", kwargs={"acronym": iab.acronym})
+        }
+    )
     return JsonResponse(groups_by_parent)
 
 


### PR DESCRIPTION
Fixes #6120

This is a _kludge_, but the IAB is unique in the set of groups we might want to navigate to. We could consider doing something similar for the IESG, especially after moving IESG statements and appeals to that page.
![image](https://github.com/ietf-tools/datatracker/assets/10996692/55dc205b-9298-4339-a111-aba0de93dde1)
