### PR TITLE
refactor: Return objects from get_persons api

### DIFF
--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -462,9 +462,12 @@ def rpc_persons(request):
         return HttpResponseForbidden()
     
     pks = json.loads(request.body)
-    response = dict()
-    for p in Person.objects.filter(pk__in=pks):
-        response[str(p.pk)] = p.plain_name()
+    response = {
+        "persons": [
+            {"id": p.id, "plain_name": p.plain_name()}
+            for p in Person.objects.filter(pk__in=pks)
+        ]
+    }
     return JsonResponse(response)
 
 

--- a/rpcapi.yaml
+++ b/rpcapi.yaml
@@ -30,7 +30,7 @@ paths:
         post:
             operationId: get_persons
             summary: Get a batch of persons
-            description: returns a dict of person pks to person names
+            description: returns an array of persons 
             requestBody:
                 required: true
                 content:
@@ -46,8 +46,11 @@ paths:
                         application/json:
                             schema:
                                 type: object
-                                additionalProperties:
-                                    type: string
+                                properties:
+                                    persons:
+                                        type: array
+                                        items:
+                                            $ref: '#/components/schemas/Person'
 
                 
     /person/create_demo_person/:


### PR DESCRIPTION
This is an alternative implementation of the `rpc_persons()` api endpoint. The motivation is to preserve `Person.id` as an integer rather than forcing it to be converted to a string so it can act as a JSON object key.

(Incidentally, I've called the name `plain_name` in the response to reuse the existing `rpc_person()` return value schema. I have no objection to calling it `name` instead, I just haven't changed that here.)