### PR TITLE
fix: Update group dependencies for new rfc model

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -742,11 +742,17 @@ def dependencies(request, acronym, group_type=None):
     )
     rfc_or_subseries = {"rfc", "bcp", "fyi", "std"}
     both_rfcs = Q(source__type_id="rfc", target__type_id__in=rfc_or_subseries)
-    pre_rfc_draft_to_rfc = Q(source__type_id="draft", source__states__slug="rfc", target__type_id__in=rfc_or_subseries)
-    rfc_to_pre_rfc_draft = Q(source__type_id__in=rfc_or_subseries, target__type_id="draft", target__states__slug="rfc")
+    pre_rfc_draft_to_rfc = Q(
+        source__states__type="draft",
+        source__states__slug="rfc",
+        target__type_id__in=rfc_or_subseries,
+    )
     both_pre_rfcs = Q(
-        source__type_id="draft", source__states__slug="rfc",
-        target__type_id="draft", target__states__slug="rfc",
+        source__states__type="draft",
+        source__states__slug="rfc",
+        target__type_id="draft",
+        target__states__type="draft",
+        target__states__slug="rfc",
     )
     inactive = Q(source__states__slug__in=["expired", "repl"])
     attractor = Q(target__name__in=["rfc5000", "rfc5741"])
@@ -755,7 +761,6 @@ def dependencies(request, acronym, group_type=None):
         RelatedDocument.objects.filter(references)
         .exclude(both_rfcs)
         .exclude(pre_rfc_draft_to_rfc)
-        .exclude(rfc_to_pre_rfc_draft)
         .exclude(both_pre_rfcs)
         .exclude(inactive)
         .exclude(attractor)

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -754,9 +754,12 @@ def dependencies(request, acronym, group_type=None):
         target__states__type="draft",
         target__states__slug="rfc",
     )
-    inactive = Q(source__states__slug__in=["expired", "repl"])
+    inactive = Q(
+        source__states__type="draft",
+        source__states__slug__in=["expired", "repl"],
+    )
     attractor = Q(target__name__in=["rfc5000", "rfc5741"])
-    removed = Q(source__states__slug__in=["auth-rm", "ietf-rm"])
+    removed = Q(source__states__type="draft", source__states__slug__in=["auth-rm", "ietf-rm"])
     relations = (
         RelatedDocument.objects.filter(references)
         .exclude(both_rfcs)

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -772,11 +772,10 @@ def dependencies(request, acronym, group_type=None):
         "nodes": [
             {
                 "id": x.name,
-                "rfc": x.get_state("draft").slug == "rfc",
-                "post-wg": not x.get_state("draft-iesg").slug
-                in ["idexists", "watching", "dead"],
-                "expired": x.get_state("draft").slug == "expired",
-                "replaced": x.get_state("draft").slug == "repl",
+                "rfc": x.type_id == "rfc",
+                "post-wg": x.get_state_slug("draft-iesg") not in ["idexists", "watching", "dead"],
+                "expired": x.get_state_slug("draft") == "expired",
+                "replaced": x.get_state_slug("draft") == "repl",
                 "group": x.group.acronym if x.group.acronym != "none" else "",
                 "url": x.get_absolute_url(),
                 "level": x.intended_std_level.name

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -780,7 +780,7 @@ def dependencies(request, acronym, group_type=None):
     graph = {
         "nodes": [
             {
-                "id": x.name,
+                "id": x.became_rfc().name if x.became_rfc() else x.name,
                 "rfc": x.type_id == "rfc",
                 "post-wg": x.get_state_slug("draft-iesg") not in ["idexists", "watching", "dead"],
                 "expired": x.get_state_slug("draft") == "expired",
@@ -797,8 +797,8 @@ def dependencies(request, acronym, group_type=None):
         ],
         "links": [
             {
-                "source": x.source.name,
-                "target": x.target.name,
+                "source": x.source.became_rfc().name if x.source.became_rfc() else x.source.name,
+                "target": x.target.became_rfc().name if x.target.became_rfc() else x.target.name,
                 "rel": "downref" if x.is_downref() else x.relationship.slug,
             }
             for x in links

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -744,6 +744,10 @@ def dependencies(request, acronym, group_type=None):
     both_rfcs = Q(source__type_id="rfc", target__type_id__in=rfc_or_subseries)
     pre_rfc_draft_to_rfc = Q(source__type_id="draft", source__states__slug="rfc", target__type_id__in=rfc_or_subseries)
     rfc_to_pre_rfc_draft = Q(source__type_id__in=rfc_or_subseries, target__type_id="draft", target__states__slug="rfc")
+    both_pre_rfcs = Q(
+        source__type_id="draft", source__states__slug="rfc",
+        target__type_id="draft", target__states__slug="rfc",
+    )
     inactive = Q(source__states__slug__in=["expired", "repl"])
     attractor = Q(target__name__in=["rfc5000", "rfc5741"])
     removed = Q(source__states__slug__in=["auth-rm", "ietf-rm"])
@@ -752,10 +756,12 @@ def dependencies(request, acronym, group_type=None):
         .exclude(both_rfcs)
         .exclude(pre_rfc_draft_to_rfc)
         .exclude(rfc_to_pre_rfc_draft)
+        .exclude(both_pre_rfcs)
         .exclude(inactive)
         .exclude(attractor)
         .exclude(removed)
     )
+    import pdb; pdb.set_trace()
 
     links = set()
     for x in relations:

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -737,7 +737,7 @@ def dependencies(request, acronym, group_type=None):
 
     references = Q(
         Q(source__group=group) | Q(source__in=cl_docs),
-        source__type="draft",  # does this need to be type__in=["draft", "rfc"]? Check for informative ref rfc->draft
+        source__type="draft",
         relationship__slug__startswith="ref",
     )
     rfc_or_subseries = {"rfc", "bcp", "fyi", "std"}

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -781,7 +781,7 @@ def dependencies(request, acronym, group_type=None):
         "nodes": [
             {
                 "id": x.became_rfc().name if x.became_rfc() else x.name,
-                "rfc": x.type_id == "rfc",
+                "rfc": x.type_id == "rfc" or x.became_rfc() is not None,
                 "post-wg": x.get_state_slug("draft-iesg") not in ["idexists", "watching", "dead"],
                 "expired": x.get_state_slug("draft") == "expired",
                 "replaced": x.get_state_slug("draft") == "repl",

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -761,7 +761,6 @@ def dependencies(request, acronym, group_type=None):
         .exclude(attractor)
         .exclude(removed)
     )
-    import pdb; pdb.set_trace()
 
     links = set()
     for x in relations:

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -764,8 +764,8 @@ def dependencies(request, acronym, group_type=None):
 
     links = set()
     for x in relations:
-        target_state = x.target.get_state_slug("draft")
-        if target_state != "rfc" or x.is_downref():
+        always_include = x.target.type_id not in rfc_or_subseries and x.target.get_state_slug("draft") != "rfc" 
+        if always_include or x.is_downref():
             links.add(x)
 
     replacements = RelatedDocument.objects.filter(


### PR DESCRIPTION
This eliminates the attempts to get `state.slug` when `state is None`, which superficially fixes the error in ticket #6768.

PR is put up as a draft because I think more attention may be needed - some of the logic identifies RFCs by using the `draft` state. I think that should look at the type instead but I'm still sorting out what's meant to be going on.

Fixes #6768