### PR TITLE
feat: celery tasks to replace ietf/bin scripts

### DIFF
--- a/bin/hourly
+++ b/bin/hourly
@@ -45,6 +45,7 @@ ID=/a/ietfdata/doc/draft/repository
 DERIVED=/a/ietfdata/derived
 DOWNLOAD=/a/www/www6s/download
 
+## Start of script refactored into idindex_update_task() ===
 export TMPDIR=/a/tmp
 
 TMPFILE1=`mktemp` || exit 1
@@ -84,6 +85,8 @@ mv $TMPFILE8 $DERIVED/all_id.txt
 mv $TMPFILE9 $DERIVED/1id-index.txt
 mv $TMPFILEA $DERIVED/1id-abstracts.txt
 mv $TMPFILEB $DERIVED/all_id2.txt
+
+## End of script refactored into idindex_update_task() ===
 
 $DTDIR/ietf/manage.py generate_idnits2_rfc_status
 $DTDIR/ietf/manage.py generate_idnits2_rfcs_obsoleted

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -1,0 +1,48 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+#
+# Celery task definitions
+#
+import datetime
+import debug  # pyflakes:ignore
+
+from celery import shared_task
+
+from ietf.utils import log
+from ietf.utils.timezone import datetime_today
+
+from .expire import (
+    in_draft_expire_freeze,
+    get_expired_drafts,
+    expirable_drafts,
+    send_expire_notice_for_draft,
+    expire_draft,
+    clean_up_draft_files,
+)
+from .models import Document
+
+
+@shared_task
+def expire_ids_task():
+    try:
+        if not in_draft_expire_freeze():
+            log.log("Expiring drafts ...")
+            for doc in get_expired_drafts():
+                # verify expirability -- it might have changed after get_expired_drafts() was run
+                # (this whole loop took about 2 minutes on 04 Jan 2018)
+                # N.B., re-running expirable_drafts() repeatedly is fairly expensive. Where possible,
+                # it's much faster to run it once on a superset query of the objects you are going
+                # to test and keep its results. That's not desirable here because it would defeat
+                # the purpose of double-checking that a document is still expirable when it is actually
+                # being marked as expired.
+                if expirable_drafts(
+                    Document.objects.filter(pk=doc.pk)
+                ).exists() and doc.expires < datetime_today() + datetime.timedelta(1):
+                    send_expire_notice_for_draft(doc)
+                    expire_draft(doc)
+                    log.log(f"  Expired draft {doc.name}-{doc.rev}")
+
+        log.log("Cleaning up draft files")
+        clean_up_draft_files()
+    except Exception as e:
+        log.log("Exception in expire-ids: %s" % e)
+        raise

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -17,6 +17,8 @@ from .expire import (
     send_expire_notice_for_draft,
     expire_draft,
     clean_up_draft_files,
+    get_soon_to_expire_drafts,
+    send_expire_warning_for_draft,
 )
 from .models import Document
 
@@ -46,3 +48,9 @@ def expire_ids_task():
     except Exception as e:
         log.log("Exception in expire-ids: %s" % e)
         raise
+
+
+@shared_task
+def notify_expirations_task(notify_days=14):
+    for doc in get_soon_to_expire_drafts(notify_days):
+        send_expire_warning_for_draft(doc)

