### PR TITLE
fix: Make review settings history usable (fixes #3213).

### DIFF
--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -881,3 +881,21 @@ def badgeify(blob):
             )
 
     return text
+
+@register.filter
+def simple_history_delta_changes(history):
+    """Returns diff between given history and previous entry."""
+    prev = history.prev_record
+    if prev:
+        delta = history.diff_against(prev)
+        return delta.changes
+    return []
+
+@register.filter
+def simple_history_delta_change_cnt(history):
+    """Returns number of changes between given history and previous entry."""
+    prev = history.prev_record
+    if prev:
+        delta = history.diff_against(prev)
+        return len(delta.changes)
+    return 0

--- a/ietf/templates/group/change_reviewer_settings.html
+++ b/ietf/templates/group/change_reviewer_settings.html
@@ -105,11 +105,17 @@
             {% if reviewersettings.history.all %}
                 <tbody>
                     {% for h in reviewersettings.history.all %}
+                        {% if h|simple_history_delta_change_cnt > 0 or h.history_change_reason != "skipped" and h.history_change_reason %}
                         <tr>
                             <td>{{ h.history_date|date }}</td>
                             <td>{% person_link h.history_user.person %}</td>
-                            <td>{{ h.history_change_reason }}</td>
+                            <td>{% if h.history_change_reason != "skipped" and h.history_change_reason %} {{ h.history_change_reason }}<br> {% endif %}
+                                {% for change in h|simple_history_delta_changes %}
+                                   {{ change.field }} changed from "{{change.old}}" to "{{change.new}}"<br>
+                                {% endfor %}
+                            </td>
                         </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             {% endif %}


### PR DESCRIPTION
Makes the history of the review settings usable, by filtering out useless "skipped" and "None" entries from the list unless they have some actual changes to the settings (i.e., if the delta change count is not zero). Also do not save settings every single time when document is assigned to anybody for everybody, i.e., only do bulk update for those users whose skip_next count was decremented. Added some more useful change reasons.

This should fix #3213.