### PR TITLE
fix: Make authors take at least two lines in HTMLized

### DIFF
--- a/ietf/static/css/document_html_txt.scss
+++ b/ietf/static/css/document_html_txt.scss
@@ -165,6 +165,7 @@ blockquote {
   #identifiers dd.authors .author {
     display: inline-block;
     margin: 0 2ch 0 1ch;
+    min-height: calc(2 * var(--line));
   }
   #identifiers dd.authors .author:last-of-type {
     margin-right: 0;


### PR DESCRIPTION
From https://github.com/martinthomson/rfc-txt-html/commit/32f8003712fc27519111d8fa5eb79f23d1619bed

Fixes #6575