### PR TITLE
fix: Improve status page for canceled submissions

### DIFF
--- a/ietf/submit/views.py
+++ b/ietf/submit/views.py
@@ -356,7 +356,21 @@ def submission_status(request, submission_id, access_token=None):
     message = None
 
     if submission.state_id == "cancel":
-        message = ('error', 'This submission has been cancelled, modification is no longer possible.')
+        # would be nice to have a less heuristic mechansim for reporting async processing failure
+        async_processing_error = submission.submissionevent_set.filter(
+            desc__startswith="Submission rejected: A system error occurred"
+        ).exists()
+        if async_processing_error:
+            message = (
+                "error",
+                "This submission has been cancelled due to a system error during processing. "
+                "Modification is no longer possible.",
+            )
+        else:
+            message = (
+                "error",
+                "This submission has been cancelled, modification is no longer possible.",
+            )
     elif submission.state_id == "auth":
         message = ('success', 'The submission is pending email authentication. An email has been sent to: %s' % ", ".join(confirmation_list))
     elif submission.state_id == "grp-appr":

--- a/ietf/submit/views.py
+++ b/ietf/submit/views.py
@@ -317,7 +317,10 @@ def submission_status(request, submission_id, access_token=None):
     if access_token and not key_matched:
         raise Http404
 
-    errors = validate_submission(submission)
+    if submission.state.slug == "cancel":
+        errors = {}
+    else:
+        errors = validate_submission(submission)
     passes_checks = all([ c.passed!=False for c in submission.checks.all() ])
 
     is_secretariat = has_role(request.user, "Secretariat")

--- a/ietf/templates/submit/submission_status.html
+++ b/ietf/templates/submit/submission_status.html
@@ -155,33 +155,39 @@
         {% else %}
         <h2 class="mt-5">Meta-data from the submission</h2>
         {% if errors %}
-            <div class="alert alert-danger my-3">
-                <p>
-                    <b>Meta-Data errors found!</b>
-                </p>
-                <p >
-                    Please make sure that your Internet-Draft includes all of the required meta-data in the proper format.
-                </p>
-                <ul>
-                    <li>
-                        If your Internet-Draft <b>does</b> include all of the required meta-data in the proper format, and if
-                        the error(s) identified below are due to the failure of the tool to extract the meta-data correctly,
-                        then please use the "Adjust meta-data" button below, which will take you to the "Adjust screen" where
-                        you can correct the improperly extracted meta-data. You will then be able to submit your Internet-Draft
-                        to the Secretariat for manual posting.
-                    </li>
-                    <li>
-                        If your Internet-Draft <b>does not</b> include all of the required meta-data in the proper format, then
-                        please cancel this submission, update your Internet-Draft, and resubmit it.
-                    </li>
-                </ul>
-                <p class="mb-0">
-                    <b>Note:</b> The secretariat will <b>not</b> add any
-                    meta-data to your Internet-Draft or edit the meta-data. An
-                    Internet-Draft that does not include all of the required meta-data in
-                    the proper format <b>will</b> be returned to the submitter.
-                </p>
-            </div>
+            {% if submission.state.slug == "cancel" %}
+                <div class="alert alert-warning my-3">
+                    <b>Note:</b> The meta-data extracted from this cancelled draft has errors or is incomplete. 
+                </div>
+            {% else %}
+                <div class="alert alert-danger my-3">
+                    <p>
+                        <b>Meta-Data errors found!</b>
+                    </p>
+                    <p >
+                        Please make sure that your Internet-Draft includes all of the required meta-data in the proper format.
+                    </p>
+                    <ul>
+                        <li>
+                            If your Internet-Draft <b>does</b> include all of the required meta-data in the proper format, and if
+                            the error(s) identified below are due to the failure of the tool to extract the meta-data correctly,
+                            then please use the "Adjust meta-data" button below, which will take you to the "Adjust screen" where
+                            you can correct the improperly extracted meta-data. You will then be able to submit your Internet-Draft
+                            to the Secretariat for manual posting.
+                        </li>
+                        <li>
+                            If your Internet-Draft <b>does not</b> include all of the required meta-data in the proper format, then
+                            please cancel this submission, update your Internet-Draft, and resubmit it.
+                        </li>
+                    </ul>
+                    <p class="mb-0">
+                        <b>Note:</b> The secretariat will <b>not</b> add any
+                        meta-data to your Internet-Draft or edit the meta-data. An
+                        Internet-Draft that does not include all of the required meta-data in
+                        the proper format <b>will</b> be returned to the submitter.
+                    </p>
+                </div>
+            {% endif %}
         {% endif %}
     {% endif %}
     <table class="table table-sm table-striped">