--- a/ietf/doc/tests_tasks.py
+++ b/ietf/doc/tests_tasks.py
@@ -1,0 +1,54 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+import mock
+
+from ietf.utils.test_utils import TestCase
+from ietf.utils.timezone import datetime_today
+
+from .factories import DocumentFactory
+from .models import Document
+from .tasks import expire_ids_task
+
+
+class TaskTests(TestCase):
+
+    @mock.patch("ietf.doc.tasks.in_draft_expire_freeze")
+    @mock.patch("ietf.doc.tasks.get_expired_drafts")
+    @mock.patch("ietf.doc.tasks.expirable_drafts")
+    @mock.patch("ietf.doc.tasks.send_expire_notice_for_draft")
+    @mock.patch("ietf.doc.tasks.expire_draft")
+    @mock.patch("ietf.doc.tasks.clean_up_draft_files")
+    def test_expire_ids_task(
+        self,
+        clean_up_draft_files_mock,
+        expire_draft_mock,
+        send_expire_notice_for_draft_mock,
+        expirable_drafts_mock,
+        get_expired_drafts_mock,
+        in_draft_expire_freeze_mock,
+    ):
+        # set up mocks
+        in_draft_expire_freeze_mock.return_value = False
+        doc, other_doc = DocumentFactory.create_batch(2)
+        doc.expires = datetime_today()
+        get_expired_drafts_mock.return_value = [doc, other_doc]
+        expirable_drafts_mock.side_effect = [
+            Document.objects.filter(pk=doc.pk),
+            Document.objects.filter(pk=other_doc.pk),
+        ]
+        
+        # call task
+        expire_ids_task()
+        
+        # check results
+        self.assertTrue(in_draft_expire_freeze_mock.called)
+        self.assertEqual(expirable_drafts_mock.call_count, 2)
+        self.assertEqual(send_expire_notice_for_draft_mock.call_count, 1)
+        self.assertEqual(send_expire_notice_for_draft_mock.call_args[0], (doc,))
+        self.assertEqual(expire_draft_mock.call_count, 1)
+        self.assertEqual(expire_draft_mock.call_args[0], (doc,))
+        self.assertTrue(clean_up_draft_files_mock.called)
+
+        # test that an exception is raised
+        in_draft_expire_freeze_mock.side_effect = RuntimeError
+        with self.assertRaises(RuntimeError):(
+            expire_ids_task())

--- a/ietf/idindex/tasks.py
+++ b/ietf/idindex/tasks.py
@@ -4,6 +4,8 @@
 #
 import shutil
 
+import debug    # pyflakes:ignore
+
 from celery import shared_task
 from contextlib import AbstractContextManager
 from pathlib import Path
@@ -18,7 +20,7 @@ class TempFileManager(AbstractContextManager):
         self.dir = tmpdir
 
     def make_temp_file(self, content):
-        with NamedTemporaryFile(delete=False, dir=self.dir) as tf:
+        with NamedTemporaryFile(mode="wt", delete=False, dir=self.dir) as tf:
             tf_path = Path(tf.name)
             self.cleanup_list.add(tf_path)
             tf.write(content)
@@ -34,9 +36,7 @@ class TempFileManager(AbstractContextManager):
             tf_path.unlink(missing_ok=True)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is not None:
-            # exception occurred
-            self.cleanup()
+        self.cleanup()
         return False  # False: do not suppress the exception
 
 

--- a/ietf/idindex/tasks.py
+++ b/ietf/idindex/tasks.py
@@ -15,7 +15,7 @@ from .index import all_id_txt, all_id2_txt, id_index_txt
 
 
 class TempFileManager(AbstractContextManager):
-    def __init__(self, tmpdir=None):
+    def __init__(self, tmpdir=None) -> None:
         self.cleanup_list: set[Path] = set()
         self.dir = tmpdir
 

--- a/ietf/idindex/tasks.py
+++ b/ietf/idindex/tasks.py
@@ -5,73 +5,83 @@
 import shutil
 
 from celery import shared_task
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from .index import all_id_txt, all_id2_txt, id_index_txt
 
 
-@shared_task
-def idindex_update_task():
-    """Update I-D indexes"""
-    cleanup_list: set[Path] = set()
+class TempFileManager:
+    def __init__(self, tmpdir=None):
+        self.cleanup_list: set[Path] = set()
+        self.dir = tmpdir
 
-    def _make_temp_file(content):
-        with NamedTemporaryFile(delete=False, dir="/a/tmp") as tf:
+    def make_temp_file(self, content):
+        with NamedTemporaryFile(delete=False, dir=self.dir) as tf:
             tf_path = Path(tf.name)
-            cleanup_list.add(tf_path)
+            self.cleanup_list.add(tf_path)
             tf.write(content)
         return tf_path
 
