### PR TITLE
feat: Notify Meetecho via API on slides changes

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -92,6 +92,7 @@ from ietf.stats.models import MeetingRegistration
 from ietf.utils import markdown
 from ietf.utils.decorators import require_api_key
 from ietf.utils.hedgedoc import Note, NoteError
+from ietf.utils.meetecho import SlidesManager
 from ietf.utils.log import assertion
 from ietf.utils.mail import send_mail_message, send_mail_text
 from ietf.utils.mime import get_mime_type
@@ -3153,6 +3154,11 @@ def ajax_reorder_slides_in_session(request, session_id, num):
         session_slides.filter(order__gte=newIndex, order__lt=oldIndex).update(order=F('order')+1)
     sp.order = newIndex
     sp.save()
+
+    # Update slide order with Meetecho if the API is configured
+    if hasattr(settings, "MEETECHO_API_CONFIG"):
+        mgr = SlidesManager(api_config=settings.MEETECHO_API_CONFIG)
+        mgr.send_update(session)
 
     return HttpResponse(json.dumps({'success':True}), content_type='application/json')
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1694,48 +1694,58 @@ def api_get_agenda_data (request, num=None):
         "floors": list(map(agenda_extract_floorplan, floors))
     })
 
-def api_get_session_materials (request, session_id=None):
-    session = get_object_or_404(Session,pk=session_id)
+
+def api_get_session_materials(request, session_id=None):
+    session = get_object_or_404(Session, pk=session_id)
 
     minutes = session.minutes()
     slides_actions = []
     if can_manage_session_materials(request.user, session.group, session):
-        slides_actions.append({
-            'label': 'Upload slides',
-            'url': reverse(
-                'ietf.meeting.views.upload_session_slides',
-                kwargs={'num': session.meeting.number, 'session_id': session.pk},
-            ),
-        })
+        slides_actions.append(
+            {
+                "label": "Upload slides",
+                "url": reverse(
+                    "ietf.meeting.views.upload_session_slides",
+                    kwargs={"num": session.meeting.number, "session_id": session.pk},
+                ),
+            }
+        )
     elif not session.is_material_submission_cutoff():
-        slides_actions.append({
-            'label': 'Propose slides',
-            'url': reverse(
-                'ietf.meeting.views.propose_session_slides',
-                kwargs={'num': session.meeting.number, 'session_id': session.pk},
-            ),
-        })
+        slides_actions.append(
+            {
+                "label": "Propose slides",
+                "url": reverse(
+                    "ietf.meeting.views.propose_session_slides",
+                    kwargs={"num": session.meeting.number, "session_id": session.pk},
+                ),
+            }
+        )
     else:
         pass  # no action available if it's past cutoff
-    
-    agenda = session.agenda() 
+
+    agenda = session.agenda()
     agenda_url = agenda.get_href() if agenda is not None else None
-    return JsonResponse({
-        "url": agenda_url,
-        "slides": {
-            "decks": [
-                agenda_extract_slide(slide) | {"order": order}  # add "order" field
-                for order, slide in enumerate(session.slides())
-            ],
-            "actions": slides_actions,
-        },
-        "minutes": {
-            "id": minutes.id,
-            "title": minutes.title,
-            "url": minutes.get_href(),
-            "ext": minutes.file_extension()
-        } if minutes is not None else None
-    })
+    return JsonResponse(
+        {
+            "url": agenda_url,
+            "slides": {
+                "decks": [
+                    agenda_extract_slide(slide) | {"order": order}  # add "order" field
+                    for order, slide in enumerate(session.slides())
+                ],
+                "actions": slides_actions,
+            },
+            "minutes": {
+                "id": minutes.id,
+                "title": minutes.title,
+                "url": minutes.get_href(),
+                "ext": minutes.file_extension(),
+            }
+            if minutes is not None
+            else None,
+        }
+    )
+
 
 def agenda_extract_schedule (item):
     return {
@@ -1758,9 +1768,9 @@ def agenda_extract_schedule (item):
         "filterKeywords": item.filter_keywords,
         "groupAcronym": item.session.group_at_the_time().acronym,
         "groupName": item.session.group_at_the_time().name,
-        "groupParent": {
+        "groupParent": ({
             "acronym": item.session.group_parent_at_the_time().acronym
-        } if item.session.group_parent_at_the_time() else {},
+        } if item.session.group_parent_at_the_time() else {}),
         "note": item.session.agenda_note,
         "remoteInstructions": item.session.remote_instructions,
         "flags": {
@@ -1793,7 +1803,8 @@ def agenda_extract_schedule (item):
         # }
     }
 
-def agenda_extract_floorplan (item):
+
+def agenda_extract_floorplan(item):
     try:
         item.image.width
     except FileNotFoundError:
@@ -1806,10 +1817,11 @@ def agenda_extract_floorplan (item):
         "short": item.short,
         "width": item.image.width,
         "height": item.image.height,
-        "rooms": list(map(agenda_extract_room, item.room_set.all()))
+        "rooms": list(map(agenda_extract_room, item.room_set.all())),
     }
 
