### PR TITLE
fix: Allow editing of interim meeting subject lines

### DIFF
--- a/ietf/templates/meeting/interim_send_announcement.html
+++ b/ietf/templates/meeting/interim_send_announcement.html
@@ -13,7 +13,7 @@
         {% csrf_token %}
         <div class="row mb-3">
             <label for="{{ form.to.id_for_label }}" class="col-md-2 fw-bold col-form-label">To</label>
-            <div class="col-md-10">{% render_field form.to class="form-control" readonly="readonly" %}</div>
+            <div class="col-md-10">{% render_field form.to class="form-control" disabled="disabled" %}</div>
         </div>
         <div class="row mb-3">
             <label for="{{ form.cc.id_for_label }}" class="col-md-2 fw-bold col-form-label">Cc</label>
@@ -21,11 +21,11 @@
         </div>
         <div class="row mb-3">
             <label for="{{ form.frm.id_for_label }}" class="col-md-2 fw-bold col-form-label">From</label>
-            <div class="col-md-10">{% render_field form.frm class="form-control" readonly="readonly" %}</div>
+            <div class="col-md-10">{% render_field form.frm class="form-control" disabled="disabled" %}</div>
         </div>
         <div class="row mb-3">
             <label for="{{ form.subject.id_for_label }}" class="col-md-2 fw-bold col-form-label">Subject</label>
-            <div class="col-md-10">{% render_field form.subject class="form-control" readonly="readonly" %}</div>
+            <div class="col-md-10">{% render_field form.subject class="form-control" %}</div>
         </div>
         <div class="row mb-3">
             <label for="{{ form.body.id_for_label }}" class="col-md-2 fw-bold col-form-label">Body</label>


### PR DESCRIPTION
Also change "readonly" to "disabled" to give a visual hint about which fields are not changeable.

Fixes #6310