### PR TITLE
fix: Linkify email address lists one-by-one

### DIFF
--- a/ietf/templates/doc/document_email.html
+++ b/ietf/templates/doc/document_email.html
@@ -51,11 +51,11 @@
                     </td>
                     <td>
                         {% for addr in to %}
-                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                            {{ addr|linkify }}{% if not forloop.last %}, {% endif %}
                         {% endfor %}
                     <td>
                         {% for addr in cc %}
-                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                            {{ addr|linkify }}{% if not forloop.last %}, {% endif %}
                         {% endfor %}
                     </td>
                 </tr>

--- a/ietf/templates/doc/document_email.html
+++ b/ietf/templates/doc/document_email.html
@@ -49,8 +49,15 @@
                         <a href="{% url 'ietf.mailtrigger.views.show_triggers' trigger %}"
                            title="{{ desc }}">{{ trigger }}</a>
                     </td>
-                    <td>{{ to|join:', '|linkify }}</td>
-                    <td>{{ cc|join:', '|linkify }}</td>
+                    <td>
+                        {% for addr in to %}
+                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    <td>
+                        {% for addr in cc %}
+                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/ietf/templates/doc/document_email.html
+++ b/ietf/templates/doc/document_email.html
@@ -53,6 +53,7 @@
                         {% for addr in to %}
                             {{ addr|linkify }}{% if not forloop.last %}, {% endif %}
                         {% endfor %}
+                    </td>
                     <td>
                         {% for addr in cc %}
                             {{ addr|linkify }}{% if not forloop.last %}, {% endif %}

--- a/ietf/templates/doc/review/complete_review.html
+++ b/ietf/templates/doc/review/complete_review.html
@@ -66,9 +66,7 @@
         </p>
         <p>
             If you enter the review below, the review will be sent
-            to {{ review_to|join:", "|linkify }}
-            {% if review_cc %}, with a CC to {{ review_cc|join:", "|linkify }}{% endif %}
-            .
+            to {% for addr in to %}{{addr|linkify}}{% if not forloop.last %}, {% endif %}{% endfor %}{% if review_cc %}, with a CC to {% for addr in cc %}{{addr|linkify}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}.
         </p>
     {% elif assignment %}
         <p>

--- a/ietf/templates/doc/review/complete_review.html
+++ b/ietf/templates/doc/review/complete_review.html
@@ -66,7 +66,7 @@
         </p>
         <p>
             If you enter the review below, the review will be sent
-            to {% for addr in to %}{{addr|linkify}}{% if not forloop.last %}, {% endif %}{% endfor %}{% if review_cc %}, with a CC to {% for addr in cc %}{{addr|linkify}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}.
+            to {% for addr in to %}{{ addr|linkify }}{% if not forloop.last %}, {% endif %}{% endfor %}{% if review_cc %}, with a CC to {% for addr in cc %}{{ addr|linkify }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}.
         </p>
     {% elif assignment %}
         <p>

--- a/ietf/templates/group/email.html
+++ b/ietf/templates/group/email.html
@@ -47,8 +47,16 @@
                         <a href="{% url 'ietf.mailtrigger.views.show_triggers' trigger %}"
                            title="{{ desc }}">{{ trigger }}</a>
                     </td>
-                    <td>{{ to|join:', '|unescape|linkify }}</td>
-                    <td>{{ cc|join:', '|unescape|linkify }}</td>
+                    <td>
+                        {% for addr in to %}
+                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for addr in cc %}
+                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/ietf/templates/group/email.html
+++ b/ietf/templates/group/email.html
@@ -49,12 +49,12 @@
                     </td>
                     <td>
                         {% for addr in to %}
-                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                            {{ addr|linkify }}{% if not forloop.last %}, {% endif %}
                         {% endfor %}
                     </td>
                     <td>
                         {% for addr in cc %}
-                            {{addr|linkify}}{% if not forloop.last %}, {% endif %}
+                            {{ addr|linkify }}{% if not forloop.last %}, {% endif %}
                         {% endfor %}
                     </td>
                 </tr>


### PR DESCRIPTION
Seems to work around a bug in mozilla/bleach.

Fixes #6307