### PR TITLE
test: Add delay to upcoming mtg filter tests

### DIFF
--- a/ietf/meeting/tests_js.py
+++ b/ietf/meeting/tests_js.py
@@ -1045,6 +1045,7 @@ class InterimTests(IetfSeleniumTestCase):
     def do_upcoming_view_filter_test(self, querystring, visible_meetings=()):
         self.login()
         self.driver.get(self.absreverse('ietf.meeting.views.upcoming') + querystring)
+        time.sleep(0.2)  # gross, but give the filter JS time to do its thing 
         self.assert_upcoming_meeting_visibility(visible_meetings)
         self.assert_upcoming_meeting_calendar(visible_meetings)
         self.assert_upcoming_view_filter_matches_ics_filter(querystring)


### PR DESCRIPTION
Hopefully this will fix the [transient failures around the `do_upcoming_view_filter_test` helper](https://github.com/ietf-tools/datatracker/issues/5834#issuecomment-1832666199)

This is the quick-and-dirty approach - could be smarter and use a `WebDriverWait` if something unexpected is encountered, but that will require some care so let's see if this works first. Probably adds ~5 seconds to the testing time because there are 22 tests using the helper.