### PR TITLE
feat: Only send slides notifications near session time

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1173,6 +1173,10 @@ CELERY_TASK_IGNORE_RESULT = True  # ignore results unless specifically enabled f
 #     'client_id': 'datatracker',
 #     'client_secret': 'some secret',
 #     'request_timeout': 3.01,  # python-requests doc recommend slightly > a multiple of 3 seconds
+#     # How many minutes before/after session to enable slide update API. Defaults to 15. Set to None to disable,
+#     # or < 0 to _always_ send updates (useful for debugging)
+#     'slides_notify_time': 15, 
+#     'debug': False,  # if True, API calls will be echoed as debug instead of sent (only works for slides for now)
 # }
 
 # Meetecho URLs - instantiate with url.format(session=some_session)


### PR DESCRIPTION
The main change here is to limit the sessions for which slides updates result in calls to the MeetEcho API. This adds a `slides_notify_time` option to the `MEETECHO_API_CONFIG` dict to control the window around the session during which notifications will be sent. This is a number of minutes (defaults to 15) before / after the session where changes will be pushed to MeetEcho. If it is set to `None`, then updates are disabled entirely, and if it is `< 0` then the window is infinite (for debugging). Regardless, the API will be called _only_ for scheduled sessions.

As a general improvement, also catches exceptions from the slide update calls - this will prevent errors in the MeetEcho update from breaking slide updates entirely.