### PR TITLE
refactor: Allow existing Person in create_demo_person

### DIFF
--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -500,9 +500,5 @@ def create_demo_person(request):
     
     request_params = json.loads(request.body)
     name = request_params["name"]
-    if Person.objects.filter(name=name).exists():
-        return HttpResponseForbidden()
-    person = PersonFactory(name=name)
-
-
+    person = Person.objects.filter(name=name).first() or PersonFactory(name=name)
     return JsonResponse({"user_id":person.user.pk,"person_pk":person.pk}, status=201)


### PR DESCRIPTION
Instead of returning a 403 Forbidden error, just return the existing `Person` if a `create_demo_person()` API call tries to create a person who already exists. This avoids having to clean out the datatracker DB when re-running `create_rpc_demo` in the rpc tool.

Could instead handle the 403 (or return a distinct indicator that the name is in use, perhaps a 409 Conflict) and deal with this on the API caller side, but this is the lower hanging fix