-    def _move_into_place(src_path: Path, dest_path: Path):
+    def move_into_place(self, src_path: Path, dest_path: Path):
         shutil.move(src_path, dest_path)
         dest_path.chmod(0o644)
-        cleanup_list.remove(src_path)
+        self.cleanup_list.remove(src_path)
 
-    def _cleanup():
-        for tf_path in cleanup_list:
+    def cleanup(self):
+        for tf_path in self.cleanup_list:
             tf_path.unlink(missing_ok=True)
 
+@contextmanager
+def get_tempfile_manager(tmpdir):
+    mgr = TempFileManager(tmpdir)
+    try:
+        yield mgr
+    finally:
+        mgr.cleanup()
+
+
+@shared_task
+def idindex_update_task():
+    """Update I-D indexes"""
     id_path = Path("/a/ietfdata/doc/draft/repository")
     derived_path = Path("/a/ietfdata/derived")
     download_path = Path("/a/www/www6s/download")
 
-    # all_id
-    try:
+    with get_tempfile_manager("/a/tmp") as tmp_mgr:
         # Generate copies of new contents
         all_id_content = all_id_txt()
-        all_id_tmpfile = _make_temp_file(all_id_content)
-        derived_all_id_tmpfile = _make_temp_file(all_id_content)
-        download_all_id_tmpfile = _make_temp_file(all_id_content)
+        all_id_tmpfile = tmp_mgr.make_temp_file(all_id_content)
+        derived_all_id_tmpfile = tmp_mgr.make_temp_file(all_id_content)
+        download_all_id_tmpfile = tmp_mgr.make_temp_file(all_id_content)
 
         id_index_content = id_index_txt()
-        id_index_tmpfile = _make_temp_file(id_index_content)
-        derived_id_index_tmpfile = _make_temp_file(id_index_content)
-        download_id_index_tmpfile = _make_temp_file(id_index_content)
+        id_index_tmpfile = tmp_mgr.make_temp_file(id_index_content)
+        derived_id_index_tmpfile = tmp_mgr.make_temp_file(id_index_content)
+        download_id_index_tmpfile = tmp_mgr.make_temp_file(id_index_content)
 
         id_abstracts_content = id_index_txt(with_abstracts=True)
-        id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
-        derived_id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
-        download_id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
+        id_abstracts_tmpfile = tmp_mgr.make_temp_file(id_abstracts_content)
+        derived_id_abstracts_tmpfile = tmp_mgr.make_temp_file(id_abstracts_content)
+        download_id_abstracts_tmpfile = tmp_mgr.make_temp_file(id_abstracts_content)
 
         all_id2_content = all_id2_txt()
-        all_id2_tmpfile = _make_temp_file(all_id2_content)
-        derived_all_id2_tmpfile = _make_temp_file(all_id2_content)
+        all_id2_tmpfile = tmp_mgr.make_temp_file(all_id2_content)
+        derived_all_id2_tmpfile = tmp_mgr.make_temp_file(all_id2_content)
 
         # Move temp files as-atomically-as-possible into place
-        _move_into_place(all_id_tmpfile, id_path / "all_id.txt")
-        _move_into_place(derived_all_id_tmpfile, derived_path / "all_id.txt")
-        _move_into_place(download_all_id_tmpfile, download_path / "id-all.txt")
+        tmp_mgr.move_into_place(all_id_tmpfile, id_path / "all_id.txt")
+        tmp_mgr.move_into_place(derived_all_id_tmpfile, derived_path / "all_id.txt")
+        tmp_mgr.move_into_place(download_all_id_tmpfile, download_path / "id-all.txt")
 
-        _move_into_place(id_index_tmpfile, id_path / "1id-index.txt")
-        _move_into_place(derived_id_index_tmpfile, derived_path / "1id-index.txt")
-        _move_into_place(download_id_index_tmpfile, download_path / "id-index.txt")
+        tmp_mgr.move_into_place(id_index_tmpfile, id_path / "1id-index.txt")
+        tmp_mgr.move_into_place(derived_id_index_tmpfile, derived_path / "1id-index.txt")
+        tmp_mgr.move_into_place(download_id_index_tmpfile, download_path / "id-index.txt")
 
