### PR TITLE
feat: Give better errors when docName is missing

### DIFF
--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -127,6 +127,8 @@ class XMLDraft(Draft):
 
     def _parse_docname(self):
         docname = self.xmlroot.attrib.get('docName')
+        if docname is None:
+            raise ValueError("Missing docName attribute in the XML root element")
         revmatch = re.match(
             r'^(?P<filename>.+?)(?:-(?P<rev>[0-9][0-9]))?$',
             docname,

--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -29,7 +29,7 @@ class XMLDraft(Draft):
         # cast xml_file to str so, e.g., this will work with a Path
         self.xmltree, self.xml_version = self.parse_xml(str(xml_file))
         self.xmlroot = self.xmltree.getroot()
-        self.filename, self.revision = self._parse_docname()
+        self.filename, self.revision = self.parse_docname(self.xmlroot)
 
     @staticmethod
     def parse_xml(filename):
@@ -125,8 +125,9 @@ class XMLDraft(Draft):
             section_name = section_elt.get('title')  # fall back to title if we have it
         return section_name
 
-    def _parse_docname(self):
-        docname = self.xmlroot.attrib.get('docName')
+    @staticmethod
+    def parse_docname(xmlroot):
+        docname = xmlroot.attrib.get('docName')
         if docname is None:
             raise ValueError("Missing docName attribute in the XML root element")
         revmatch = re.match(


### PR DESCRIPTION
Fixes #7079 

It's very hard not to tear some of the existing behavior out (see comments in the new test) but I'm resisting that urge.

We _might_ see failures in `rebuild_reference_relations()` related to this change if any of the XML files it comes across are missing the `docName` attribute, but that shouldn't happen and will be easy to fix if/when we run that again.