### PR TITLE
chore: reconfigure pylint in dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,23 +33,16 @@
                 "oderwat.indent-rainbow",
                 "redhat.vscode-yaml",
                 "spmeesseman.vscode-taskexplorer",
-                "visualstudioexptteam.vscodeintellicode"
+                "visualstudioexptteam.vscodeintellicode",
+                "ms-python.pylint"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "zsh",
                 "python.pythonPath": "/usr/local/bin/python",
                 "python.languageServer": "Default",
-                "python.linting.enabled": true,
-                "python.linting.pylintEnabled": true,
                 "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
                 "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
                 "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-                "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-                "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-                "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
                 "python.testing.pytestArgs": [
                     "ietf"
                 ],


### PR DESCRIPTION
Removes deprecated configuration.

Do we even _need_ pylint given pylance?

But without it, users are annoyed with a nag to install it.