### PR TITLE
fix: Do not force showAgenda when agenda_note is set

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1761,7 +1761,7 @@ def agenda_extract_schedule (item):
         "remoteInstructions": item.session.remote_instructions,
         "flags": {
             "agenda": True if item.session.agenda() is not None else False,
-            "showAgenda": True if (item.session.agenda() is not None or item.session.remote_instructions or item.session.agenda_note) else False
+            "showAgenda": True if (item.session.agenda() is not None or item.session.remote_instructions) else False
         },
         "agenda": {
             "url": item.session.agenda().get_href()


### PR DESCRIPTION
Fixes issue where "break" and "other" type sessions with `agenda_note` are shown with notepad and other irrelevant links.

At least for IETF-119's' schedule, I don't see any sessions that unexpectedly lose these links as a result of this change 