### PR TITLE
fix: Migrate and handle subseries IprDocRels

### DIFF
--- a/ietf/ipr/migrations/0002_iprdocrel_no_aliases.py
+++ b/ietf/ipr/migrations/0002_iprdocrel_no_aliases.py
@@ -2,14 +2,29 @@
 
 from django.db import migrations
 import django.db.models.deletion
-from django.db.models import F, Subquery, OuterRef, ManyToManyField
+from django.db.models import F, Subquery, OuterRef, ManyToManyField, CharField
 import ietf.utils.models
 
 def forward(apps, schema_editor):
     IprDocRel = apps.get_model("ipr", "IprDocRel")
     DocAlias = apps.get_model("doc", "DocAlias")
-    subquery = Subquery(DocAlias.objects.filter(pk=OuterRef("deprecated_document")).values("docs")[:1])
-    IprDocRel.objects.annotate(firstdoc=subquery).update(document=F("firstdoc")) 
+    document_subquery = Subquery(
+        DocAlias.objects.filter(
+            pk=OuterRef("deprecated_document")
+        ).values("docs")[:1]
+    )
+    name_subquery = Subquery(
+        DocAlias.objects.filter(
+            pk=OuterRef("deprecated_document")
+        ).values("name")[:1]
+    )
+    IprDocRel.objects.annotate(
+        firstdoc=document_subquery,
+        aliasname=name_subquery,
+    ).update(
+        document=F("firstdoc"),
+        originaldocumentaliasname=F("aliasname"),
+    ) 
     # This might not be right - we may need here (and in the relateddocument migrations) to pay attention to
     # whether the name being pointed to is and rfc name or a draft name and point to the right object instead...
 
@@ -56,6 +71,12 @@ class Migration(migrations.Migration):
                 db_index=False,
             ),
             preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="iprdocrel",
+            name="originaldocumentaliasname",
+            field=CharField(max_length=255,null=True),
+            preserve_default=True,
         ),
         migrations.RunPython(forward, reverse),
         migrations.AlterField(

--- a/ietf/ipr/migrations/0002_iprdocrel_no_aliases.py
+++ b/ietf/ipr/migrations/0002_iprdocrel_no_aliases.py
@@ -75,7 +75,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="iprdocrel",
             name="originaldocumentaliasname",
-            field=CharField(max_length=255,null=True),
+            field=CharField(max_length=255,null=True,blank=True),
             preserve_default=True,
         ),
         migrations.RunPython(forward, reverse),

--- a/ietf/ipr/models.py
+++ b/ietf/ipr/models.py
@@ -176,7 +176,7 @@ class IprDocRel(models.Model):
 
     def formatted_name(self):
         name = self.document.name
-        if name.startswith("rfc"):
+        if len(name) >= 3 and name[:3] in ("rfc", "bcp", "fyi", "std"):
             return name.upper()
         #elif self.revisions:
         #    return "%s-%s" % (name, self.revisions)

--- a/ietf/ipr/models.py
+++ b/ietf/ipr/models.py
@@ -163,6 +163,7 @@ class IprDocRel(models.Model):
     document   = ForeignKey(Document)
     sections   = models.TextField(blank=True)
     revisions  = models.CharField(max_length=16,blank=True) # allows strings like 01-07
+    originaldocumentaliasname = models.CharField(max_length=255, null=True)
 
     def doc_type(self):
         name = self.document.name

--- a/ietf/ipr/models.py
+++ b/ietf/ipr/models.py
@@ -163,7 +163,7 @@ class IprDocRel(models.Model):
     document   = ForeignKey(Document)
     sections   = models.TextField(blank=True)
     revisions  = models.CharField(max_length=16,blank=True) # allows strings like 01-07
-    originaldocumentaliasname = models.CharField(max_length=255, null=True)
+    originaldocumentaliasname = models.CharField(max_length=255, null=True, blank=True)
 
     def doc_type(self):
         name = self.document.name

--- a/ietf/templates/ipr/details_view.html
+++ b/ietf/templates/ipr/details_view.html
@@ -384,7 +384,7 @@
                                     </dt>
                                     <dd class="col-sm-8 my-0">
                                         {{ iprdocrel.formatted_name|urlize_ietf_docs }}
-                                        ("{% firstof iprdocrel.document.title iprdocrel.document.name|prettystdname %}")
+                                        {% if iprdocrel.document.title %}("{{ iprdocrel.document.title }}"){% endif %}
                                     </dd>
                                     {% if iprdocrel.revisions %}
                                         <dt class="col-sm-4 my-0">
