### PR TITLE
fix: Restore the ability to search in tables

### DIFF
--- a/ietf/static/js/list.js
+++ b/ietf/static/js/list.js
@@ -267,6 +267,9 @@ $(document)
                                 });
                         }
                     });
+                    e.on("searchComplete", function () {
+                        replace_with_internal(table, internal_table, i);
+                    });
                 });
 
                 $(table.addClass("tablesorter-done"));


### PR DESCRIPTION
This was broken by 57030e4303aa42423335366f6d025b379b25f6ef