### PR TITLE
fix: Only enable city/country entry for in-person interims

### DIFF
--- a/ietf/static/js/meeting-interim-request.js
+++ b/ietf/static/js/meeting-interim-request.js
@@ -207,11 +207,12 @@ const interimRequest = (function() {
 
         toggleLocation: function () {
             if (this.checked) {
-                $(".location")
+                $(".location input, .location select")
                     .prop('disabled', false);
             } else {
-                $(".location")
-                    .prop('disabled', true);
+                $(".location input, .location select")
+                    .prop('disabled', true)
+                    .val('');
             }
         },
 

--- a/ietf/templates/meeting/interim_request.html
+++ b/ietf/templates/meeting/interim_request.html
@@ -24,8 +24,8 @@
             </div>
         {% endif %}
         {% bootstrap_field form.meeting_type layout='horizontal' %}
-        {% bootstrap_field form.city layout='horizontal' %}
-        {% bootstrap_field form.country layout='horizontal' %}
+        {% bootstrap_field form.city layout='horizontal' wrapper_class='location mb-3' %}
+        {% bootstrap_field form.country layout='horizontal' wrapper_class='location mb-3' %}
         {% bootstrap_field form.time_zone layout='horizontal' %}
         {{ formset.management_form }}
         {% if formset.non_form_errors %}<div class="my-3 alert alert-danger">{{ formset.non_form_errors }}</div>{% endif %}


### PR DESCRIPTION
Was probably broken during the bs5 transition.

Fixes #6346