### PR TITLE
ci: collectstatic --no-input

### DIFF
--- a/dev/build/datatracker-start.sh
+++ b/dev/build/datatracker-start.sh
@@ -7,7 +7,7 @@ echo "Running Datatracker migrations..."
 ./ietf/manage.py migrate --settings=settings_local
 
 echo "Running collectstatic..."
-./ietf/manage.py collectstatic
+./ietf/manage.py collectstatic --no-input
 
 echo "Starting Datatracker..."
 


### PR DESCRIPTION
Needed to prevent errors when starting up a container if there are updated timestamps.

I think we should eventually get rid of the collectstatic call for production, though?