### PR TITLE
fix: Replace joint session field with instructions

### DIFF
--- a/ietf/secr/templates/includes/sessions_request_form.html
+++ b/ietf/secr/templates/includes/sessions_request_form.html
@@ -103,16 +103,7 @@
                     Joint session with:<br>
                     (To request one session for multiple WGs together.)
                 </td>
-                <td>{{ form.joint_with_groups_selector }}
-                    <button type="button" onclick="ietf_sessions.delete_last_joint_with_groups(); return 1;">Delete the last entry</button><br>
-                    {{ form.joint_with_groups.errors }}{{ form.joint_with_groups }}
-                </td>
-            </tr>
-            <tr class="bg1">
-                <td>
-                    Of the sessions requested by this WG, the joint session, if applicable, is:
-                </td>
-                <td>{{ form.joint_for_session.errors }}{{ form.joint_for_session }}</td>
+                <td>To request a joint session with another group, please contact the secretariat.</td>
             </tr>
 
         {% endif %}


### PR DESCRIPTION
To avoid further issues like #6996 and #4080, this eliminates the "joint_with_groups" UI from the sreq view. This is superficial only - the broken plumbing is still in place. That could go away, but will require cleaning up a lot of tests, so I'm inclined to leave it to be part of #6146.