### PR TITLE
fix: Move submission files using shutil.move()

### DIFF
--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -641,12 +641,14 @@ def cancel_submission(submission):
     submission.save()
     remove_submission_files(submission)
 
+
 def rename_submission_files(submission, prev_rev, new_rev):
     for ext in settings.IDSUBMIT_FILE_TYPES:
-        source = os.path.join(settings.IDSUBMIT_STAGING_PATH, '%s-%s.%s' % (submission.name, prev_rev, ext))
-        dest = os.path.join(settings.IDSUBMIT_STAGING_PATH, '%s-%s.%s' % (submission.name, new_rev, ext))
-        if os.path.exists(source):
-            os.rename(source, dest)
+        staging_path = Path(settings.IDSUBMIT_STAGING_PATH) 
+        source = staging_path / f"{submission.name}-{prev_rev}.{ext}"
+        dest = staging_path / f"{submission.name}-{new_rev}.{ext}"
+        if source.exists():
+            move(source, dest)
 
 
 def move_files_to_repository(submission):

--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -11,6 +11,8 @@ import time
 import traceback
 import xml2rfc
 
+from pathlib import Path
+from shutil import move
 from typing import Optional, Union  # pyflakes:ignore
 from unidecode import unidecode
 
@@ -646,17 +648,18 @@ def rename_submission_files(submission, prev_rev, new_rev):
         if os.path.exists(source):
             os.rename(source, dest)
 
+
 def move_files_to_repository(submission):
     for ext in settings.IDSUBMIT_FILE_TYPES:
-        source = os.path.join(settings.IDSUBMIT_STAGING_PATH, '%s-%s.%s' % (submission.name, submission.rev, ext))
-        dest = os.path.join(settings.IDSUBMIT_REPOSITORY_PATH, '%s-%s.%s' % (submission.name, submission.rev, ext))
-        if os.path.exists(source):
-            os.rename(source, dest)
-        else:
-            if os.path.exists(dest):
-                log.log("Intended to move '%s' to '%s', but found source missing while destination exists.")
-            elif ext in submission.file_types.split(','):
-                raise ValueError("Intended to move '%s' to '%s', but found source and destination missing.")
+        fname = f"{submission.name}-{submission.rev}.{ext}"
+        source = Path(settings.IDSUBMIT_STAGING_PATH) / fname
+        dest = Path(settings.IDSUBMIT_REPOSITORY_PATH) / fname
+        if source.exists():
+            move(source, dest)
+        elif dest.exists():
+            log.log("Intended to move '%s' to '%s', but found source missing while destination exists.")
+        elif ext in submission.file_types.split(','):
+            raise ValueError("Intended to move '%s' to '%s', but found source and destination missing.")
 
 
 def remove_staging_files(name, rev, exts=None):


### PR DESCRIPTION
Fixes #6216 

The change to `rename_submission_files()` is not strictly required because both source and dest are in the same directory so cannot be on different filesystems. However, `shutil.move()` uses `os.rename()` in this case so I think it's better to use it consistently.

Also switches some `os.path.join` to `pathlib.Path` - this works for Python 3.9 and later, which I believe is all we're supporting now, but calling it out in case I'm confused.