-        _move_into_place(id_abstracts_tmpfile, id_path / "1id-abstracts.txt")
-        _move_into_place(derived_id_abstracts_tmpfile, derived_path / "1id-abstracts.txt")
-        _move_into_place(download_id_abstracts_tmpfile, download_path / "id-abstract.txt")
+        tmp_mgr.move_into_place(id_abstracts_tmpfile, id_path / "1id-abstracts.txt")
+        tmp_mgr.move_into_place(derived_id_abstracts_tmpfile, derived_path / "1id-abstracts.txt")
+        tmp_mgr.move_into_place(download_id_abstracts_tmpfile, download_path / "id-abstract.txt")
 
-        _move_into_place(all_id2_tmpfile, id_path / "all_id2.txt")
-        _move_into_place(derived_all_id2_tmpfile, derived_path / "all_id2.txt")
-    finally:
-        _cleanup()
+        tmp_mgr.move_into_place(all_id2_tmpfile, id_path / "all_id2.txt")
+        tmp_mgr.move_into_place(derived_all_id2_tmpfile, derived_path / "all_id2.txt")

--- a/ietf/idindex/tasks.py
+++ b/ietf/idindex/tasks.py
@@ -1,0 +1,77 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+#
+# Celery task definitions
+#
+import shutil
+
+from celery import shared_task
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+
+from .index import all_id_txt, all_id2_txt, id_index_txt
+
+@shared_task
+def idindex_update_task():
+    """Update I-D indexes"""
+    cleanup_list = set()
+    
+    def _make_temp_file(content):
+        with NamedTemporaryFile(delete=False, dir="/a/tmp") as tf:
+            cleanup_list.add(tf)
+            tf_path = Path(tf.name)
+            tf_path.chmod(0o644)
+            tf.write(content)
+        return tf_path
+
+    def _move_into_place(tf_path, dest):
+        shutil.move(tf_path, dest)
+        cleanup_list.remove(tf_path)
+
+    def _cleanup():
+        for tf_path in cleanup_list:
+            tf_path.unlink(missing_ok=True)
+
+    id_path = Path("/a/ietfdata/doc/draft/repository")
+    derived_path = Path("/a/ietfdata/derived")
+    download_path = Path("/a/www/www6s/download")
+
+    # all_id
+    try:
+        # Generate copies of new contents
+        all_id_content = all_id_txt()
+        all_id_tmpfile = _make_temp_file(all_id_content)
+        derived_all_id_tmpfile = _make_temp_file(all_id_content)
+        download_all_id_tmpfile = _make_temp_file(all_id_content)
+
+        id_index_content = id_index_txt()
+        id_index_tmpfile = _make_temp_file(id_index_content)
+        derived_id_index_tmpfile = _make_temp_file(id_index_content)
+        download_id_index_tmpfile = _make_temp_file(id_index_content)
+        
+        id_abstracts_content = id_index_txt(with_abstracts=True)
+        id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
+        derived_id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
+        download_id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
+        
+        all_id2_content = all_id2_txt()
+        all_id2_tmpfile = _make_temp_file(all_id2_content)
+        derived_all_id2_tmpfile = _make_temp_file(all_id2_content)
+        
+        # Move temp files as-atomically-as-possible into place
+        _move_into_place(all_id_tmpfile, id_path / "all_id.txt")
+        _move_into_place(derived_all_id_tmpfile, derived_path / "all_id.txt")
+        _move_into_place(download_all_id_tmpfile, download_path / "id-all.txt")
+        
+        _move_into_place(id_index_tmpfile, id_path / "1id-index.txt")
+        _move_into_place(derived_id_index_tmpfile, derived_path / "1id-index.txt")
+        _move_into_place(download_id_index_tmpfile, download_path / "id-index.txt")
+        
+        _move_into_place(id_abstracts_tmpfile, id_path / "1id-abstracts.txt")
+        _move_into_place(derived_id_abstracts_tmpfile, derived_path / "1id-abstracts.txt")
+        _move_into_place(download_id_abstracts_tmpfile, download_path / "id-abstract.txt")
+        
+        _move_into_place(all_id2_tmpfile, id_path / "all_id2.txt")
+        _move_into_place(derived_all_id2_tmpfile, derived_path / "all_id2.txt")
+    finally:
+        _cleanup()

