### PR TITLE
Install lsb-release to avoid docker container build failure

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -11,6 +11,8 @@ COPY docker/scripts/app-setup-debian.sh /tmp/library-scripts/docker-setup-debian
 RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-debian.sh && chmod +x /tmp/library-scripts/docker-setup-debian.sh
 
 # Add Postgresql Apt Repository to get 14    
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends lsb-release
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 


### PR DESCRIPTION
The Docker repository wasn't building for me, but this fix resolved the issue.