### PR TITLE
fix: replace copy of draft minutes on iesg moderator page with a link

### DIFF
--- a/ietf/templates/iesg/moderator_package.html
+++ b/ietf/templates/iesg/moderator_package.html
@@ -96,9 +96,7 @@ Some parts Copyright (c) 2009 The IETF Trust, all rights reserved.
                 <p>
                     Are there narrative minutes to approve for today?
                 </p>
-                {% filter linebreaks_crlf %}
-                    <pre>{{ section.text }}</pre>
-                {% endfilter %}
+                <a href="{% url 'ietf.iesg.views.telechat_agenda_content_view' section='minutes' %}">Draft minutes</a>
             {% endif %}
             {% if num == "1.4" %}
                 {% filter linebreaks_crlf %}


### PR DESCRIPTION
fixes #6710 