### PR TITLE
fix: Remove Google from doc search action

### DIFF
--- a/ietf/templates/doc/document_draft.html
+++ b/ietf/templates/doc/document_draft.html
@@ -677,14 +677,6 @@
                             IETF Mail Archive
                         </a>
                     </li>
-                    <li role="presentation">
-                        <a class="dropdown-item"
-                           href="https://www.google.com/search?as_q={{ doc.name }}&amp;as_sitesearch={{ search_archive }}"
-                           rel="nofollow"
-                           target="_blank">
-                            Google
-                        </a>
-                    </li>
                     {% if user|has_role:"Area Director" %}
                         <li role="presentation">
                             <a class="dropdown-item"


### PR DESCRIPTION
Remove google from the "search lists" pulldown on the document page.
