### PR TITLE
fix: avoid confusing gray color for Add to calendar in the agenda

### DIFF
--- a/client/agenda/Agenda.vue
+++ b/client/agenda/Agenda.vue
@@ -58,14 +58,17 @@
             n-button(
               :type='agendaStore.isTimezoneMeeting ? `primary` : `default`'
               @click='setTimezone(`meeting`)'
+              :text-color='agendaStore.isTimezoneMeeting ? `#FFF` : null'
               ) Meeting
             n-button(
               :type='agendaStore.isTimezoneLocal ? `primary` : `default`'
               @click='setTimezone(`local`)'
+              :text-color='agendaStore.isTimezoneLocal ? `#FFF` : null'
               ) Local
             n-button(
               :type='agendaStore.timezone === `UTC` ? `primary` : `default`'
               @click='setTimezone(`UTC`)'
+              :text-color='agendaStore.timezone === `UTC` ? `#FFF` : null'
               ) UTC
           n-select.agenda-timezone-ddn(
             v-if='siteStore.viewport > 1250'

--- a/client/agenda/AgendaQuickAccess.vue
+++ b/client/agenda/AgendaQuickAccess.vue
@@ -62,7 +62,8 @@
         n-button.mt-2(
           id='agenda-quickaccess-calview-btn'
           block
-          color='#6c757d'
+          color='#6f42c1'
+          text-color='#FFF'
           size='large'
           strong
           @click='agendaStore.$patch({ calendarShown: true })'
@@ -78,8 +79,8 @@
           n-button.mt-2(
             id='agenda-quickaccess-addtocal-btn'
             block
-            secondary
-            color='#6c757d'
+            :color='siteStore.theme === `dark` ? `rgba(111, 66, 193, .3)` : `#e2d9f3`'
+            :text-color='siteStore.theme === `dark` ? `#e2d9f3` : `#59359a`'
             size='large'
             strong
             )

--- a/client/agenda/AgendaScheduleCalendar.vue
+++ b/client/agenda/AgendaScheduleCalendar.vue
@@ -11,14 +11,17 @@ n-drawer(v-model:show='isShown', placement='bottom', :height='state.drawerHeight
             n-button(
               :type='agendaStore.isTimezoneMeeting ? `primary` : `default`'
               @click='setTimezone(`meeting`)'
+              :text-color='agendaStore.isTimezoneMeeting ? `#FFF` : null'
               ) Meeting
             n-button(
               :type='agendaStore.isTimezoneLocal ? `primary` : `default`'
               @click='setTimezone(`local`)'
+              :text-color='agendaStore.isTimezoneLocal ? `#FFF` : null'
               ) Local
             n-button(
               :type='agendaStore.timezone === `UTC` ? `primary` : `default`'
               @click='setTimezone(`UTC`)'
+              :text-color='agendaStore.timezone === `UTC` ? `#FFF` : null'
               ) UTC
           n-divider(vertical)
         n-button.me-2(
@@ -32,7 +35,7 @@ n-drawer(v-model:show='isShown', placement='bottom', :height='state.drawerHeight
           n-badge.ms-2(:value='agendaStore.selectedCatSubs.length', processing)
         n-button(
           ghost
-          color='gray'
+          :color='siteStore.theme === `dark` ? `#e35d6a` : `gray`'
           strong
           @click='close'
           )


### PR DESCRIPTION
Fixing #7096 by using the Bootstrap 'info' rather than 'secondary' color for Add to calendar.