--- a/ietf/idindex/tasks.py
+++ b/ietf/idindex/tasks.py
@@ -8,25 +8,25 @@ from celery import shared_task
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-
 from .index import all_id_txt, all_id2_txt, id_index_txt
+
 
 @shared_task
 def idindex_update_task():
     """Update I-D indexes"""
-    cleanup_list = set()
-    
+    cleanup_list: set[Path] = set()
+
     def _make_temp_file(content):
         with NamedTemporaryFile(delete=False, dir="/a/tmp") as tf:
-            cleanup_list.add(tf)
             tf_path = Path(tf.name)
-            tf_path.chmod(0o644)
+            cleanup_list.add(tf_path)
             tf.write(content)
         return tf_path
 
-    def _move_into_place(tf_path, dest):
-        shutil.move(tf_path, dest)
-        cleanup_list.remove(tf_path)
+    def _move_into_place(src_path: Path, dest_path: Path):
+        shutil.move(src_path, dest_path)
+        dest_path.chmod(0o644)
+        cleanup_list.remove(src_path)
 
     def _cleanup():
         for tf_path in cleanup_list:
@@ -48,29 +48,29 @@ def idindex_update_task():
         id_index_tmpfile = _make_temp_file(id_index_content)
         derived_id_index_tmpfile = _make_temp_file(id_index_content)
         download_id_index_tmpfile = _make_temp_file(id_index_content)
-        
+
         id_abstracts_content = id_index_txt(with_abstracts=True)
         id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
         derived_id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
         download_id_abstracts_tmpfile = _make_temp_file(id_abstracts_content)
-        
+
         all_id2_content = all_id2_txt()
         all_id2_tmpfile = _make_temp_file(all_id2_content)
         derived_all_id2_tmpfile = _make_temp_file(all_id2_content)
-        
+
         # Move temp files as-atomically-as-possible into place
         _move_into_place(all_id_tmpfile, id_path / "all_id.txt")
         _move_into_place(derived_all_id_tmpfile, derived_path / "all_id.txt")
         _move_into_place(download_all_id_tmpfile, download_path / "id-all.txt")
-        
+
         _move_into_place(id_index_tmpfile, id_path / "1id-index.txt")
         _move_into_place(derived_id_index_tmpfile, derived_path / "1id-index.txt")
         _move_into_place(download_id_index_tmpfile, download_path / "id-index.txt")
-        
+
         _move_into_place(id_abstracts_tmpfile, id_path / "1id-abstracts.txt")
         _move_into_place(derived_id_abstracts_tmpfile, derived_path / "1id-abstracts.txt")
         _move_into_place(download_id_abstracts_tmpfile, download_path / "id-abstract.txt")
-        
+
         _move_into_place(all_id2_tmpfile, id_path / "all_id2.txt")
         _move_into_place(derived_all_id2_tmpfile, derived_path / "all_id2.txt")
     finally:

--- a/ietf/idindex/tests.py
+++ b/ietf/idindex/tests.py
@@ -16,6 +16,7 @@ from ietf.doc.models import Document, RelatedDocument, State, LastCallDocEvent, 
 from ietf.group.factories import GroupFactory
 from ietf.name.models import DocRelationshipName
 from ietf.idindex.index import all_id_txt, all_id2_txt, id_index_txt
+from ietf.idindex.tasks import idindex_update_task
 from ietf.person.factories import PersonFactory, EmailFactory
 from ietf.utils.test_utils import TestCase
 
@@ -151,3 +152,8 @@ class IndexTests(TestCase):
         txt = id_index_txt(with_abstracts=True)
 
         self.assertTrue(draft.abstract[:20] in txt)
