### PR TITLE
fix: Accept&ignore group_type for some views

### DIFF
--- a/ietf/community/views.py
+++ b/ietf/community/views.py
@@ -24,6 +24,7 @@ from ietf.group.models import Group
 from ietf.doc.models import DocEvent, Document
 from ietf.doc.utils_search import prepare_document_table
 from ietf.person.utils import lookup_persons
+from ietf.utils.decorators import ignore_view_kwargs
 from ietf.utils.http import is_ajax
 from ietf.utils.response import permission_denied
 
@@ -70,6 +71,7 @@ def view_list(request, email_or_name=None):
     })
 
 @login_required
+@ignore_view_kwargs("group_type")
 def manage_list(request, email_or_name=None, acronym=None):
     # we need to be a bit careful because clist may not exist in the
     # database so we can't call related stuff on it yet
@@ -209,6 +211,7 @@ def untrack_document(request, name, email_or_name=None, acronym=None):
     })
 
 
+@ignore_view_kwargs("group_type")
 def export_to_csv(request, email_or_name=None, acronym=None):
     try:
         clist = lookup_community_list(request, email_or_name, acronym)
@@ -253,6 +256,7 @@ def export_to_csv(request, email_or_name=None, acronym=None):
 
     return response
 
+@ignore_view_kwargs("group_type")
 def feed(request, email_or_name=None, acronym=None):
     try:
         clist = lookup_community_list(request, email_or_name, acronym)
@@ -292,6 +296,7 @@ def feed(request, email_or_name=None, acronym=None):
 
 
 @login_required
+@ignore_view_kwargs("group_type")
 def subscription(request, email_or_name=None, acronym=None):
     try:
         clist = lookup_community_list(request, email_or_name, acronym)

--- a/ietf/doc/views_material.py
+++ b/ietf/doc/views_material.py
@@ -21,9 +21,11 @@ from ietf.doc.models import NewRevisionDocEvent
 from ietf.doc.utils import add_state_change_event, check_common_doc_name_rules
 from ietf.group.models import Group
 from ietf.group.utils import can_manage_materials
+from ietf.utils.decorators import ignore_view_kwargs
 from ietf.utils.response import permission_denied
 
 @login_required
+@ignore_view_kwargs("group_type")
 def choose_material_type(request, acronym):
     group = get_object_or_404(Group, acronym=acronym)
     if not group.features.has_nonsession_materials:
@@ -91,6 +93,7 @@ class UploadMaterialForm(forms.Form):
         return name
 
 @login_required
+@ignore_view_kwargs("group_type")
 def edit_material(request, name=None, acronym=None, action=None, doc_type=None):
     # the materials process is not very developed, so at the moment we
     # handle everything through the same view/form

--- a/ietf/group/milestones.py
+++ b/ietf/group/milestones.py
@@ -399,7 +399,7 @@ def edit_milestones(request, acronym, group_type=None, milestone_set="current"):
                        can_change_uses_milestone_dates=can_change_uses_milestone_dates))
 
 @login_required
-def reset_charter_milestones(request, group_type, acronym):
+def reset_charter_milestones(request, acronym, group_type=None):
     """Reset charter milestones to the currently in-use milestones."""
     group = get_group_or_404(acronym, group_type)
     if not group.features.has_milestones:

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -116,6 +116,7 @@ from ietf.dbtemplate.models import DBTemplate
 from ietf.mailtrigger.utils import gather_address_lists
 from ietf.mailtrigger.models import Recipient
 from ietf.settings import MAILING_LIST_INFO_URL
+from ietf.utils.decorators import ignore_view_kwargs
 from ietf.utils.response import permission_denied
 from ietf.utils.text import strip_suffix
 from ietf.utils import markdown
@@ -2158,7 +2159,8 @@ def appeals(request, acronym, group_type=None):
         ),
     )
 
-def appeal_artifact(request, acronym, artifact_id, group_type=None):
+@ignore_view_kwargs("group_type")
+def appeal_artifact(request, acronym, artifact_id):
     artifact = get_object_or_404(AppealArtifact, pk=artifact_id)
     if artifact.is_markdown():
         artifact_html = markdown.markdown(artifact.bits.tobytes().decode("utf-8"))
@@ -2177,7 +2179,8 @@ def appeal_artifact(request, acronym, artifact_id, group_type=None):
         )
     
 @role_required("Secretariat")
-def appeal_artifact_markdown(request, acronym, artifact_id, group_type=None):
+@ignore_view_kwargs("group_type")
+def appeal_artifact_markdown(request, acronym, artifact_id):
     artifact = get_object_or_404(AppealArtifact, pk=artifact_id)
     if artifact.is_markdown():
         return HttpResponse(artifact.bits, content_type=artifact.content_type)

--- a/ietf/utils/decorators.py
+++ b/ietf/utils/decorators.py
@@ -114,3 +114,30 @@ def memoize(func):
     # we cannot set up the cache here.
     return decorate(func, _memoize)
 
+
+def ignore_view_kwargs(*args):
+    """Ignore the specified kwargs if they are present
+
+    Usage: 
+      @ignore_view_kwargs("ignore_arg1", "ignore_arg2")
+      def my_view(request, good_arg, ignore_arg1, ignore_arg2):
+        ...
+
+      This will allow my_view() to be used in url() paths that have zero, one, or both of
+      ignore_arg1 and ignore_arg2 captured. These will be ignored, while good_arg will still
+      be captured as usual.
+    """
+    kwargs_to_ignore = args
+
+    def decorate(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            for kwarg in kwargs_to_ignore:
+                kwargs.pop(kwarg, None)
+            return view(*args, **kwargs)
+
+        return wrapped
+
+    return decorate
+
+


### PR DESCRIPTION
Fixes #7050 

This adds a decorator that wraps a Django view and causes the view to ignore one or more kwargs if they are present when the view is called with a request. This is applied to views in the `ietf.group.urls.info_detail_urls` that do not already accept `group_type` so that they won't fail when accessed by way of `ietf.group.urls.grouptype_urls`.

A couple of views that accepted and ignored `group_type` have been refactored to use the decorator as a hint that they're not intended to use the parameter.

One view, `ietf.group.milestones.reset_charter_milestones`, has had its signature changed to allow it to work without the `group_type` parameter. It already guards against the case that its group does not use charter milestones, so this tweak should allow it to work from a `/group/xyz` url rather than only a `/wg/xyz` url when it makes sense.