-def agenda_extract_room (item):
+
+def agenda_extract_room(item):
     return {
         "id": item.id,
         "name": item.name,
@@ -1821,7 +1833,8 @@ def agenda_extract_room (item):
         "bottom": item.bottom()
     }
 
-def agenda_extract_recording (item):
+
+def agenda_extract_recording(item):
     return {
         "id": item.id,
         "name": item.name,
@@ -1829,7 +1842,8 @@ def agenda_extract_recording (item):
         "url": item.external_url
     }
 
-def agenda_extract_slide (item):
+
+def agenda_extract_slide(item):
     return {
         "id": item.id,
         "title": item.title,
@@ -1837,6 +1851,7 @@ def agenda_extract_slide (item):
         "url": item.get_versionless_href(),
         "ext": item.file_extension(),
     }
+
 
 def agenda_csv(schedule, filtered_assignments, utc=False):
     encoding = 'utf-8'

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1723,7 +1723,10 @@ def api_get_session_materials (request, session_id=None):
     return JsonResponse({
         "url": agenda_url,
         "slides": {
-            "decks": list(map(agenda_extract_slide, session.slides())),
+            "decks": [
+                agenda_extract_slide(slide) | {"order": order}  # add "order" field
+                for order, slide in enumerate(session.slides())
+            ],
             "actions": slides_actions,
         },
         "minutes": {
@@ -1830,8 +1833,9 @@ def agenda_extract_slide (item):
     return {
         "id": item.id,
         "title": item.title,
+        "rev": item.rev,
         "url": item.get_versionless_href(),
-        "ext": item.file_extension()
+        "ext": item.file_extension(),
     }
 
 def agenda_csv(schedule, filtered_assignments, utc=False):

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3073,6 +3073,11 @@ def ajax_add_slides_to_session(request, session_id, num):
         session.presentations.create(document=doc,rev=doc.rev,order=order)
         DocEvent.objects.create(type="added_comment", doc=doc, rev=doc.rev, by=request.user.person, desc="Added to session: %s" % session)
 
+        # Notify Meetecho of new slides if the API is configured
+        if hasattr(settings, "MEETECHO_API_CONFIG"):
+            sm = SlidesManager(api_config=settings.MEETECHO_API_CONFIG)
+            sm.add(session=session, slides=doc, order=order)
+
     return HttpResponse(json.dumps({'success':True}), content_type='application/json')
 
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3124,7 +3124,8 @@ def ajax_reorder_slides_in_session(request, session_id, num):
     if request.method != 'POST' or not request.POST:
         return HttpResponse(json.dumps({ 'success' : False, 'error' : 'No data submitted or not POST' }),content_type='application/json')  
 
-    num_slides_in_session = session.presentations.filter(document__type_id='slides').count()
+    session_slides = session.presentations.filter(document__type_id="slides")
+    num_slides_in_session = session_slides.count()
     oldIndex_str = request.POST.get('oldIndex', None)
     try:
         oldIndex = int(oldIndex_str)
@@ -3145,11 +3146,11 @@ def ajax_reorder_slides_in_session(request, session_id, num):
         return HttpResponse(json.dumps({ 'success' : False, 'error' : 'Supplied index is not valid' }),content_type='application/json')
 
     condition_slide_order(session)
-    sp = session.presentations.get(order=oldIndex)
+    sp = session_slides.get(order=oldIndex)
     if oldIndex < newIndex:
-        session.presentations.filter(order__gt=oldIndex, order__lte=newIndex).update(order=F('order')-1)
+        session_slides.filter(order__gt=oldIndex, order__lte=newIndex).update(order=F('order')-1)
     else:
-        session.presentations.filter(order__gte=newIndex, order__lt=oldIndex).update(order=F('order')+1)
+        session_slides.filter(order__gte=newIndex, order__lt=oldIndex).update(order=F('order')+1)
     sp.order = newIndex
     sp.save()
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1172,6 +1172,7 @@ CELERY_TASK_IGNORE_RESULT = True  # ignore results unless specifically enabled f
 #     'api_base': 'https://meetings.conf.meetecho.com/api/v1/',
 #     'client_id': 'datatracker',
 #     'client_secret': 'some secret',
+#     'materials_repository": 'value from meetecho',
 #     'request_timeout': 3.01,  # python-requests doc recommend slightly > a multiple of 3 seconds
 # }
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1172,7 +1172,6 @@ CELERY_TASK_IGNORE_RESULT = True  # ignore results unless specifically enabled f
 #     'api_base': 'https://meetings.conf.meetecho.com/api/v1/',
 #     'client_id': 'datatracker',
 #     'client_secret': 'some secret',
-#     'materials_repository": 'value from meetecho',
 #     'request_timeout': 3.01,  # python-requests doc recommend slightly > a multiple of 3 seconds
 # }
 

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -191,6 +191,10 @@ class MeetechoAPI:
             "POST", "meeting/interim/deleteRoom", api_token=deletion_token
         )
 
+    def send_session_update_notification(self, session_id):
+        debug.say(f"Sent update for Session {session_id}")
+        return None
+
 
 class MeetechoAPIError(Exception):
     """Base class for MeetechoAPI exceptions"""

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -1,9 +1,10 @@
-# Copyright The IETF Trust 2021, All Rights Reserved
+# Copyright The IETF Trust 2021-2024, All Rights Reserved
 #
 """Meetecho interim meeting scheduling API
 
 Implements the v1 API described in email from alex@meetecho.com
-on 2021-12-09.
+on 2021-12-09, plus additional slide management API discussed via
+IM in 2024 Feb.
 
 API methods return Python objects equivalent to the JSON structures
 specified in the API documentation. Times and durations are represented

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -276,6 +276,36 @@ class MeetechoAPI:
         session: str,  # unique id
         decks: list[SlideDeckDict],
     ):
+        """Update/reorder decks for specified session
+
+        PUT /materials
+        + Authentication -> same as interim scheduler
+        + content application/json
+        + body
+            {
+                "session": String,
+                "decks": [
+                    {
+                        "id": Number,
+                        "title": String,
+                        "url": String,
+                        "rev": String,
+                        "order": Number
+                    },
+                    {
+                        "id": Number,
+                        "title": String,
+                        "url": String,
+                        "rev": String,
+                        "order": Number
+                    },
+                    ...
+                ]
+            }
+         
+        + Results 
+            202 Accepted
+        """
         self._request(
             "PUT",
             "materials",

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -48,7 +48,8 @@ class MeetechoAPI:
             )
         except requests.RequestException as err:
             raise MeetechoAPIError(str(err)) from err
-        if response.status_code != 200:
+        if response.status_code not in (200, 202):
+            # Could be more selective about status codes, but not seeing an immediate need
             raise MeetechoAPIError(
                 f"API request failed (HTTP status code = {response.status_code})"
             )
@@ -57,7 +58,7 @@ class MeetechoAPI:
         try:
             return response.json()
         except JSONDecodeError as err:
-            if response.headers["Content-Type"].startswith("application/json"):
+            if response.headers.get("Content-Type", "").startswith("application/json"):
                 # complain if server told us to expect JSON and it was invalid
                 raise MeetechoAPIError("Error decoding response as JSON") from err
         return None

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -451,6 +451,13 @@ class SlidesManager(Manager):
             }
         )
 
+    def delete(self, session: "Session", slides: "Document"):
+        self.api.delete_slide_deck(
+            wg_token=self.wg_token(session.group),
+            session=str(session.pk),
+            id=slides.pk,
+        )
+    
     def send_update(self, session: "Session"):
         self.api.update_slide_decks(
             wg_token=self.wg_token(session.group),

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -244,6 +244,22 @@ class MeetechoAPI:
         session: str, # unique identifier
         id: int, 
     ):
+        """Delete a slide deck from the specified session
+
+        API spec:
+        DELETE /materials
+        + Authentication -> same as interim scheduler
+        + content application/json
+        + body
+            {
+                "session": String,
+                "id": Number
+            }
+         
+        + Results 
+            202 Accepted
+            {4xx}
+        """
         self._request(
             "DELETE",
             "materials",

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -15,13 +15,12 @@ import debug  # pyflakes: ignore
 
 from datetime import datetime, timedelta
 from json import JSONDecodeError
-from pytz import utc
 from typing import Dict, Sequence, TypedDict, Union
 from urllib.parse import urljoin
 
 
 class MeetechoAPI:
-    timezone = utc
+    timezone = datetime.timezone.utc
 
     def __init__(
         self, api_base: str, client_id: str, client_secret: str, material_repository: str, request_timeout=3.01

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -212,7 +212,6 @@ class MeetechoAPI:
         + content application/json
         + body
             {
-                "repository": String, // a constant value that identifies the repository on Meetecho side
                 "session": String, // Unique session identifier
                 "title": String,
                 "id": Number,
@@ -229,7 +228,6 @@ class MeetechoAPI:
             "POST",
             "materials",
             json={
-                "repository": self.materials_repository,
                 "session": session,
                 "title": deck["title"],
                 "id": deck["id"],
@@ -249,7 +247,6 @@ class MeetechoAPI:
             "DELETE",
             "materials",
             json={
-                "repository": self.materials_repository,
                 "session": session,
                 "id": id,
             },
@@ -265,7 +262,6 @@ class MeetechoAPI:
             "PUT",
             "materials",
             json={
-                "repository": self.materials_repository,
                 "session": session,
                 "decks": decks,
             }

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -439,12 +439,12 @@ class SlidesManager(Manager):
             session=str(session.pk),
             decks=[
                 {
-                    "id": deck.pk,
-                    "title": deck.title,
-                    "url": deck.get_absolute_url(),
-                    "rev": deck.rev,
+                    "id": deck.document.pk,
+                    "title": deck.document.title,
+                    "url": deck.document.get_absolute_url(),
+                    "rev": deck.document.rev,
                     "order": deck.order,
                 }
-                for deck in session.presentations.all(type="slides")
+                for deck in session.presentations.filter(document__type="slides")
             ]
         )

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -13,7 +13,7 @@ import requests
 
 import debug  # pyflakes: ignore
 
-from datetime import datetime, timedelta
+import datetime
 from json import JSONDecodeError
 from typing import Dict, Sequence, TypedDict, Union
 from urllib.parse import urljoin
@@ -62,16 +62,16 @@ class MeetechoAPI:
                 raise MeetechoAPIError("Error decoding response as JSON") from err
         return None
 
-    def _deserialize_time(self, s: str) -> datetime:
-        return self.timezone.localize(datetime.strptime(s, "%Y-%m-%d %H:%M:%S"))
+    def _deserialize_time(self, s: str) -> datetime.datetime:
+        return datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S").replace(tzinfo=self.timezone)
 
-    def _serialize_time(self, dt: datetime) -> str:
+    def _serialize_time(self, dt: datetime.datetime) -> str:
         return dt.astimezone(self.timezone).strftime("%Y-%m-%d %H:%M:%S")
 
-    def _deserialize_duration(self, minutes: int) -> timedelta:
-        return timedelta(minutes=minutes)
+    def _deserialize_duration(self, minutes: int) -> datetime.timedelta:
+        return datetime.timedelta(minutes=minutes)
 
-    def _serialize_duration(self, td: timedelta) -> int:
+    def _serialize_duration(self, td: datetime.timedelta) -> int:
         return int(td.total_seconds() // 60)
 
     def _deserialize_meetings_response(self, response):
@@ -108,8 +108,8 @@ class MeetechoAPI:
         self,
         wg_token: str,
         description: str,
-        start_time: datetime,
-        duration: timedelta,
+        start_time: datetime.datetime,
+        duration: datetime.timedelta,
         extrainfo="",
     ):
         """Schedule a meeting session

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -23,12 +23,11 @@ class MeetechoAPI:
     timezone = datetime.timezone.utc
 
     def __init__(
-        self, api_base: str, client_id: str, client_secret: str, material_repository: str, request_timeout=3.01
+        self, api_base: str, client_id: str, client_secret: str, request_timeout=3.01
     ):
         self.client_id = client_id
         self.client_secret = client_secret
         self.request_timeout = request_timeout  # python-requests doc recommend slightly > a multiple of 3 seconds
-        self.materials_repository = material_repository
         self._session = requests.Session()
         # if needed, add a trailing slash so urljoin won't eat the trailing path component
         self.api_base = api_base if api_base.endswith("/") else f"{api_base}/"

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -445,6 +445,6 @@ class SlidesManager(Manager):
                     "rev": deck.rev,
                     "order": deck.order,
                 }
-                for deck in session.sessionpresentation_set.all(type="slides")
+                for deck in session.presentations.all(type="slides")
             ]
         )

