### PR TITLE
fix: Avoid validation crash when title parsing fails

### DIFF
--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -1371,6 +1371,7 @@ def process_and_accept_uploaded_submission(submission):
     try:
         process_and_validate_submission(submission)
     except SubmissionError as err:
+        submission.refresh_from_db()  # guard against incomplete changes in submission validation / processing
         cancel_submission(submission)  # changes Submission.state
         create_submission_event(None, submission, f"Submission rejected: {err}")
         return
@@ -1410,11 +1411,13 @@ def process_uploaded_submission(submission):
     try:
         process_and_validate_submission(submission)
     except InconsistentRevisionError as consistency_error:
+        submission.refresh_from_db()  # guard against incomplete changes in submission validation / processing
         submission.state_id = "manual"
         submission.save()
         create_submission_event(None, submission, desc="Uploaded submission (diverted to manual process)")
         send_manual_post_request(None, submission, errors=dict(consistency=str(consistency_error)))
     except SubmissionError as err:
+        submission.refresh_from_db()  # guard against incomplete changes in submission validation / processing
         cancel_submission(submission)  # changes Submission.state
         create_submission_event(None, submission, f"Submission rejected: {err}")
     else:

--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -1280,11 +1280,11 @@ def process_and_validate_submission(submission):
         if xml_metadata is not None:
             # Items preferred / only available from XML
             submission.xml_version = xml_metadata["xml_version"]
-            submission.title = xml_metadata["title"]
+            submission.title = xml_metadata["title"] or ""
             submission.authors = xml_metadata["authors"]
         else:
             # Items to get from text only if XML not available
-            submission.title = text_metadata["title"]
+            submission.title = text_metadata["title"] or ""
             submission.authors = text_metadata["authors"]
 
         if not submission.title:


### PR DESCRIPTION
Fixes #7130 - fixes the specific cause and adds more general guards against saving a mutated submission when updating its status.