### PR TITLE
chore: Fix (mostly harmless) quoting error

### DIFF
--- a/ietf/name/models.py
+++ b/ietf/name/models.py
@@ -150,4 +150,4 @@ class ExtResourceName(NameModel):
 class SlideSubmissionStatusName(NameModel):
     "Pending, Accepted, Rejected"
 class TelechatAgendaSectionName(NameModel):
-    "roll_call", "minutes", "action_items"
+    """roll_call, minutes, action_items"""


### PR DESCRIPTION
My linter pointed out that this statement had no effect - it was a harmless tuple in a class body, but was meant to be a docstring.