### PR TITLE
fix: Add "numeric" option to localecompare

### DIFF
--- a/ietf/static/js/list.js
+++ b/ietf/static/js/list.js
@@ -14,7 +14,8 @@ function text_sort(a, b, options) {
     // sort by text content
     return prep(a, options).localeCompare(prep(b, options), "en", {
         sensitivity: "base",
-        ignorePunctuation: true
+        ignorePunctuation: true,
+        numeric: true
     });
 }
 


### PR DESCRIPTION
Fixes #6493