### PR TITLE
fix: Show requested rev if it is current, even w/o dochistory

### DIFF
--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -210,8 +210,8 @@ def document_main(request, name, rev=None, document_html=False):
     snapshot = False
 
     gh = None
-    if rev:
-        # find the entry in the history
+    if rev and rev != doc.rev:
+        # find the entry in the history if the rev requested is not the current rev
         for h in doc.history_set.order_by("-time"):
             if rev == h.rev:
                 snapshot = True


### PR DESCRIPTION
This fixes #6699 by restoring the old datatracker behavior when the viewing the latest rev of a draft that has no `DocHistory`.