### PR TITLE
fix: restore interim announce ability

### DIFF
--- a/ietf/templates/meeting/interim_send_announcement.html
+++ b/ietf/templates/meeting/interim_send_announcement.html
@@ -13,7 +13,7 @@
         {% csrf_token %}
         <div class="row mb-3">
             <label for="{{ form.to.id_for_label }}" class="col-md-2 fw-bold col-form-label">To</label>
-            <div class="col-md-10">{% render_field form.to class="form-control" disabled="disabled" %}</div>
+            <div class="col-md-10">{% render_field form.to class="form-control" readonly="readonly" %}</div>
         </div>
         <div class="row mb-3">
             <label for="{{ form.cc.id_for_label }}" class="col-md-2 fw-bold col-form-label">Cc</label>
@@ -21,7 +21,7 @@
         </div>
         <div class="row mb-3">
             <label for="{{ form.frm.id_for_label }}" class="col-md-2 fw-bold col-form-label">From</label>
-            <div class="col-md-10">{% render_field form.frm class="form-control" disabled="disabled" %}</div>
+            <div class="col-md-10">{% render_field form.frm class="form-control" readonly="readonly" %}</div>
         </div>
         <div class="row mb-3">
             <label for="{{ form.subject.id_for_label }}" class="col-md-2 fw-bold col-form-label">Subject</label>


### PR DESCRIPTION
Intentionally targeting the release branch - this is an emergency patch.

The changes to use disabled instead of readonly cause the browsers to not include the fields in the POST, rendering the form invalid. (The page doesn't show the form errors - I'll open an issue for that).

It would be very nice to find a way to have this kind of breakage detected in tests.

cc: @larseggert 