+
+
+class TaskTests(TestCase):
+    def test_idindex_update_task(self):
+        

--- a/ietf/sync/tasks.py
+++ b/ietf/sync/tasks.py
@@ -70,7 +70,7 @@ def rfc_editor_index_update_task(full_index=False):
 
 
 @shared_task
-def iana_changes_updates_task():
+def iana_changes_update_task():
     # compensate to avoid we ask for something that happened now and then
     # don't get it back because our request interval is slightly off
     CLOCK_SKEW_COMPENSATION = 5  # seconds

--- a/ietf/sync/tasks.py
+++ b/ietf/sync/tasks.py
@@ -133,7 +133,7 @@ def iana_protocols_update_task():
         )
     except requests.Timeout as exc:
         log.log(f'GET request timed out retrieving IANA protocols page: {exc}')
-        raise
+        return
 
     rfc_numbers = iana.parse_protocol_page(response.text)
 

--- a/ietf/sync/tasks.py
+++ b/ietf/sync/tasks.py
@@ -7,7 +7,6 @@ import io
 import requests
 
 from celery import shared_task
-from itertools import batched
 
 from django.conf import settings
 from django.utils import timezone
@@ -137,6 +136,14 @@ def iana_protocols_update_task():
         raise
 
     rfc_numbers = iana.parse_protocol_page(response.text)
