### PR TITLE
ci: shared PersistentVolumeClaim on /a

### DIFF
--- a/helm/templates/persistentvolumeclaims.yaml
+++ b/helm/templates/persistentvolumeclaims.yaml
@@ -1,6 +1,17 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: "datatracker-shared-volume-claim"
+spec:
+  accessModes:
+    - ReadWriteMany  # or ReadWriteOnce and force datatracker/celery/beat to a single node
+  resources:
+    requests:
+      storage: 400Gi  # adjust to something satisfied by the /a PersistentVolume
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
   name: "rabbitmq-data-claim"
 spec:
 #  storageClassName: "local"

--- a/helm/templates/persistentvolumeclaims.yaml
+++ b/helm/templates/persistentvolumeclaims.yaml
@@ -2,12 +2,15 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "datatracker-shared-volume-claim"
+  # Note: This is the /a shared volume. The spec should be adjusted to ensure it always
+  # matches the correct EBS volume in production. For the moment, it just requests a
+  # large volume.
 spec:
   accessModes:
     - ReadWriteMany  # or ReadWriteOnce and force datatracker/celery/beat to a single node
   resources:
     requests:
-      storage: 400Gi  # adjust to something satisfied by the /a PersistentVolume
+      storage: 600Gi  # adjust to something satisfied by the /a PersistentVolume
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -129,12 +129,16 @@ datatracker:
     - name: settings-local-volume
       configMap:
         name: django-configmap
-    - name: cache-volume
-      emptyDir:
-        sizeLimit: 1Gi
-    - name: staging-volume
-      emptyDir:
-        sizeLimit: 1Gi
+    - name: datatracker-shared-volume
+      persistentVolumeClaim:
+        claimName: "datatracker-shared-volume-claim"
+# cache-volume and staging-volume are a hack to create paths for debugging without a /a volume
+#    - name: cache-volume
+#      emptyDir:
+#        sizeLimit: 1Gi
+#    - name: staging-volume
+#      emptyDir:
+#        sizeLimit: 1Gi
   # - name: foo
   #   secret:
   #     secretName: mysecret
@@ -146,10 +150,13 @@ datatracker:
       mountPath: /workspace/ietf/settings_local.py
       subPath: settings_local.py
       readOnly: true
-    - name: cache-volume
-      mountPath: "/a/cache"
-    - name: staging-volume
-      mountPath: "/test/staging"
+    - name: datatracker-shared-volume
+      mountPath: /a
+# cache-volume and staging-volume are a hack to create paths for debugging without a /a volume
+#    - name: cache-volume
+#      mountPath: "/a/cache"
+#    - name: staging-volume
+#      mountPath: "/test/staging"
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
@@ -240,12 +247,16 @@ celery:
     - name: settings-local-volume
       configMap:
         name: django-configmap
-    - name: cache-volume
-      emptyDir:
-        sizeLimit: 1Gi
-    - name: staging-volume
-      emptyDir:
-        sizeLimit: 1Gi
+    - name: datatracker-shared-volume
+      persistentVolumeClaim:
+        claimName: "datatracker-shared-volume-claim"
+# cache-volume and staging-volume are a hack to create paths for debugging without a /a volume
+#    - name: cache-volume
+#      emptyDir:
+#        sizeLimit: 1Gi
+#    - name: staging-volume
+#      emptyDir:
+#        sizeLimit: 1Gi
   # - name: foo
   #   secret:
   #     secretName: mysecret
@@ -257,10 +268,13 @@ celery:
       mountPath: /workspace/ietf/settings_local.py
       subPath: settings_local.py
       readOnly: true
-    - name: cache-volume
-      mountPath: "/a/cache"
-    - name: staging-volume
-      mountPath: "/test/staging"
+    - name: datatracker-shared-volume
+      mountPath: /a
+# cache-volume and staging-volume are a hack to create paths for debugging without a /a volume
+#    - name: cache-volume
+#      mountPath: "/a/cache"
+#    - name: staging-volume
+#      mountPath: "/test/staging"
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
@@ -351,12 +365,16 @@ beat:
     - name: settings-local-volume
       configMap:
         name: django-configmap
-    - name: cache-volume
-      emptyDir:
-        sizeLimit: 1Gi
-    - name: staging-volume
-      emptyDir:
-        sizeLimit: 1Gi
+    - name: datatracker-shared-volume
+      persistentVolumeClaim:
+        claimName: "datatracker-shared-volume-claim"
+# cache-volume and staging-volume are a hack to create paths for debugging without a /a volume
+#    - name: cache-volume
+#      emptyDir:
+#        sizeLimit: 1Gi
+#    - name: staging-volume
+#      emptyDir:
+#        sizeLimit: 1Gi
   # - name: foo
   #   secret:
   #     secretName: mysecret
@@ -368,10 +386,13 @@ beat:
       mountPath: /workspace/ietf/settings_local.py
       subPath: settings_local.py
       readOnly: true
-    - name: cache-volume
-      mountPath: "/a/cache"
-    - name: staging-volume
-      mountPath: "/test/staging"
+    - name: datatracker-shared-volume
+      mountPath: /a
+# cache-volume and staging-volume are a hack to create paths for debugging without a /a volume
+#    - name: cache-volume
+#      mountPath: "/a/cache"
+#    - name: staging-volume
+#      mountPath: "/test/staging"
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true


### PR DESCRIPTION
Tested in minikube by setting `accessModes` to `ReadWriteOnce` and confirming that datatracker / celery / beat all saw the same filesystem.