@@ -431,7 +431,7 @@
                                 </dt>
                                 <dd class="{% if prev %}col-sm-8{% else %}col-sm-9{% endif %} my-0">
                                     {{ iprdocrel.formatted_name|urlize_ietf_docs }}
-                                    ("{% firstof iprdocrel.document.title iprdocrel.document.name|prettystdname%}")
+                                    {% if iprdocrel.document.title %}("{{ iprdocrel.document.title }}"){% endif %}
                                 </dd>
                                 {% if iprdocrel.revisions %}
                                     <dt class="{% if prev %}col-sm-4{% else %}col-sm-3{% endif %} my-0">

--- a/ietf/templates/ipr/details_view.html
+++ b/ietf/templates/ipr/details_view.html
@@ -383,7 +383,8 @@
                                         {{ iprdocrel.doc_type }}:
                                     </dt>
                                     <dd class="col-sm-8 my-0">
-                                        {{ iprdocrel.formatted_name|urlize_ietf_docs }} ("{{ iprdocrel.document.document.title }}")
+                                        {{ iprdocrel.formatted_name|urlize_ietf_docs }}
+                                        ("{% firstof iprdocrel.document.title iprdocrel.document.name|prettystdname %}")
                                     </dd>
                                     {% if iprdocrel.revisions %}
                                         <dt class="col-sm-4 my-0">
@@ -429,7 +430,8 @@
                                     {{ iprdocrel.doc_type }}:
                                 </dt>
                                 <dd class="{% if prev %}col-sm-8{% else %}col-sm-9{% endif %} my-0">
-                                    {{ iprdocrel.formatted_name|urlize_ietf_docs }} ("{{ iprdocrel.document.document.title }}")
+                                    {{ iprdocrel.formatted_name|urlize_ietf_docs }}
+                                    ("{% firstof iprdocrel.document.title iprdocrel.document.name|prettystdname%}")
                                 </dd>
                                 {% if iprdocrel.revisions %}
                                     <dt class="{% if prev %}col-sm-4{% else %}col-sm-3{% endif %} my-0">

--- a/ietf/templates/ipr/search_result.html
+++ b/ietf/templates/ipr/search_result.html
@@ -54,8 +54,7 @@
                                                 is related to
                                                 {% for item in iprdocrels %}
                                                     {% if forloop.last and forloop.counter > 1 %}and{% endif %}
-                                                    {{ item.formatted_name|urlize_ietf_docs }} 
-                                                    ("{% firstof item.document.title item.document.name|prettystdname %}"){% if not forloop.last and forloop.counter > 1 %},{% endif %}
+                                                    {{ item.formatted_name|urlize_ietf_docs }}{% if item.document.title %} ("{{ item.document.title }}"){% endif %}{% if not forloop.last and forloop.counter > 1 %},{% endif %}
                                                 {% endfor %}
                                             {% endif %}
                                         {% endwith %}

--- a/ietf/templates/ipr/search_result.html
+++ b/ietf/templates/ipr/search_result.html
@@ -54,7 +54,8 @@
                                                 is related to
                                                 {% for item in iprdocrels %}
                                                     {% if forloop.last and forloop.counter > 1 %}and{% endif %}
-                                                    {{ item.formatted_name|urlize_ietf_docs }} ("{{ item.document.document.title }}"){% if not forloop.last and forloop.counter > 1 %},{% endif %}
+                                                    {{ item.formatted_name|urlize_ietf_docs }} 
+                                                    ("{% firstof item.document.title item.document.name|prettystdname %}"){% if not forloop.last and forloop.counter > 1 %},{% endif %}
                                                 {% endfor %}
                                             {% endif %}
                                         {% endwith %}


### PR DESCRIPTION
This addresses the concern in https://github.com/ietf-tools/datatracker/pull/6739#discussion_r1416457286 - specifically, `IprDocRel` instances pointing at BCP documents were not migrated correctly.

This uses the same mechanism used for `RelatedDocument` - the original `DocAlias.name` referred to in the `IprDocRel` is stashed in a new field, `originaldocumentaliasname` which is later used to fix up the reference once the BCP documents are created. As with `RelatedDocument`, the expectation is that this stash field will be removed in a release after the migration and fixup are complete.

Additionally cleans up a couple places where `IprDocRel.document` was still being treated as a `DocAlias`. This leads to a user-visible change: IPR declarations pointing at BCP docs used to label them like `bcp11 ("The Organizations Involved in the IETF Standards Process")`, where the parentheses contained the title of the draft pointed to by the BCP doc alias. This now just renders as `BCP11` (which is linkified, so the title is still reasonably accessible)