### PR TITLE
chore: Pin WeasyPrint to avoid bug in v60.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,6 @@ tlds>=2022042700    # Used to teach bleach about which TLDs currently exist
 tqdm>=4.64.0
 Unidecode>=1.3.4
 urllib3<2        # v2 causes selenium tests to fail with "Timeout value was <object..." error
-weasyprint>=59
+weasyprint>=59,<60  # v60.0 bug affects datatracker: https://github.com/Kozea/WeasyPrint/issues/1973
 xml2rfc>=3.12.4
 xym>=0.6,<1.0


### PR DESCRIPTION
Keep the pin until the fix for https://github.com/Kozea/WeasyPrint/issues/1973 is released and confirmed to work with datatracker.