### PR TITLE
fix: redundant word in banner for Legacy stream documents

### DIFF
--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -603,12 +603,7 @@ def document_main(request, name, rev=None, document_html=False):
         additional_urls = doc.documenturl_set.exclude(tag_id='auth48')
 
         # Stream description and name passing test
-        if doc.stream != None:
-            stream_desc = doc.stream.desc
-            stream = "draft-stream-" + doc.stream.slug
-        else:
-            stream_desc = "(None)"
-            stream = "(None)"
+        stream = ("draft-stream-" + doc.stream.slug) if doc.stream != None else "(None)"
 
         html = None
         js = None
@@ -647,7 +642,6 @@ def document_main(request, name, rev=None, document_html=False):
                                        revisions=simple_diff_revisions if document_html else revisions,
                                        snapshot=snapshot,
                                        stream=stream,
-                                       stream_desc=stream_desc,
                                        latest_revision=latest_revision,
                                        latest_rev=latest_rev,
                                        can_edit=can_edit,

--- a/ietf/name/fixtures/names.json
+++ b/ietf/name/fixtures/names.json
@@ -14058,7 +14058,7 @@
   },
   {
     "fields": {
-      "desc": "Legacy stream",
+      "desc": "Legacy",
       "name": "Legacy",
       "order": 6,
       "used": true

--- a/ietf/name/migrations/0014_change_legacy_stream_desc.py
+++ b/ietf/name/migrations/0014_change_legacy_stream_desc.py
@@ -1,0 +1,21 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+
+from django.db import migrations
+
+def forward(apps, schema_editor):
+    StreamName = apps.get_model("name", "StreamName")
+    StreamName.objects.filter(pk="legacy").update(desc="Legacy")
+
+def reverse(apps, schema_editor):
+    StreamName = apps.get_model("name", "StreamName")
+    StreamName.objects.filter(pk="legacy").update(desc="Legacy stream")
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("name", "0013_narrativeminutes"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse)
+    ]

--- a/ietf/secr/templates/telechat/doc.html
+++ b/ietf/secr/templates/telechat/doc.html
@@ -86,7 +86,7 @@
                 <h2 id="downrefs">Downward References</h2>
                 {% for ref in downrefs %}
                     <p>Add {{ref.target.name}}
-                        ({{ref.target.std_level}} - {{ref.target.stream.desc}})
+                        ({{ref.target.std_level}} - {{ref.target.stream.desc}} stream)
                         to downref registry.<br>
                         {% if not ref.target.std_level %}
                             +++ Warning: The standards level has not been set yet!!!<br>

--- a/ietf/templates/doc/mail/last_call_announcement.txt
+++ b/ietf/templates/doc/mail/last_call_announcement.txt
@@ -33,7 +33,7 @@ No IPR declarations have been submitted directly on this I-D.
 {% if downrefs %}
 The document contains these normative downward references.
 See RFC 3967 for additional information: 
-{% for ref in downrefs %}    {{ref.target.name}}: {{ref.target.title}} ({{ref.target.std_level}} - {{ref.target.stream.desc}})
+{% for ref in downrefs %}    {{ref.target.name}}: {{ref.target.title}} ({{ref.target.std_level}} - {{ref.target.stream.desc}} stream)
 {% endfor %}{%endif%}
 
 {% endautoescape %}


### PR DESCRIPTION
This does all the changes suggested by @rjsparks in #6902 and a little bit more cleanup