### PR TITLE
refactor: Remove decorator dependency from debug.py

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -55,7 +55,7 @@ def trace(fn):                 # renamed from 'report' by henrik 16 Jun 2011
         if len(s) > n+3:
             s = s[:n]+"..."
         return s
-    def wrap(fn, *params,**kwargs):
+    def wrap(*params,**kwargs):
         call = wrap.callcount = wrap.callcount + 1
 
         indent = ' ' * _report_indent[0]
@@ -81,8 +81,8 @@ def trace(fn):                 # renamed from 'report' by henrik 16 Jun 2011
         return ret
     wrap.callcount = 0
     if debug:
-        from decorator import decorator
-        return decorator(wrap, fn)
+        from functools import update_wrapper
+        return update_wrapper(wrap, fn)
     else:
         return fn
 
@@ -119,7 +119,7 @@ def clock(s):
 def time(fn):
     """Decorator to print timing information about a function call.
     """
-    def wrap(fn, *params,**kwargs):
+    def wrap(*params,**kwargs):
 
         indent = ' ' * _report_indent[0]
         fc = "%s.%s()" % (fn.__module__, fn.__name__,)
@@ -132,8 +132,8 @@ def time(fn):
         return ret
     wrap.callcount = 0
     if debug:
-        from decorator import decorator
-        return decorator(wrap, fn)
+        from functools import update_wrapper
+        return update_wrapper(wrap, fn)
     else:
         return fn
 
@@ -190,7 +190,7 @@ def type(name):
         value = eval(name, frame.f_globals, frame.f_locals)
         indent = ' ' * (_report_indent[0])
         sys.stderr.write("%s%s: %s\n" % (indent, name, value))
-            
+
 def say(s):
     if debug:
         indent = ' ' * (_report_indent[0])
@@ -205,11 +205,11 @@ def profile(fn):
         prof.dump_stats(datafn)
         return retval
     if debug:
-        from decorator import decorator
-        return decorator(wrapper, fn)
+        from functools import update_wrapper
+        return update_wrapper(wrapper, fn)
     else:
         return fn
-    
+
 def traceback(levels=None):
     if debug:
         indent = ' ' * (_report_indent[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ bleach>=6
 types-bleach>=6
 celery>=5.2.6
 coverage>=4.5.4,<5.0    # Coverage 5.x moves from a json database to SQLite.  Moving to 5.x will require substantial rewrites in ietf.utils.test_runner and ietf.release.views
-decorator>=5.1.1
-types-decorator>=5.1.1
 defusedxml>=0.7.1    # for TastyPie when using xml; not a declared dependency
 Django>4.2,<5
 django-analytical>=3.1.0
@@ -56,7 +54,7 @@ pyquery>=1.4.3
 python-dateutil>=2.8.2
 types-python-dateutil>=2.8.2
 python-magic==0.4.18    # Versions beyond the yanked .19 and .20 introduce form failures
-pymemcache>=4.0.0  # for django.core.cache.backends.memcached.PyMemcacheCache 
+pymemcache>=4.0.0  # for django.core.cache.backends.memcached.PyMemcacheCache
 python-mimeparse>=1.6    # from TastyPie
 pytz==2022.2.1   # Pinned as changes need to be vetted for their effect on Meeting fields
 requests>=2.31.0


### PR DESCRIPTION
The PR removes the `decorator` dependency from `debug.py`. This should complete #5654.

See also: #7199 