--- a/ietf/utils/tests_meetecho.py
+++ b/ietf/utils/tests_meetecho.py
@@ -299,6 +299,66 @@ class APITests(TestCase):
             "Incorrect request content"
         )
 
+    def test_update_slide_decks(self):
+        self.requests_mock.put(self.slide_deck_url, status_code=202)
+
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.update_slide_decks(
+            wg_token="my-token",
+            session="1234",
+            decks=[
+                {
+                    "title": "A Slide Deck",
+                    "id": 17,
+                    "url": "https://example.com/decks/17",
+                    "rev": "00",
+                    "order": 0,
+                },
+                {
+                    "title": "Another Slide Deck",
+                    "id": 23,
+                    "url": "https://example.com/decks/23",
+                    "rev": "03",
+                    "order": 1,
+                }
+            ]
+        )
+        self.assertIsNone(api_response)  # no return value from this call
+
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertIn("Authorization", request.headers)
+        self.assertEqual(
+            request.headers["Content-Type"],
+            "application/json",
+            "Incorrect request content-type",
+        )
+        self.assertEqual(request.headers["Authorization"], "bearer my-token",
+                         "Incorrect request authorization header")
+        self.assertEqual(
+            request.json(),
+            {
+                "session": "1234",
+                "decks": [
+                    {
+                        "title": "A Slide Deck",
+                        "id": 17,
+                        "url": "https://example.com/decks/17",
+                        "rev": "00",
+                        "order": 0,
+                    },
+                    {
+                        "title": "Another Slide Deck",
+                        "id": 23,
+                        "url": "https://example.com/decks/23",
+                        "rev": "03",
+                        "order": 1,
+                    },
+                ],
+            },
+            "Incorrect request content"
+        )
+
     def test_request_helper_failed_requests(self):
         self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'unauthorized/url/endpoint'), status_code=401)
         self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'forbidden/url/endpoint'), status_code=403)

