### PR TITLE
feat: Group admin form accepts acronyms starting with numbers for SDO groups

### DIFF
--- a/ietf/group/admin.py
+++ b/ietf/group/admin.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2010-2020, All Rights Reserved
+# Copyright The IETF Trust 2010-2024, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 import re
@@ -71,6 +71,12 @@ class GroupForm(forms.ModelForm):
                 error_msg = (
                     'Acronym is invalid. For groups that create documents, the acronym must be at least '
                     'two characters and only contain lowercase letters and numbers starting with a letter.'
+                )
+            elif self.cleaned_data['type'].pk == 'sdo':
+                valid_re = r'^[a-z0-9-]+[a-z0-9]$'
+                error_msg = (
+                    'Acronym is invalid. It must be at least two characters and only contain lowercase '
+                    'letters and numbers. It may contain hyphens, but that is discouraged.'
                 )
             else:
                 valid_re = r'^[a-z][a-z0-9-]*[a-z0-9]$'

--- a/ietf/group/admin.py
+++ b/ietf/group/admin.py
@@ -73,7 +73,7 @@ class GroupForm(forms.ModelForm):
                     'two characters and only contain lowercase letters and numbers starting with a letter.'
                 )
             elif self.cleaned_data['type'].pk == 'sdo':
-                valid_re = r'^[a-z0-9-]+[a-z0-9]$'
+                valid_re = r'^[a-z0-9][a-z0-9-]*[a-z0-9]$'
                 error_msg = (
                     'Acronym is invalid. It must be at least two characters and only contain lowercase '
                     'letters and numbers. It may contain hyphens, but that is discouraged.'

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -2042,9 +2042,9 @@ class AcronymValidationTests(TestCase):
         # For the ITU we have a hierarchy of group names that use hyphens as delimiters
         form = AdminGroupForm({'acronym':'should-pass','name':'should pass','type':'sdo','state':'active','used_roles':'[]','time':now})
         self.assertTrue(form.is_valid())
-        form = AdminGroupForm({'acronym':'shouldfail-','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
+        form = AdminGroupForm({'acronym':'shouldfail-','name':'should fail','type':'sdo','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)
-        form = AdminGroupForm({'acronym':'-shouldfail','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
+        form = AdminGroupForm({'acronym':'-shouldfail','name':'should fail','type':'sdo','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)
         # SDO groups (and only SDO groups) can have a leading number
         form = AdminGroupForm({'acronym':'3gpp-should-pass','name':'should pass','type':'sdo','state':'active','used_roles':'[]','time':now})

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -2042,7 +2042,11 @@ class AcronymValidationTests(TestCase):
         # For the ITU we have a hierarchy of group names that use hyphens as delimiters
         form = AdminGroupForm({'acronym':'should-pass','name':'should pass','type':'sdo','state':'active','used_roles':'[]','time':now})
         self.assertTrue(form.is_valid())
+        form = AdminGroupForm({'acronym':'shouldfail-','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
+        self.assertIn('acronym',form.errors)
         form = AdminGroupForm({'acronym':'shouldfail-','name':'should fail','type':'sdo','state':'active','used_roles':'[]','time':now})
+        self.assertIn('acronym',form.errors)
+        form = AdminGroupForm({'acronym':'-shouldfail','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)
         form = AdminGroupForm({'acronym':'-shouldfail','name':'should fail','type':'sdo','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2009-2023, All Rights Reserved
+# Copyright The IETF Trust 2009-2024, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 
@@ -2045,6 +2045,11 @@ class AcronymValidationTests(TestCase):
         form = AdminGroupForm({'acronym':'shouldfail-','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)
         form = AdminGroupForm({'acronym':'-shouldfail','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
+        self.assertIn('acronym',form.errors)
+        # SDO groups (and only SDO groups) can have a leading number
+        form = AdminGroupForm({'acronym':'3gpp-should-pass','name':'should pass','type':'sdo','state':'active','used_roles':'[]','time':now})
+        self.assertTrue(form.is_valid())
+        form = AdminGroupForm({'acronym':'123shouldfail','name':'should fail','type':'wg','state':'active','used_roles':'[]','time':now})
         self.assertIn('acronym',form.errors)
 
         wg = GroupFactory(acronym='bad-idea', type_id='wg') # There are some existing wg and programs with hyphens in their acronyms.


### PR DESCRIPTION
Fixes #6825