### PR TITLE
fix: Set develop URL correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If VS Code is not available to you, in your clone, type `cd docker; ./run`
 
 Once the containers are started, run the tests to make sure your checkout is a good place to start from (all tests should pass - if any fail, ask for help at tools-develop@). Inside the app container's shell type:
 ```sh
-ietf/manage.py test --settings=settings_test
+./ietf/manage.py test --settings=settings_test
 ```
 
 Note that we recently moved the datatracker onto PostgreSQL - you may still find older documentation that suggests testing with settings_sqlitetest. That will no longer work.
@@ -187,7 +187,7 @@ The result is that all static files collected via the `collectstatic` command wi
 
 ##### Development Mode
 
-In development mode, `STATIC_URL` is set to `/static/`, and Django's `staticfiles` infrastructure makes the static files available under that local URL root (unless you set `settings.SERVE_CDN_FILES_LOCALLY_IN_DEV_MODE` to `False`). It is not necessary to actually populate the `static/` directory by running `collectstatic` in order for static files to be served when running `ietf/manage.py runserver` -- the `runserver` command has extra support for finding and serving static files without running collectstatic.
+In development mode, `STATIC_URL` is set to `/static/`, and Django's `staticfiles` infrastructure makes the static files available under that local URL root (unless you set `settings.SERVE_CDN_FILES_LOCALLY_IN_DEV_MODE` to `False`). It is not necessary to actually populate the `static/` directory by running `collectstatic` in order for static files to be served when running `./ietf/manage.py runserver` -- the `runserver` command has extra support for finding and serving static files without running collectstatic.
 
 In order to work backwards from a file served in development mode to the location from which it is served, the mapping is as follows:
 
@@ -218,7 +218,7 @@ In order to make the template files refer to the correct versioned CDN URL (as g
 During deployment, it is now necessary to run the management command:
 
 ```sh
-ietf/manage.py collectstatic
+./ietf/manage.py collectstatic
 ````
 before activating a new release.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,7 +99,7 @@ You can also open the datatracker project folder and click the **Reopen in conta
 2. Wait for the containers to initialize. Upon completion, you will be dropped into a shell from which you can start the datatracker and execute related commands as usual, for example
 
     ```
-    ietf/manage.py runserver 8001
+    ./ietf/manage.py runserver
     ```
 
     to start the datatracker.

--- a/docker/configs/nginx-502.html
+++ b/docker/configs/nginx-502.html
@@ -51,7 +51,7 @@
         <div>
             <p>Is the datatracker server running?</p>
             <p class="mt">Using <strong>VS Code</strong>, open the <strong>Run and Debug</strong> tab on the left and click the <i>&#x2023;</i> symbol (Run Server) to start the server.</p>
-            <p>Otherwise, run the command <code>ietf/manage.py runserver 8001</code> from the terminal.</p>
+            <p>Otherwise, run the command <code>./ietf/manage.py runserver</code> from the terminal.</p>
         </div>
         <div class="mt">
             <p>You can manage the database at <a href="/pgadmin">/pgadmin</a>.</p>

--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from ietf.settings import *                                          # pyflakes:ignore
+IDTRACKER_BASE_URL = "https://localhost:8000"
 
 ALLOWED_HOSTS = ['*']
 

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -103,11 +103,11 @@ if [ -z "$EDITOR_VSCODE" ]; then
         echo
         echo "You can execute arbitrary commands now, e.g.,"
         echo
-        echo "    ietf/manage.py runserver 8001"
+        echo "    ./ietf/manage.py runserver"
         echo
         echo "to start a development instance of the Datatracker."
         echo
-        echo "    ietf/manage.py test --settings=settings_test"
+        echo "    ./ietf/manage.py test --settings=settings_test"
         echo
         echo "to run all the python tests."
         echo

--- a/ietf/manage.py
+++ b/ietf/manage.py
@@ -12,4 +12,10 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
+    if sys.argv[1] == 'runserver':
+        if len(sys.argv) == 2:
+            sys.argv.append('8001')
+        elif sys.argv[2] != '8001':
+            print("WARNING: Non-default port; URLs might be wrong");
+
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
feat: Change texts to say "./ietf/manage.py" throughout; add the "./" prefix.

feat: Change manage.py to have a default argument of 8001, and docs to not reference an explicit port so they pick up the default.

feat: Change manage.py so that if you give an argument other than 8001 print a warning message that the URLs may be wrong

fix: Override the IDTRACKER_BASE_URL in the settings_local file to point to "http://localhost:8000" under the assumption that the docker default port mapping is being used.

Fixes: #4507