--- a/ietf/templates/submit/submission_status.html
+++ b/ietf/templates/submit/submission_status.html
@@ -152,7 +152,7 @@
             {% endwith %}
             Please contact the secretariat for assistance if it has been more than an hour.
         </div>
-        {% else %}
+    {% else %}
         <h2 class="mt-5">Meta-data from the submission</h2>
         {% if submission.state.slug == "cancel" %}
             <div class="alert alert-warning my-3">

--- a/ietf/templates/submit/submission_status.html
+++ b/ietf/templates/submit/submission_status.html
@@ -154,40 +154,38 @@
         </div>
         {% else %}
         <h2 class="mt-5">Meta-data from the submission</h2>
-        {% if errors %}
-            {% if submission.state.slug == "cancel" %}
-                <div class="alert alert-warning my-3">
-                    <b>Note:</b> The meta-data extracted from this cancelled draft has errors or is incomplete. 
-                </div>
-            {% else %}
-                <div class="alert alert-danger my-3">
-                    <p>
-                        <b>Meta-Data errors found!</b>
-                    </p>
-                    <p >
-                        Please make sure that your Internet-Draft includes all of the required meta-data in the proper format.
-                    </p>
-                    <ul>
-                        <li>
-                            If your Internet-Draft <b>does</b> include all of the required meta-data in the proper format, and if
-                            the error(s) identified below are due to the failure of the tool to extract the meta-data correctly,
-                            then please use the "Adjust meta-data" button below, which will take you to the "Adjust screen" where
-                            you can correct the improperly extracted meta-data. You will then be able to submit your Internet-Draft
-                            to the Secretariat for manual posting.
-                        </li>
-                        <li>
-                            If your Internet-Draft <b>does not</b> include all of the required meta-data in the proper format, then
-                            please cancel this submission, update your Internet-Draft, and resubmit it.
-                        </li>
-                    </ul>
-                    <p class="mb-0">
-                        <b>Note:</b> The secretariat will <b>not</b> add any
-                        meta-data to your Internet-Draft or edit the meta-data. An
-                        Internet-Draft that does not include all of the required meta-data in
-                        the proper format <b>will</b> be returned to the submitter.
-                    </p>
-                </div>
-            {% endif %}
+        {% if submission.state.slug == "cancel" %}
+            <div class="alert alert-warning my-3">
+                <b>Note:</b> The meta-data shown for a cancelled draft may be incorrect or incomplete.
+            </div>
+        {% elif errors %}
+            <div class="alert alert-danger my-3">
+                <p>
+                    <b>Meta-Data errors found!</b>
+                </p>
+                <p >
+                    Please make sure that your Internet-Draft includes all of the required meta-data in the proper format.
+                </p>
+                <ul>
+                    <li>
+                        If your Internet-Draft <b>does</b> include all of the required meta-data in the proper format, and if
+                        the error(s) identified below are due to the failure of the tool to extract the meta-data correctly,
+                        then please use the "Adjust meta-data" button below, which will take you to the "Adjust screen" where
+                        you can correct the improperly extracted meta-data. You will then be able to submit your Internet-Draft
+                        to the Secretariat for manual posting.
+                    </li>
+                    <li>
+                        If your Internet-Draft <b>does not</b> include all of the required meta-data in the proper format, then
+                        please cancel this submission, update your Internet-Draft, and resubmit it.
+                    </li>
+                </ul>
+                <p class="mb-0">
+                    <b>Note:</b> The secretariat will <b>not</b> add any
+                    meta-data to your Internet-Draft or edit the meta-data. An
+                    Internet-Draft that does not include all of the required meta-data in
+                    the proper format <b>will</b> be returned to the submitter.
+                </p>
+            </div>
         {% endif %}
     {% endif %}
     <table class="table table-sm table-striped">


### PR DESCRIPTION
This improves the submission status page for canceled submissions. It suppresses error messages about meta-data problems which are often misleading. For a canceled submission, the bold, attention-grabbing alert box when there is an error is replaced by a milder warning that the metadata may be inaccurate or incomplete. This warning is always shown for canceled submissions.

When an unhandled async submission error occurred, the status message for the submission is adjusted to indicate that a system error caused the cancellation. This is done by scraping the submission event descriptions which is not ideal.

Related to #5696, but we should probably keep that open until we handle and report the more specific failures catalogued there.