### PR TITLE
fix: better Meetecho API "order" management

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -6477,15 +6477,10 @@ class MaterialsTests(TestCase):
         self.assertEqual(replacement_sp.document.rev,'01')
         self.assertEqual(mock_slides_manager_cls.call_count, 1)
         self.assertEqual(mock_slides_manager_cls.call_args, call(api_config="fake settings"))
-        self.assertEqual(mock_slides_manager_cls.return_value.delete.call_count, 1)
+        self.assertEqual(mock_slides_manager_cls.return_value.revise.call_count, 1)
         self.assertEqual(
-            mock_slides_manager_cls.return_value.delete.call_args,
+            mock_slides_manager_cls.return_value.revise.call_args,
             call(session=session2, slides=sp.document),
-        )
-        self.assertEqual(mock_slides_manager_cls.return_value.add.call_count, 1)
-        self.assertEqual(
-            mock_slides_manager_cls.return_value.add.call_args,
-            call(session=session2, slides=replacement_sp.document, order=2),
         )
 
     def test_upload_slide_title_bad_unicode(self):

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2955,8 +2955,7 @@ def upload_session_slides(request, session_id, num, name=None):
                     sp.rev = doc.rev
                     sp.save()
                     if sm is not None:
-                        sm.delete(session=sess, slides=doc)  # removes the existing deck with previous revision
-                        sm.add(session=sess, slides=doc, order=sp.order)
+                        sm.revise(session=sess, slides=doc)
                 else:
                     max_order = (
                         sess.presentations.filter(document__type="slides").aggregate(


### PR DESCRIPTION
Follow up a DELETE with a PUT to refresh the order of the remaining slides