### PR TITLE
fix: Reject nul characters in ipr search parameters

### DIFF
--- a/ietf/ipr/views.py
+++ b/ietf/ipr/views.py
@@ -10,7 +10,7 @@ from django.contrib import messages
 from django.db.models import Q
 from django.forms.models import inlineformset_factory, model_to_dict
 from django.forms.formsets import formset_factory
-from django.http import HttpResponse, Http404, HttpResponseRedirect, HttpResponseNotAllowed
+from django.http import HttpResponse, Http404, HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render, get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse as urlreverse
@@ -630,7 +630,7 @@ def post(request, id):
 def search(request):
     search_type = request.GET.get("submit")
     if search_type and "\x00" in search_type:
-        return HttpResponseNotAllowed("Null characters are not allowed")
+        return HttpResponseBadRequest("Null characters are not allowed")
 
     # query field
     q = ''
@@ -638,7 +638,7 @@ def search(request):
     if not search_type and request.GET.get("option", None) == "document_search":
         docname = request.GET.get("document_search", "")
         if docname and "\x00" in docname:
-            return HttpResponseNotAllowed("Null characters are not allowed")
+            return HttpResponseBadRequest("Null characters are not allowed")
         if docname.startswith("draft-"):
             search_type = "draft"
             q = docname
@@ -649,7 +649,7 @@ def search(request):
         form = SearchForm(request.GET)
         docid = request.GET.get("id") or request.GET.get("id_document_tag") or ""
         if docid and "\x00" in docid:
-            return HttpResponseNotAllowed("Null characters are not allowed")
+            return HttpResponseBadRequest("Null characters are not allowed")
         docs = doc = None
         iprs = []
         related_iprs = []
@@ -657,7 +657,7 @@ def search(request):
         # set states
         states = request.GET.getlist('state',settings.PUBLISH_IPR_STATES)
         if any("\x00" in state for state in states if state):
-            return HttpResponseNotAllowed("Null characters are not allowed")
+            return HttpResponseBadRequest("Null characters are not allowed")
         if states == ['all']:
             states = IprDisclosureStateName.objects.values_list('slug',flat=True)
         
@@ -665,7 +665,7 @@ def search(request):
         if request.GET.get(search_type):
             q = request.GET.get(search_type)
             if q and "\x00" in q:
-                return HttpResponseNotAllowed("Null characters are not allowed")
+                return HttpResponseBadRequest("Null characters are not allowed")
 
         if q or docid:
             # Search by RFC number or draft-identifier

--- a/ietf/ipr/views.py
+++ b/ietf/ipr/views.py
@@ -675,13 +675,12 @@ def search(request):
 
                 if docid:
                     start = DocAlias.objects.filter(name__iexact=docid)
-                else:
-                    if search_type == "draft":
-                        q = normalize_draftname(q)
-                        start = DocAlias.objects.filter(name__icontains=q, name__startswith="draft")
-                    elif search_type == "rfc":
-                        start = DocAlias.objects.filter(name="rfc%s" % q.lstrip("0"))
-                
+                elif search_type == "draft":
+                    q = normalize_draftname(q)
+                    start = DocAlias.objects.filter(name__icontains=q, name__startswith="draft")
+                else:  # search_type == "rfc"
+                    start = DocAlias.objects.filter(name="rfc%s" % q.lstrip("0"))
+            
                 # one match
                 if len(start) == 1:
                     first = start[0]

--- a/ietf/ipr/views.py
+++ b/ietf/ipr/views.py
@@ -637,7 +637,7 @@ def search(request):
     # legacy support
     if not search_type and request.GET.get("option", None) == "document_search":
         docname = request.GET.get("document_search", "")
-        if docname > 0 and "\x00" in docname:
+        if docname and "\x00" in docname:
             return HttpResponseNotAllowed("Null characters are not allowed")
         if docname.startswith("draft-"):
             search_type = "draft"

--- a/ietf/ipr/views.py
+++ b/ietf/ipr/views.py
@@ -629,7 +629,7 @@ def post(request, id):
     
 def search(request):
     search_type = request.GET.get("submit")
-    if "\x00" in search_type:
+    if search_type and "\x00" in search_type:
         return HttpResponseNotAllowed("Null characters are not allowed")
 
     # query field
@@ -637,7 +637,7 @@ def search(request):
     # legacy support
     if not search_type and request.GET.get("option", None) == "document_search":
         docname = request.GET.get("document_search", "")
-        if "\x00" in docname:
+        if docname > 0 and "\x00" in docname:
             return HttpResponseNotAllowed("Null characters are not allowed")
         if docname.startswith("draft-"):
             search_type = "draft"
@@ -648,7 +648,7 @@ def search(request):
     if search_type:
         form = SearchForm(request.GET)
         docid = request.GET.get("id") or request.GET.get("id_document_tag") or ""
-        if "\x00" in docid:
+        if docid and "\x00" in docid:
             return HttpResponseNotAllowed("Null characters are not allowed")
         docs = doc = None
         iprs = []
@@ -656,7 +656,7 @@ def search(request):
 
         # set states
         states = request.GET.getlist('state',settings.PUBLISH_IPR_STATES)
-        if any("\x00" in state for state in states):
+        if any("\x00" in state for state in states if state):
             return HttpResponseNotAllowed("Null characters are not allowed")
         if states == ['all']:
             states = IprDisclosureStateName.objects.values_list('slug',flat=True)
@@ -664,7 +664,7 @@ def search(request):
         # get query field
         if request.GET.get(search_type):
             q = request.GET.get(search_type)
-            if "\x00" in q:
+            if q and "\x00" in q:
                 return HttpResponseNotAllowed("Null characters are not allowed")
 
         if q or docid:


### PR DESCRIPTION
Really ought to rework this as a form, but in the meantime this should prevent 500s. Could probably reduce the number of places we check the value.