### PR TITLE
fix: Allow blank originaltargetaliasname

### DIFF
--- a/ietf/doc/migrations/0015_relate_no_aliases.py
+++ b/ietf/doc/migrations/0015_relate_no_aliases.py
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="relateddocument",
             name="originaltargetaliasname",
-            field=CharField(max_length=255,null=True),
+            field=CharField(max_length=255,null=True,blank=True),
             preserve_default=True,
         ),
         migrations.RunPython(forward, reverse),

--- a/ietf/doc/migrations/0016_relate_hist_no_aliases.py
+++ b/ietf/doc/migrations/0016_relate_hist_no_aliases.py
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="relateddochistory",
             name="originaltargetaliasname",
-            field=CharField(max_length=255,null=True),
+            field=CharField(max_length=255,null=True,blank=True),
             preserve_default=True,
         ),
         migrations.RunPython(forward, reverse),

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -684,7 +684,7 @@ class RelatedDocument(models.Model):
     source = ForeignKey('Document')
     target = ForeignKey('Document', related_name='targets_related')
     relationship = ForeignKey(DocRelationshipName)
-    originaltargetaliasname = models.CharField(max_length=255,null=True)
+    originaltargetaliasname = models.CharField(max_length=255, null=True, blank=True)
     def action(self):
         return self.relationship.name
     def __str__(self):
@@ -1136,7 +1136,7 @@ class RelatedDocHistory(models.Model):
     source = ForeignKey('DocHistory')
     target = ForeignKey('Document', related_name="reversely_related_document_history_set")
     relationship = ForeignKey(DocRelationshipName)
-    originaltargetaliasname = models.CharField(max_length=255,null=True)
+    originaltargetaliasname = models.CharField(max_length=255, null=True, blank=True)
     def __str__(self):
         return u"%s %s %s" % (self.source.doc.name, self.relationship.name.lower(), self.target.name)
 


### PR DESCRIPTION
This is a preventative measure - without `blank=True`, a `ModelForm` involving a `RelatedDocument` or `RelatedDocHistory` may refuse to save unless `originaltargetaliasname` is filled in. There have not been indications that this is a problem, but docs created after the `feat/rfc` migrations will have this field blank and our sandbox testing might not have made it easy to run into the problem.