### PR TITLE
ci: Install libreoffice

### DIFF
--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -5,6 +5,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get purge -y imagemagick imagemagick-6-common
 
+# Install libreoffice (needed via PPT2PDF_COMMAND)
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/bullseye-backports.list && \
+    apt-get update && \
+    apt-get -qyt bullseye-backports install libreoffice-nogui
+
 COPY . .
 COPY ./dev/build/start.sh ./start.sh
 COPY ./dev/build/datatracker-start.sh ./datatracker-start.sh


### PR DESCRIPTION
Use bullseye-backports to get something more recent (ietfa has 7.3.6.2; bullseye has 7.0.x.x; bullseye-backports has 7.4.7.2)