### PR TITLE
ci: Get APP_API_TOKENS from env

### DIFF
--- a/helm/settings_local.py
+++ b/helm/settings_local.py
@@ -196,6 +196,8 @@ DE_GFM_BINARY = "/usr/local/bin/de-gfm"
 IDSUBMIT_IDNITS_BINARY = "/usr/local/bin/idnits"
 
 # Duplicating production cache from settings.py and using it whether we're in production mode or not
+MEMCACHED_HOST = os.environ.get("MEMCACHED_SERVICE_HOST", "127.0.0.1")
+MEMCACHED_PORT = os.environ.get("MEMCACHED_SERVICE_PORT", "11211")
 from ietf import __version__
 CACHES = {
     "default": {

--- a/helm/settings_local.py
+++ b/helm/settings_local.py
@@ -3,6 +3,7 @@
 
 from base64 import b64decode
 from email.utils import parseaddr
+import json
 
 from ietf import __release_hash__
 from ietf.settings import *                                          # pyflakes:ignore
@@ -136,11 +137,11 @@ elif SERVER_MODE == "production":
         "DATATRACKER_MEETECHO_CLIENT_ID and DATATRACKER_MEETECHO_CLIENT_SECRET must be set in production"
     )
 
-APP_API_TOKENS = {
-    "ietf.api.views.directauth": ["redacted",],
-    "ietf.api.views.email_aliases": ["redacted"],
-    "ietf.api.views.active_email_list": ["redacted"],
-}
+_APP_API_TOKENS_JSON = os.environ.get("DATATRACKER_APP_API_TOKENS_JSON", None)
+if _APP_API_TOKENS_JSON is not None:
+    APP_API_TOKENS = json.loads(_APP_API_TOKENS_JSON)
+else:
+    APP_API_TOKENS = {}
 
 EMAIL_COPY_TO = ""
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -597,5 +597,5 @@ env:
     {
       "ietf.api.views.directauth": ["secret-for-directauth"],
       "ietf.api.views.email_aliases": ["secret-for-email-aliases"],
-      "ietf.api.views.active_email_list": ["secret-for-active-email-list"],
+      "ietf.api.views.active_email_list": ["secret-for-active-email-list"]
     }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -593,3 +593,9 @@ env:
   # DATATRACKER_MATOMO_SITE_ID: "7"  # must be present to enable Matomo
   # DATATRACKER_MATOMO_DOMAIN_PATH: "analytics.ietf.org"
   CELERY_PASSWORD: "this-is-a-secret"
+  DATATRACKER_APP_API_TOKENS_JSON: |-
+    {
+      "ietf.api.views.directauth": ["secret-for-directauth"],
+      "ietf.api.views.email_aliases": ["secret-for-email-aliases"],
+      "ietf.api.views.active_email_list": ["secret-for-active-email-list"],
+    }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -593,9 +593,4 @@ env:
   # DATATRACKER_MATOMO_SITE_ID: "7"  # must be present to enable Matomo
   # DATATRACKER_MATOMO_DOMAIN_PATH: "analytics.ietf.org"
   CELERY_PASSWORD: "this-is-a-secret"
-  DATATRACKER_APP_API_TOKENS_JSON: |-
-    {
-      "ietf.api.views.directauth": ["secret-for-directauth"],
-      "ietf.api.views.email_aliases": ["secret-for-email-aliases"],
-      "ietf.api.views.active_email_list": ["secret-for-active-email-list"]
-    }
+  # DATATRACKER_APP_API_TOKENS_JSON: "<JSON blob>" 


### PR DESCRIPTION
Expects a string containing JSON.

Also fixes a problem in `helm/settings_local.py` that prevented the datatracker from starting up. Needed to read the memcached service host/port from `settings_local.py` because it's imported before `settings.py` fills in those values.