### PR TITLE
feat: API to retrieve active email addrs

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -858,10 +858,16 @@ class CustomApiTests(TestCase):
         EmailFactory(active=True)  # make sure there's at least one active email...
         EmailFactory(active=False)  # ... and at least one non-active emai
         url = urlreverse("ietf.api.views.active_email_list")
+        r = self.client.post(url, headers={})
+        self.assertEqual(r.status_code, 403)
         r = self.client.get(url, headers={})
         self.assertEqual(r.status_code, 403)
         r = self.client.get(url, headers={"X-Api-Key": "not-the-valid-token"})
         self.assertEqual(r.status_code, 403)
+        r = self.client.post(url, headers={"X-Api-Key": "not-the-valid-token"})
+        self.assertEqual(r.status_code, 403)
+        r = self.client.post(url, headers={"X-Api-Key": "valid-token"})
+        self.assertEqual(r.status_code, 405)
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers["Content-Type"], "application/json")

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -936,7 +936,6 @@ class DirectAuthApiTests(TestCase):
         self.assertEqual(data["reason"], "invalid post")       
 
     def test_notokenstore(self):
-        debug.show("settings.APP_API_TOKENS")
         self.assertFalse(hasattr(settings, "APP_API_TOKENS"))
         r = self.client.post(self.url,self.valid_body_with_good_password)
         self.assertEqual(r.status_code, 200)

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -49,6 +49,8 @@ urlpatterns = [
     # OpenID authentication provider
     url(r'^openid/$', TemplateView.as_view(template_name='api/openid-issuer.html'), name='ietf.api.urls.oidc_issuer'),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
+    # Email alias listing
+    url(r'^person/email/$', api_views.active_email_list),
     # Draft submission API
     url(r'^submit/?$', submit_views.api_submit),
     # Draft upload API

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -499,3 +499,4 @@ def active_email_list(request):
                 "addresses": list(Email.objects.filter(active=True).values_list("address", flat=True)),
             }
         )
+    return HttpResponse(status=405)

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -488,3 +488,14 @@ def group_aliases(request):
             }
         )
     return HttpResponse(status=405)
+
+
+@requires_api_token
+@csrf_exempt
+def active_email_list(request):
+    if request.method == "GET":
+        return JsonResponse(
+            {
+                "addresses": list(Email.objects.filter(active=True).values_list("address", flat=True)),
+            }
+        )


### PR DESCRIPTION
Likely to be needed when `make_global_whitelist` is refactored to decouple mailman and datatracker