--- a/ietf/utils/tests_meetecho.py
+++ b/ietf/utils/tests_meetecho.py
@@ -229,6 +229,47 @@ class APITests(TestCase):
         self.assertIsNone(request.body, 'Delete meeting request has no body')
         self.assertCountEqual(api_response, data_to_fetch)
 
+    def test_add_slide_deck(self):
+        self.requests_mock.post(self.slide_deck_url, status_code=202)
+        
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.add_slide_deck(
+            wg_token="my-token",
+            session="1234",
+            deck={
+                "title": "A Slide Deck",
+                "id": 17,
+                "url": "https://example.com/decks/17",
+                "rev": "00",
+                "order": 0,
+            }
+        )
+        self.assertIsNone(api_response)  # no return value from this call
+
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertIn("Authorization", request.headers)
+        self.assertEqual(
+            request.headers["Content-Type"],
+            "application/json",
+            "Incorrect request content-type",
+        )
+        self.assertEqual(request.headers["Authorization"], "bearer my-token",
+                         "Incorrect request authorization header")
+        self.assertEqual(
+            request.json(),
+            {
+                "session": "1234",
+                "title": "A Slide Deck",
+                "id": 17,
+                "url": "https://example.com/decks/17",
+                "rev": "00",
+                "order": 0,
+            },
+            "Incorrect request content"
+        )
+
+
     def test_request_helper_failed_requests(self):
         self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'unauthorized/url/endpoint'), status_code=401)
         self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'forbidden/url/endpoint'), status_code=403)