+
+    def batched(l, n):
+        """Split list l up in batches of max size n.
+        
+        For Python 3.12 or later, replace this with itertools.batched()
+        """
+        return (l[i:i + n] for i in range(0, len(l), n))
+
     for batch in batched(rfc_numbers, 100):
         updated = iana.update_rfc_log_from_protocol_page(
             batch,

--- a/ietf/sync/tests.py
+++ b/ietf/sync/tests.py
@@ -809,7 +809,7 @@ class TaskTests(TestCase):
     @mock.patch("ietf.sync.tasks.iana.update_history_with_changes")
     @mock.patch("ietf.sync.tasks.iana.parse_changes_json")
     @mock.patch("ietf.sync.tasks.iana.fetch_changes_json")
-    def test_iana_changes_updates_task(
+    def test_iana_changes_update_task(
         self, 
         fetch_changes_mock,
         parse_changes_mock,
@@ -827,7 +827,7 @@ class TaskTests(TestCase):
             ["oh no!"],  # warnings
         ]
         
-        tasks.iana_changes_updates_task()
+        tasks.iana_changes_update_task()
         self.assertEqual(fetch_changes_mock.call_count, 1)
         self.assertEqual(
             fetch_changes_mock.call_args[0][0],

--- a/ietf/sync/tests.py
+++ b/ietf/sync/tests.py
@@ -892,3 +892,14 @@ class TaskTests(TestCase):
             published_later_than, 
             {datetime.datetime(2012,11,26,tzinfo=datetime.timezone.utc)}
         )
+
+        # try with an exception
+        requests_get_mock.reset_mock()
+        parse_protocols_mock.reset_mock()
+        update_rfc_log_mock.reset_mock()
+        requests_get_mock.side_effect = requests.Timeout
+
+        tasks.iana_protocols_update_task()
+        self.assertTrue(requests_get_mock.called)
+        self.assertFalse(parse_protocols_mock.called)
+        self.assertFalse(update_rfc_log_mock.called)

--- a/ietf/sync/tests.py
+++ b/ietf/sync/tests.py
@@ -685,8 +685,8 @@ class TaskTests(TestCase):
         RFC_EDITOR_INDEX_URL="https://rfc-editor.example.com/index/",
         RFC_EDITOR_ERRATA_JSON_URL="https://rfc-editor.example.com/errata/",
     )
-    @mock.patch("ietf.sync.tasks.update_docs_from_rfc_index")
-    @mock.patch("ietf.sync.tasks.parse_index")
+    @mock.patch("ietf.sync.tasks.rfceditor.update_docs_from_rfc_index")
+    @mock.patch("ietf.sync.tasks.rfceditor.parse_index")
     @mock.patch("ietf.sync.tasks.requests.get")
     def test_rfc_editor_index_update_task(
         self, requests_get_mock, parse_index_mock, update_docs_mock

--- a/ietf/sync/views.py
+++ b/ietf/sync/views.py
@@ -98,14 +98,12 @@ def notify(request, org, notification):
         elif notification == "changes":
             log("Queuing IANA changes sync from notify view POST")
             tasks.iana_changes_update_task.delay()
-        else:
+        elif notification == "protocols":
+            log("Queuing IANA protocols sync from notify view POST")
+            tasks.iana_protocols_update_task.delay()
+        elif notification == "queue":
             log("Running sync script from notify view POST")
-    
-            if notification == "protocols":
-                runscript("iana-protocols-updates")
-    
-            if notification == "queue":
-                runscript("rfc-editor-queue-updates")
+            runscript("rfc-editor-queue-updates")
 
         return HttpResponse("OK", content_type="text/plain; charset=%s"%settings.DEFAULT_CHARSET)
 

--- a/ietf/sync/views.py
+++ b/ietf/sync/views.py
@@ -17,6 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from ietf.doc.models import DeletedEvent, StateDocEvent, DocEvent
 from ietf.ietfauth.utils import role_required, has_role
+from ietf.sync import tasks
 from ietf.sync.discrepancies import find_discrepancies
 from ietf.utils.serialize import object_as_shallow_dict
 from ietf.utils.log import log
@@ -91,19 +92,20 @@ def notify(request, org, notification):
                 log("Subprocess error %s when running '%s': %s %s" % (p.returncode, cmd, err, out))
                 raise subprocess.CalledProcessError(p.returncode, cmdstring, "\n".join([err, out]))
 
-        log("Running sync script from notify view POST")
-
-        if notification == "protocols":
-            runscript("iana-protocols-updates")
-
-        if notification == "changes":
-            runscript("iana-changes-updates")
-
-        if notification == "queue":
-            runscript("rfc-editor-queue-updates")
-
         if notification == "index":
-            runscript("rfc-editor-index-updates")
+            log("Queuing RFC Editor index sync from notify view POST")
+            tasks.rfc_editor_index_update_task.delay()
+        elif notification == "changes":
+            log("Queuing IANA changes sync from notify view POST")
+            tasks.iana_changes_updates_task.delay()
+        else:
+            log("Running sync script from notify view POST")
+    
+            if notification == "protocols":
+                runscript("iana-protocols-updates")
+    
+            if notification == "queue":
+                runscript("rfc-editor-queue-updates")
 
         return HttpResponse("OK", content_type="text/plain; charset=%s"%settings.DEFAULT_CHARSET)
 

--- a/ietf/sync/views.py
+++ b/ietf/sync/views.py
@@ -97,7 +97,7 @@ def notify(request, org, notification):
             tasks.rfc_editor_index_update_task.delay()
         elif notification == "changes":
             log("Queuing IANA changes sync from notify view POST")
-            tasks.iana_changes_updates_task.delay()
+            tasks.iana_changes_update_task.delay()
         else:
             log("Running sync script from notify view POST")
     

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -113,6 +113,16 @@ class Command(BaseCommand):
             ),
         )
 
+        PeriodicTask.objects.get_or_create(
+            name="Sync with IANA changes",
+            task="ietf.sync.tasks.iana_changes_update_task",
+            defaults=dict(
+                enabled=False,
+                crontab=self.crontabs["hourly"],
+                description="Fetch change list from IANA and apply to documents",
+            ),
+        )
+
     def show_tasks(self):
         for label, crontab in self.crontabs.items():
             tasks = PeriodicTask.objects.filter(crontab=crontab).order_by(

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -160,6 +160,16 @@ class Command(BaseCommand):
                 description="Update I-D index files",
             ),
         )
