### PR TITLE
fix: Properly set AD as action holder when submitting to IESG for publication

### DIFF
--- a/ietf/doc/views_draft.py
+++ b/ietf/doc/views_draft.py
@@ -564,9 +564,7 @@ def to_iesg(request,name):
 
             events = []
             def doc_event(type, by, doc, desc):
-                e = DocEvent(type=type, by=by, doc=doc, rev=doc.rev, desc=desc)
-                e.save()
-                return e
+                return DocEvent.objects.create(type=type, by=by, doc=doc, rev=doc.rev, desc=desc)
 
             if doc.get_state_slug("draft-iesg") == "idexists":
                 events.append(doc_event("started_iesg_process", by, doc, f"Document is now in IESG state <b>{target_state['iesg'].name}</b>"))

--- a/ietf/doc/views_draft.py
+++ b/ietf/doc/views_draft.py
@@ -563,18 +563,18 @@ def to_iesg(request,name):
             by = request.user.person
 
             events = []
-            def append_event(type, desc):
+            def doc_event(type, by, doc, desc):
                 e = DocEvent(type=type, by=by, doc=doc, rev=doc.rev, desc=desc)
                 e.save()
-                events.append(e)
+                return e
 
             if doc.get_state_slug("draft-iesg") == "idexists":
-                append_event("started_iesg_process", f"Document is now in IESG state <b>{target_state['iesg'].name}</b>")
+                events.append(doc_event("started_iesg_process", by, doc, f"Document is now in IESG state <b>{target_state['iesg'].name}</b>"))
 
             # do this first, so AD becomes action holder
             if not doc.ad == ad :
                 doc.ad = ad
-                append_event("changed_document", f"Responsible AD changed to {doc.ad}")
+                events.append(doc_event("changed_document", by, doc, f"Responsible AD changed to {doc.ad}"))
 
             for state_type in ['draft-iesg','draft-stream-ietf']:
                 prev_state=doc.get_state(state_type)
@@ -588,12 +588,12 @@ def to_iesg(request,name):
 
             if not doc.notify == notify :
                 doc.notify = notify
-                append_event("changed_document", f"State Change Notice email list changed to {doc.notify}")
+                events.append(doc_event("changed_document", by, doc, f"State Change Notice email list changed to {doc.notify}"))
 
             # Get the last available writeup
             previous_writeup = doc.latest_event(WriteupDocEvent,type="changed_protocol_writeup")
             if previous_writeup != None:
-                append_event("changed_document", previous_writeup.text)
+                events.append(doc_event("changed_document", by, doc, previous_writeup.text))
 
             doc.save_with_history(events)
 


### PR DESCRIPTION
Fixes #5227

The clear intent of `to_iesg` is that
a) the document AD should be the group AD, if not already set, and b) the document Action Holder should be the document AD; but there was an order-of-operation error,
such that the Action Holder remained empty.