--- a/ietf/utils/tests_meetecho.py
+++ b/ietf/utils/tests_meetecho.py
@@ -269,6 +269,35 @@ class APITests(TestCase):
             "Incorrect request content"
         )
 
+    def test_delete_slide_deck(self):
+        self.requests_mock.delete(self.slide_deck_url, status_code=202)
+
+        api = MeetechoAPI(API_BASE, CLIENT_ID, CLIENT_SECRET)
+        api_response = api.delete_slide_deck(
+            wg_token="my-token",
+            session="1234",
+            id=17,
+        )
+        self.assertIsNone(api_response)  # no return value from this call
+
+        self.assertTrue(self.requests_mock.called)
+        request = self.requests_mock.last_request
+        self.assertIn("Authorization", request.headers)
+        self.assertEqual(
+            request.headers["Content-Type"],
+            "application/json",
+            "Incorrect request content-type",
+        )
+        self.assertEqual(request.headers["Authorization"], "bearer my-token",
+                         "Incorrect request authorization header")
+        self.assertEqual(
+            request.json(),
+            {
+                "session": "1234",
+                "id": 17,
+            },
+            "Incorrect request content"
+        )
 
     def test_request_helper_failed_requests(self):
         self.requests_mock.register_uri(requests_mock.ANY, urljoin(API_BASE, 'unauthorized/url/endpoint'), status_code=401)


### PR DESCRIPTION
This adds API support and makes calls when session slides are modified using the ajax-driven interactive interface. Have not addressed other places where slides might be changed.