### PR TITLE
chore: Correct typo in tracker text

### DIFF
--- a/ietf/name/fixtures/names.json
+++ b/ietf/name/fixtures/names.json
@@ -11286,8 +11286,8 @@
   },
   {
     "fields": {
-      "desc": "Issuer Tracker",
-      "name": "Issuer Tracker",
+      "desc": "Issue Tracker",
+      "name": "Issue Tracker",
       "order": 0,
       "type": "url",
       "used": true


### PR DESCRIPTION
First time contributing to Datatracker here. :) 

This PR is to fix https://github.com/ietf-tools/datatracker/issues/7002.

Steps to test:

1.  Correct the tracker text in `ietf/name/fixtures/names.json`.
2.  Run
    ``` bash
    ietf/manage.py loaddata ietf/name/fixtures/names.json
    ```
    ``` text
    Installed 1492 object(s) from 1 fixture(s)
    ```
3.  Run
    ``` bash
    ietf/manage.py runserver 8001
    ```
4.  Go to [<http://localhost:8000/doc/draft-ietf-openpgp-pqc/02/>](http://localhost:8000/doc/draft-ietf-openpgp-pqc/02/) to confirm that the text has been fixed for both the page and the tooltip.
