### PR TITLE
fix: Add history line when changing the review deadline. (fixes #6598)

### DIFF
--- a/ietf/doc/views_review.py
+++ b/ietf/doc/views_review.py
@@ -1053,10 +1053,9 @@ def edit_deadline(request, name, request_id):
         if form.is_valid():
             if form.cleaned_data['deadline'] != old_deadline:
                 form.save()
+                subject = f"Deadline changed: {review_req.team.acronym.capitalize()} {review_req.type.name.lower()} review of {review_req.doc.name}"
                 if review_req.requested_rev:
-                    subject = "Deadline changed: {} {} review of {}-{}".format(review_req.team.acronym.capitalize(),review_req.type.name.lower(), review_req.doc.name, review_req.requested_rev)
-                else:
-                    subject = "Deadline changed: {} {} review of {}".format(review_req.team.acronym.capitalize(),review_req.type.name.lower(), review_req.doc.name)
+                    subject += f"-{review_req.requested_rev}"
                 descr = "Deadine changed from {} to {}".format(old_deadline, review_req.deadline)
                 update_change_reason(review_req, descr)
                 msg = render_to_string("review/deadline_changed.txt", {

--- a/ietf/doc/views_review.py
+++ b/ietf/doc/views_review.py
@@ -1053,7 +1053,12 @@ def edit_deadline(request, name, request_id):
         if form.is_valid():
             if form.cleaned_data['deadline'] != old_deadline:
                 form.save()
-                subject = "Deadline changed: {} {} review of {}-{}".format(review_req.team.acronym.capitalize(),review_req.type.name.lower(), review_req.doc.name, review_req.requested_rev)
+                if review_req.requested_rev:
+                    subject = "Deadline changed: {} {} review of {}-{}".format(review_req.team.acronym.capitalize(),review_req.type.name.lower(), review_req.doc.name, review_req.requested_rev)
+                else:
+                    subject = "Deadline changed: {} {} review of {}".format(review_req.team.acronym.capitalize(),review_req.type.name.lower(), review_req.doc.name)
+                descr = "Deadine changed from {} to {}".format(old_deadline, review_req.deadline)
+                update_change_reason(review_req, descr)
                 msg = render_to_string("review/deadline_changed.txt", {
                     "review_req": review_req,
                     "old_deadline": old_deadline,


### PR DESCRIPTION
Add history line when the review deadline is changed. Also fixes the subject line of the email sent out, so if there is no specific revision requested it does not print the extra "-" at the end.

Subject used to look:

Subject: Deadline changed: Secdir last call review of draft-ietf-opsawg-9092-update-

now it will look:

Subject: Deadline changed: Secdir last call review of draft-ietf-opsawg-9092-update
