### PR TITLE
feat: add Meetecho to upload/remove slides; refactor upload_session_slides

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -6433,7 +6433,7 @@ class MaterialsTests(TestCase):
         self.assertEqual(mock_slides_manager_cls.return_value.add.call_count, 2)
         # don't care which order they were called in, just that both sessions were updated
         self.assertCountEqual(
-            mock_slides_manager_cls.return_value.add.call_args,
+            mock_slides_manager_cls.return_value.add.call_args_list,
             [
                 call(session=session1, slides=sp.document, order=1),
                 call(session=session2, slides=sp.document, order=1),

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2892,9 +2892,9 @@ def upload_session_slides(request, session_id, num, name=None):
 
     doc = None
     if name:
-        doc = Document.objects.filter(name=name).first()
-        if not (doc and doc.type_id == "slides"):
-            raise Http404
+        doc = get_object_or_404(
+            session.presentations, document__name=name, document__type_id="slides"
+        ).document
 
     if request.method == "POST":
         form = UploadSlidesForm(

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -17,7 +17,7 @@ import debug  # pyflakes: ignore
 import datetime
 from json import JSONDecodeError
 from pprint import pformat
-from typing import Dict, Optional, Sequence, TypedDict, TYPE_CHECKING, Union
+from typing import Sequence, TypedDict, TYPE_CHECKING, Union
 from urllib.parse import urljoin
 
 # Guard against hypothetical cyclical import problems
@@ -335,12 +335,12 @@ class DebugMeetechoAPI(MeetechoAPI):
                     f">> MeetechoAPI: request(method={method},",
                     f">> MeetechoAPI:         url={url},",
                     f">> MeetechoAPI:         api_token={api_token},",
-                    f">> MeetechoAPI:         json=" + json_lines[0],
+                    ">> MeetechoAPI:         json=" + json_lines[0],
                     (
                         ">> MeetechoAPI:              " +
-                        f"\n>> MeetechoAPI:              ".join(l for l in json_lines[1:])
+                        "\n>> MeetechoAPI:              ".join(l for l in json_lines[1:])
                     ),
-                    f">> MeetechoAPI: )"
+                    ">> MeetechoAPI: )"
                 ]
             )
         )
@@ -426,23 +426,15 @@ class Conference:
         self._manager.delete_conference(self)
 
 
-class APIConfigDict(TypedDict):
-    api_base: str  # url
-    client_id: str
-    client_secret: str
-    request_timeout: Union[float, int]
-    debug: Optional[bool]
-
-
 class Manager:
-    def __init__(self, api_config: APIConfigDict):
-        debug = api_config.get("debug", False)
-        api_config = {k: v for k, v in api_config.items() if k != "debug"}
+    def __init__(self, api_config):
+        api_config_copy = api_config.copy()
+        debug = api_config_copy.pop("debug", False)
         if debug:
-            self.api = DebugMeetechoAPI(**api_config)
+            self.api = DebugMeetechoAPI(**api_config_copy)
         else:
-            self.api = MeetechoAPI(**api_config)
-        self.wg_tokens: Dict[str, str] = {}
+            self.api = MeetechoAPI(**api_config_copy)
+        self.wg_tokens = {}
 
     def wg_token(self, group):
         group_acronym = group.acronym if hasattr(group, "acronym") else group


### PR DESCRIPTION
This is the next slew of updates to use Meetecho's API to improve slide management. The main work here is to make API calls when uploading or removing slides using the buttons on the session materials page.

A moderately substantial refactor of `upload_session_slides()` is included here. This change eliminates a double-save of a `SessionPresentation` when replacing a slide deck with a new revision. It also updates the `SessionPresentation` instances for _all_ sessions when the `apply_to_all` option is enabled - the original implementation created missing ones but did not update ones that already existed (except for the one related to `session` itself). That introduced skew between `rev` for the session used to upload the new rev and all the other sessions.