### PR TITLE
ci: give rabbitmq a persistent volume claim

### DIFF
--- a/helm/settings_local.py
+++ b/helm/settings_local.py
@@ -68,7 +68,6 @@ IDSUBMIT_REPOSITORY_PATH = INTERNET_DRAFT_PATH
 NOMCOM_PUBLIC_KEYS_DIR = "data/nomcom_keys/public_keys/"
 SLIDE_STAGING_PATH = "/test/staging/"
 
-# todo check that de-gfm is in place
 DE_GFM_BINARY = "/usr/local/bin/de-gfm"
 
 # OIDC configuration

--- a/helm/settings_local.py
+++ b/helm/settings_local.py
@@ -75,7 +75,7 @@ DE_GFM_BINARY = "/usr/local/bin/de-gfm"
 SITE_URL = os.environ.get("OIDC_SITE_URL")
 
 # todo: parameterize memcached url in settings.py
-MEMCACHED_HOST = os.environ.get(f"MEMCACHED_SERVICE_HOST", "127.0.0.1")
+MEMCACHED_HOST = os.environ.get("MEMCACHED_SERVICE_HOST", "127.0.0.1")
 MEMCACHED_PORT = os.environ.get("MEMCACHED_SERVICE_PORT", "11211")
 from ietf import __version__
 CACHES = {

--- a/helm/templates/persistentvolumeclaims.yaml
+++ b/helm/templates/persistentvolumeclaims.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "rabbitmq-data-claim"
+spec:
+#  storageClassName: "local"
+#  volumeName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -37,7 +37,7 @@ datatracker:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     # tag: "v1.1.0"
-
+  
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: ""
@@ -457,6 +457,9 @@ rabbitmq:
 
   # Additional volumes on the output Deployment definition.
   volumes:
+    - name: "rabbitmq-data"
+      persistentVolumeClaim:
+        claimName: "rabbitmq-data-claim"
     - name: "rabbitmq-config"
       configMap:
         name: "rabbitmq-configmap"
@@ -467,6 +470,8 @@ rabbitmq:
   
     # Additional volumeMounts on the output Deployment definition.
   volumeMounts:
+    - name: "rabbitmq-data"
+      mountPath: "/var/lib/rabbitmq/mnesia"
     - name: "rabbitmq-config"
       mountPath: "/etc/rabbitmq"
     # - name: foo


### PR DESCRIPTION
This adds a persistent volume claim for rabbitmq. As-is, it at least works with minikube, which creates a persistent volume on its VM to satisfy the claim. I expect this will need attention when moving to aws deployment, so this is something of a stub for now.

A couple bits of cleanup as well.