### PR TITLE
chore: update requests min version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ python-magic==0.4.18    # Versions beyond the yanked .19 and .20 introduce form 
 pymemcache>=4.0.0  # for django.core.cache.backends.memcached.PyMemcacheCache 
 python-mimeparse>=1.6    # from TastyPie
 pytz==2022.2.1   # Pinned as changes need to be vetted for their effect on Meeting fields
-requests>=2.27.1
+requests>=2.31.0
 types-requests>=2.27.1
 requests-mock>=1.9.3
 rfc2html>=2.0.3


### PR DESCRIPTION
There are potential vulnerabilities in the requests library at least as late as 2.30.0, so this moves our requirement past those. I don't believe we were actually exposed to them.

We're already at 2.31.0 on production, so this is a no-op - just bookkeeping.