### PR TITLE
Fix: Update NomCom references

### DIFF
--- a/ietf/templates/nomcom/announcements.html
+++ b/ietf/templates/nomcom/announcements.html
@@ -56,9 +56,14 @@
         </li>
         <li>
             <a href="{% url 'ietf.doc.views_doc.document_main' name='rfc8713' %}">
-                IAB, IESG, IETF Trust, and IETF LLC Selection, Confirmation, and Recall Process: Operation of the IETF Nominating and Recall Committees (RFC 8713) (Also BCP10)
+                IAB, IESG, IETF Trust, and IETF LLC Selection, Confirmation, and Recall Process: Operation of the IETF Nominating and Recall Committees (RFC 8713)
             </a>
         </li>
+	<li>
+            <a href="{% url 'ietf.doc.views_doc.document_main' name='rfc9389' %}">
+		Nominating Committee Eligibility (RFC 9389)
+	    </a>
+	</li>
         <li>
             <a href="{% url 'ietf.doc.views_doc.document_main' name='rfc3797' %}">
                 Publicly Verifiable Nominations Committee (NomCom) Random Selection (RFC 3797)


### PR DESCRIPTION
Add nomcom eligibility RFC to the references section

Fixes: #6581