### PR TITLE
fix: Set authors when publishing an RFC

### DIFF
--- a/ietf/doc/management/commands/reset_rfc_authors.py
+++ b/ietf/doc/management/commands/reset_rfc_authors.py
@@ -1,0 +1,58 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+
+# Reset an RFC's authors to those of the draft it came from
+from django.core.management.base import BaseCommand, CommandError
+
+from ietf.doc.models import Document, DocEvent
+from ietf.person.models import Person
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("rfcnum", type=int, help="RFC number to modify")
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="reset even if RFC already has authors",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            rfc = Document.objects.get(type="rfc", rfc_number=options["rfcnum"])
+        except Document.DoesNotExist:
+            raise CommandError(
+                f"rfc{options['rfcnum']} does not exist in the Datatracker."
+            )
+        n_authors = rfc.documentauthor_set.count()
+        if n_authors > 0:
+            # Potentially dangerous, so refuse unless "--force" is specified
+            if not options["force"]:
+                raise CommandError(
+                    f"{rfc.name} already has authors. Not resetting. Use '--force' to reset anyway."
+                )
+            rfc.documentauthor_set.all().delete()
+            self.stdout.write(
+                self.style.SUCCESS(f"Removed existing {n_authors} authors")
+            )
+        draft = rfc.came_from_draft()
+        if draft is None:
+            raise CommandError(f"{rfc.name} did not come from a draft. Can't reset.")
+
+        for author in draft.documentauthor_set.all():
+            # Copy the author but point at the new doc.
+            # See https://docs.djangoproject.com/en/4.2/topics/db/queries/#copying-model-instances
+            author.pk = None
+            author.id = None
+            author._state.adding = True
+            author.document = rfc
+            author.save()
+            self.stdout.write(
+                self.style.SUCCESS(f"Added author {author.person.name} <{author.email}>")
+            )
+        auth_names = draft.documentauthor_set.values_list("person__name", flat=True)
+        DocEvent.objects.create(
+            doc=rfc,
+            by=Person.objects.get(name="(System)"),
+            type="edited_authors",
+            desc=f"Set authors from rev {draft.rev} of {draft.name}: {', '.join(auth_names)}",
+        )

--- a/ietf/sync/rfceditor.py
+++ b/ietf/sync/rfceditor.py
@@ -462,6 +462,14 @@ def update_docs_from_rfc_index(
             doc.set_state(rfc_published_state)
             if draft:
                 doc.formal_languages.set(draft.formal_languages.all())
+                for author in draft.documentauthor_set.all():
+                    # Copy the author but point at the new doc. 
+                    # See https://docs.djangoproject.com/en/4.2/topics/db/queries/#copying-model-instances
+                    author.pk = None
+                    author.id = None
+                    author._state.adding = True
+                    author.document = doc
+                    author.save()
 
         if draft:
             draft_events = []


### PR DESCRIPTION
Fixes #6949 

Restores pre-v12 behavior- authors are assumed to be the same as the last rev of the draft.

Adds the `reset_rfc_authors` management command, which can be used to correct RFCs published from drafts. By default, this will not touch an RFC with at least one author, but a `--force` option will override this. Adds a `DocEvent` describing the change.