### PR TITLE
fix: move meeting management from base Docs to Meeting

### DIFF
--- a/ietf/meeting/templatetags/meetings_filters.py
+++ b/ietf/meeting/templatetags/meetings_filters.py
@@ -16,4 +16,6 @@ def can_request_interim(user):
         Returns Boolean. True means user can request an interim meeting.
     """
 
+    if not user:
+        return False
     return can_request_interim_meeting(user)

--- a/ietf/meeting/templatetags/meetings_filters.py
+++ b/ietf/meeting/templatetags/meetings_filters.py
@@ -1,0 +1,19 @@
+# Copyright The IETF Trust 2023, All Rights Reserved
+# -*- coding: utf-8 -*-
+
+from django import template
+from ietf.meeting.helpers import can_request_interim_meeting
+
+import debug                            # pyflakes:ignore
+
+register = template.Library()
+
+@register.filter
+def can_request_interim(user):
+    """Determine whether the user can request an interim meeting
+
+    Usage: can_request_interim
+        Returns Boolean. True means user can request an interim meeting.
+    """
+
+    return can_request_interim_meeting(user)

--- a/ietf/templates/base/menu.html
+++ b/ietf/templates/base/menu.html
@@ -144,14 +144,6 @@
                     </a>
                 </li>
             {% endfor %}
-            {% for g in user|matman_groups %}
-                <li>
-                    <a class="dropdown-item {% if flavor != 'top' %}text-wrap{% endif %}"
-                       href="{% url "ietf.group.views.meetings" g.acronym %}">
-                        {{ g.acronym }} {{ g.type.slug }} meetings
-                    </a>
-                </li>
-            {% endfor %}
         {% endif %}
         {% if user|has_role:"Review Team Secretary" %}
             {% if flavor == 'top' %}
@@ -276,11 +268,29 @@
         </a>
     </li>
     <li>
+        <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+           href="{% url 'ietf.meeting.views.interim_request' %}">
+            Request an interim meeting
+        </a>
+    </li>
+    <li>
         <a class="dropdown-item {% if flavor != 'top' %}text-wrap{% endif %}"
            href="{% url 'ietf.meeting.views.meeting_requests' %}">
             Session requests
         </a>
     </li>
+    {% if user|matman_groups %}
+        {% if flavor == 'top' %}<li><hr class="dropdown-divider"></li>{% endif %}
+        <li {% if flavor == 'top' %}class="dropdown-header"{% else %}class="nav-item fw-bolder"{% endif %}>Manage</li>
+        {% for g in user|matman_groups %}
+            <li>
+                <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+                    href="{% url "ietf.group.views.meetings" g.acronym %}">
+                    {{ g.acronym }} {{ g.type.slug }} meetings
+                </a>
+            </li>
+        {% endfor %}
+    {% endif %}
     {% if flavor == 'top' %}
         {% if flavor == 'top' %}
             <li><hr class="dropdown-divider">

--- a/ietf/templates/base/menu.html
+++ b/ietf/templates/base/menu.html
@@ -1,7 +1,7 @@
 {# Copyright The IETF Trust 2015-2022, All Rights Reserved #}
 {% load origin %}
 {% origin %}
-{% load ietf_filters managed_groups wg_menu active_groups_menu group_filters cache %}
+{% load ietf_filters managed_groups wg_menu active_groups_menu group_filters cache meetings_filters %}
 {% if flavor != 'top' %}
     {% include "base/menu_user.html" %}
 {% endif %}
@@ -267,12 +267,14 @@
             Request a session
         </a>
     </li>
-    <li>
-        <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
-           href="{% url 'ietf.meeting.views.interim_request' %}">
-            Request an interim meeting
-        </a>
-    </li>
+    {% if user|can_request_interim %}
+        <li>
+            <a class="dropdown-item {% if flavor != 'top' %}text-wrap link-primary{% endif %}"
+                href="{% url 'ietf.meeting.views.interim_request' %}">
+                Request an interim meeting
+            </a>
+        </li>
+    {% endif %}
     <li>
         <a class="dropdown-item {% if flavor != 'top' %}text-wrap{% endif %}"
            href="{% url 'ietf.meeting.views.meeting_requests' %}">


### PR DESCRIPTION
Move the meeting management options out from under the top Documents menu to the Meetings menu.

Add a request interim meeting link under Meetings to surface this option more logically.

Fixes #3897 and #4005.

