### PR TITLE
fix: Disable send-review-reminders from bin/daily

### DIFF
--- a/bin/daily
+++ b/bin/daily
@@ -47,5 +47,5 @@ $DTDIR/ietf/manage.py run_yang_model_checks -v0
 # Enable when removed from /a/www/ietf-datatracker/scripts/Cron-runner:
 $DTDIR/ietf/bin/expire-last-calls
 
-I# Purge older PersonApiKeyEvents
+# Purge older PersonApiKeyEvents
 $DTDIR/ietf/manage.py purge_old_personal_api_key_events 14

--- a/bin/daily
+++ b/bin/daily
@@ -47,8 +47,5 @@ $DTDIR/ietf/manage.py run_yang_model_checks -v0
 # Enable when removed from /a/www/ietf-datatracker/scripts/Cron-runner:
 $DTDIR/ietf/bin/expire-last-calls
 
-# Send reminders originating from the review app
-$DTDIR/ietf/bin/send-review-reminders
-
-# Purge older PersonApiKeyEvents
+I# Purge older PersonApiKeyEvents
 $DTDIR/ietf/manage.py purge_old_personal_api_key_events 14


### PR DESCRIPTION
This celery task was enabled a while ago, so the call here was redundant (and causing doubled reminders to be sent)