### PR TITLE
fix: Never show AD col on drafts_for_ad.html

### DIFF
--- a/ietf/doc/utils_search.py
+++ b/ietf/doc/utils_search.py
@@ -181,7 +181,7 @@ def augment_docs_with_related_docs_info(docs):
             originalDoc = d.related_that_doc('conflrev')[0]
             d.pages = originalDoc.pages
 
-def prepare_document_table(request, docs, query=None, max_results=200):
+def prepare_document_table(request, docs, query=None, max_results=200, show_ad_and_shepherd=True):
     """Take a queryset of documents and a QueryDict with sorting info
     and return list of documents with attributes filled in for
     displaying a full table of information about the documents, plus
@@ -259,12 +259,14 @@ def prepare_document_table(request, docs, query=None, max_results=200):
     if len(docs) == max_results:
         meta['max'] = max_results
 
-    meta['headers'] = [{'title': 'Document', 'key':'document'},
-                       {'title': 'Title', 'key':'title'},
-                       {'title': 'Date', 'key':'date'},
-                       {'title': 'Status', 'key':'status'},
-                       {'title': 'IPR', 'key':'ipr'},
-                       {'title': 'AD / Shepherd', 'key':'ad'}]
+    meta['headers'] = [{'title': 'Document', 'key': 'document'},
+                       {'title': 'Title', 'key': 'title'},
+                       {'title': 'Date', 'key': 'date'},
+                       {'title': 'Status', 'key': 'status'},
+                       {'title': 'IPR', 'key': 'ipr'}]
+    if show_ad_and_shepherd:
+        meta['headers'].append({'title': 'AD / Shepherd', 'key': 'ad'})
+    meta['show_ad_and_shepherd'] = show_ad_and_shepherd
 
     if query and hasattr(query, "urlencode"):  # fed a Django QueryDict
         d = query.copy()

--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -691,7 +691,7 @@ def docs_for_ad(request, name):
         {
             "docs": results,
             "meta": meta,
-            "ad_name": ad.name,
+            "ad": ad,
             "blocked_docs": blocked_docs,
             "not_balloted_docs": not_balloted_docs,
         },

--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -591,9 +591,10 @@ def docs_for_ad(request, name):
     if not ad:
         raise Http404
 
-    results, meta = prepare_document_table(request, Document.objects.filter(ad=ad), max_results=500)
+    results, meta = prepare_document_table(
+        request, Document.objects.filter(ad=ad), max_results=500, show_ad_and_shepherd=False
+    )
     results.sort(key=lambda d: sort_key(d))
-    del meta["headers"][-1]
 
     # filter out some results
     results = [

--- a/ietf/templates/doc/drafts_for_ad.html
+++ b/ietf/templates/doc/drafts_for_ad.html
@@ -6,13 +6,13 @@
 {% block pagehead %}
     <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
 {% endblock %}
-{% block title %}Documents for {{ ad_name }}{% endblock %}
+{% block title %}Documents for {{ ad.name }}{% endblock %}
 {% block content %}
     {% origin %}
-    <h1>Documents for {{ ad_name }}</h1>
+    <h1>Documents for {{ ad.name }}</h1>
     <a class="btn btn-primary my-3" href="{% url 'ietf.doc.views_search.ad_workload' %}">IESG dashboard</a>
     {% if blocked_docs %}
-        <h2 class="mt-4">Blocking positions held by {{ ad_name }}</h2>
+        <h2 class="mt-4">Blocking positions held by {{ ad.name }}</h2>
         <table class="table table-sm table-striped tablesorter">
             <thead>
                 <tr>
@@ -54,7 +54,7 @@
         </table>
     {% endif %}
     {% if not_balloted_docs %}
-        <h2 class="mt-4">Missing ballot positions for {{ ad_name }}</h2>
+        <h2 class="mt-4">Missing ballot positions for {{ ad.name }}</h2>
         <table class="table table-sm table-striped tablesorter">
             <thead>
                 <tr>
@@ -80,7 +80,7 @@
             </tbody>
         </table>
     {% endif %}
-    <h2 class="mt-4">Documents for {{ ad_name }}</h2>
+    <h2 class="mt-4">Documents for {{ ad.name }}</h2>
     {% include "doc/search/search_results.html" with start_table=True end_table=True %}
 {% endblock %}
 {% block js %}

--- a/ietf/templates/doc/search/search_result_row.html
+++ b/ietf/templates/doc/search/search_result_row.html
@@ -142,7 +142,7 @@
             </a>
         {% endif %}
     </td>
-    {% if ad is None or ad != doc.ad %}
+    {% if ad is None %}
         <td class="d-none d-sm-table-cell bg-transparent">
             {% if doc.ad %}
                 {% person_link doc.ad title="Area Director" %}

--- a/ietf/templates/doc/search/search_result_row.html
+++ b/ietf/templates/doc/search/search_result_row.html
@@ -142,7 +142,7 @@
             </a>
         {% endif %}
     </td>
-    {% if ad_name == None or ad_name != doc.ad.plain_name %}
+    {% if ad is None or ad != doc.ad %}
         <td class="d-none d-sm-table-cell bg-transparent">
             {% if doc.ad %}
                 {% person_link doc.ad title="Area Director" %}

--- a/ietf/templates/doc/search/search_result_row.html
+++ b/ietf/templates/doc/search/search_result_row.html
@@ -142,7 +142,7 @@
             </a>
         {% endif %}
     </td>
-    {% if ad is None %}
+    {% if meta.show_ad_and_shepherd %}
         <td class="d-none d-sm-table-cell bg-transparent">
             {% if doc.ad %}
                 {% person_link doc.ad title="Area Director" %}

--- a/ietf/templates/doc/search/search_result_row.html
+++ b/ietf/templates/doc/search/search_result_row.html
@@ -142,7 +142,7 @@
             </a>
         {% endif %}
     </td>
-    {% if meta.show_ad_and_shepherd %}
+    {% if show_ad_and_shepherd %}
         <td class="d-none d-sm-table-cell bg-transparent">
             {% if doc.ad %}
                 {% person_link doc.ad title="Area Director" %}

--- a/ietf/templates/doc/search/search_results.html
+++ b/ietf/templates/doc/search/search_results.html
@@ -55,7 +55,7 @@
     </tbody>
     <tbody>
         {% for doc in doc_group.list %}
-            {% include "doc/search/search_result_row.html" %}
+            {% include "doc/search/search_result_row.html" with show_ad_and_shepherd=meta.show_ad_and_shepherd %}
         {% endfor %}
     </tbody>
 {% endfor %}

--- a/ietf/templates/iesg/agenda_documents.html
+++ b/ietf/templates/iesg/agenda_documents.html
@@ -55,7 +55,7 @@
                         </thead>
                         <tbody>
                             {% for doc in section.docs %}
-                                {% include "doc/search/search_result_row.html" with color_ad_position=True %}
+                                {% include "doc/search/search_result_row.html" with color_ad_position=True show_ad_and_shepherd=True %}
                             {% endfor %}
                         </tbody>
                     </table>


### PR DESCRIPTION
This should fix a transient HTML validation failure caused by assuming `ad.name != doc.ad.plain_name()` indicated that `ad != doc.ad`.

That check was, as far as I can tell, unnecessary because the search results were selected using `doc.ad == ad`. The check is removed here.

I'm leaving in the initial change from including `ad_name` to `ad` in the template context because I don't see a benefit to handing around the string instead of the full record.

For the record, the transient failure was:
```
======================================================================
FAIL: run_template_validation (ietf.utils.test_runner.TemplateValidationTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/datatracker/datatracker/ietf/utils/test_runner.py", line 343, in run_template_validation
    self.validate_html.validate(self)
  File "/__w/datatracker/datatracker/ietf/utils/test_runner.py", line 1039, in validate
    testcase.fail('\n'.join(errors))
AssertionError: 
/tmp/html-validate-9azr981j/222fdd5170477301/ietf/templates/doc/drafts_for_ad.html:
     </td>      </tr>      
          ^^^^^^^^^^^
          info: A table row was 6 columns wide and exceeded the column count established by the first row (5).
Source snippet, lines 789 to 800:
789:                 <i class="bi bi-envelope"></i></a></span>
790:             
791:             <br>
792:             
793:         </td>
794:     
795: </tr>
796:         
797:     </tbody>
798: 
799: </table>
800: 
```