+        
+        PeriodicTask.objects.get_or_create(
+            name="Send expiration notifications",
+            task="ietf.doc.tasks.notify_expirations_task",
+            defaults=dict(
+                enabled=False,
+                crontab=self.crontabs["weekly"],
+                description="Send notifications about I-Ds that will expire in the next 14 days",
+            )
+        )
 
     def show_tasks(self):
         for label, crontab in self.crontabs.items():

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -123,6 +123,16 @@ class Command(BaseCommand):
             ),
         )
 
+        PeriodicTask.objects.get_or_create(
+            name="Sync with IANA protocols page",
+            task="ietf.sync.tasks.iana_changes_update_task",
+            defaults=dict(
+                enabled=False,
+                crontab=self.crontabs["hourly"],
+                description="Fetch protocols page from IANA and update document event logs",
+            ),
+        )
+
     def show_tasks(self):
         for label, crontab in self.crontabs.items():
             tasks = PeriodicTask.objects.filter(crontab=crontab).order_by(

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -133,6 +133,16 @@ class Command(BaseCommand):
             ),
         )
 
+        PeriodicTask.objects.get_or_create(
+            name="Update I-D index files",
+            task="ietf.idindex.tasks.idindex_update_task",
+            defaults=dict(
+                enabled=False,
+                crontab=self.crontabs["hourly"],
+                description="Update I-D index files",
+            ),
+        )
+
     def show_tasks(self):
         for label, crontab in self.crontabs.items():
             tasks = PeriodicTask.objects.filter(crontab=crontab).order_by(

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -5,6 +5,14 @@ from django_celery_beat.models import CrontabSchedule, PeriodicTask
 from django.core.management.base import BaseCommand
 
 CRONTAB_DEFS = {
+    # same as "@weekly" in a crontab
+    "weekly": {
+        "minute": "0",
+        "hour": "0",
+        "day_of_week": "0",
+        "day_of_month": "*",
+        "month_of_year": "*",
+    },
     "daily": {
         "minute": "5",
         "hour": "0",

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -9,30 +9,30 @@ CRONTAB_DEFS = {
     "weekly": {
         "minute": "0",
         "hour": "0",
-        "day_of_week": "0",
         "day_of_month": "*",
         "month_of_year": "*",
+        "day_of_week": "0",
     },
     "daily": {
         "minute": "5",
         "hour": "0",
-        "day_of_week": "*",
         "day_of_month": "*",
         "month_of_year": "*",
+        "day_of_week": "*",
     },
     "hourly": {
         "minute": "5",
         "hour": "*",
-        "day_of_week": "*",
         "day_of_month": "*",
         "month_of_year": "*",
+        "day_of_week": "*",
     },
     "every_15m": {
         "minute": "*/15",
         "hour": "*",
-        "day_of_week": "*",
         "day_of_month": "*",
         "month_of_year": "*",
+        "day_of_week": "*",
     },
 }
 

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -114,6 +114,16 @@ class Command(BaseCommand):
         )
 
         PeriodicTask.objects.get_or_create(
+            name="Expire I-Ds",
+            task="ietf.doc.tasks.expire_ids_task",
+            defaults=dict(
+                enabled=False,
+                crontab=self.crontabs["daily"],
+                description="Create expiration notices for expired I-Ds",
+            ),
+        )
+
+        PeriodicTask.objects.get_or_create(
             name="Sync with IANA changes",
             task="ietf.sync.tasks.iana_changes_update_task",
             defaults=dict(

--- a/ietf/utils/management/commands/periodic_tasks.py
+++ b/ietf/utils/management/commands/periodic_tasks.py
@@ -31,6 +31,7 @@ CRONTAB_DEFS = {
 
 class Command(BaseCommand):
     """Manage periodic tasks"""
+    crontabs = None
 
     def add_arguments(self, parser):
         parser.add_argument("--create-default", action="store_true")


### PR DESCRIPTION
This adds celery tasks that implement most of the scripts called by `bin/hourly`, `bin/daily`, etc.

It still remains to do the same for management commands (in addition to tackling `Night-runner` and `Cron-runner`, of course).

Cutting this off here to get feedback on something approaching a reasonable chunk - though probably already a bit big for that purpose.