### PR TITLE
fix: Remove incorrect line from submission API info web page

### DIFF
--- a/ietf/templates/submit/api_submission_info.html
+++ b/ietf/templates/submit/api_submission_info.html
@@ -21,7 +21,6 @@
     </p>
     <ul>
         <li>Only XML-only uploads are supported, not text or combined.</li>
-        <li>Document replacement information cannot be supplied.</li>
         <li>
             The server expects <code>multipart/form-data</code>, supported by <code>curl</code> but <b>not</b> by <code>wget</code>.
         </li>

--- a/ietf/templates/submit/api_submit_info.html
+++ b/ietf/templates/submit/api_submit_info.html
@@ -27,6 +27,7 @@
     </p>
     <ul>
         <li>Only XML-only uploads are supported, not text or combined.</li>
+        <li>Document replacement information cannot be supplied.</li>
         <li>
             The server expects <code>multipart/form-data</code>, supported by <code>curl</code> but <b>not</b> by <code>wget</code>.
         </li>

--- a/ietf/templates/submit/api_submit_info.html
+++ b/ietf/templates/submit/api_submit_info.html
@@ -27,7 +27,6 @@
     </p>
     <ul>
         <li>Only XML-only uploads are supported, not text or combined.</li>
-        <li>Document replacement information cannot be supplied.</li>
         <li>
             The server expects <code>multipart/form-data</code>, supported by <code>curl</code> but <b>not</b> by <code>wget</code>.
         </li>


### PR DESCRIPTION
Now that https://github.com/ietf-tools/datatracker/pull/4037 has landed and https://github.com/ietf-tools/datatracker/issues/3286 has been resolved, this line can be removed.