### PR TITLE
fix: Don't include csrf_token in GET-only form

### DIFF
--- a/ietf/templates/doc/search/search_form.html
+++ b/ietf/templates/doc/search/search_form.html
@@ -6,7 +6,6 @@
 <form id="search_form"
       class="form-horizontal"
       action="{% url 'ietf.doc.views_search.search' %}">
-    {% csrf_token %}
     <!-- [html-validate-disable-block input-missing-label -- labelled via aria-label] -->
     <div class="input-group search_field">
         {{ form.name|add_class:"form-control"|attr:"placeholder:Document name/title/RFC number"|attr:"aria-label:Document name/title/RFC number" }}


### PR DESCRIPTION
Fixes #6487