### PR TITLE
ci: Add scoutapm sidecar container

### DIFF
--- a/helm/settings_local.py
+++ b/helm/settings_local.py
@@ -176,14 +176,12 @@ if _SCOUT_KEY is not None:
         DEV_PRE_APPS = ["scout_apm.django", ]
     SCOUT_MONITOR = True
     SCOUT_KEY = _SCOUT_KEY
-    SCOUT_NAME = "Datatracker"
+    SCOUT_NAME = os.environ.get("DATATRACKER_SCOUT_NAME", "Datatracker")
     SCOUT_ERRORS_ENABLED = True
     SCOUT_SHUTDOWN_MESSAGE_ENABLED = False
-    SCOUT_CORE_AGENT_DIR = "/a/core-agent/1.4.0"
-    SCOUT_CORE_AGENT_FULL_NAME = "scout_apm_core-v1.4.0-x86_64-unknown-linux-musl"
     SCOUT_CORE_AGENT_SOCKET_PATH = "tcp://{host}:{port}".format(
-        host=os.environ.get("DATATRACKER_SCOUT_CORE_AGENT_HOST", "scout"),
-        port=os.environ.get("DATATRACKER_SCOUT_CORE_AGENT_PORT", "16590"),
+        host=os.environ.get("DATATRACKER_SCOUT_CORE_AGENT_HOST", "localhost"),
+        port=os.environ.get("DATATRACKER_SCOUT_CORE_AGENT_PORT", "6590"),
     ),
     SCOUT_CORE_AGENT_DOWNLOAD = False
     SCOUT_CORE_AGENT_LAUNCH = False

--- a/helm/templates/deployments/datatracker.yaml
+++ b/helm/templates/deployments/datatracker.yaml
@@ -57,6 +57,13 @@ spec:
             {{- toYaml $podValues.startupProbe | nindent 12 }}
           resources:
             {{- toYaml $podValues.resources | nindent 12 }}
+      {{- if $podValues.scoutapm }}
+      initContainers:
+        - name: "scoutapm"
+          image: "{{ $podValues.scoutapm.image.repository }}:{{ default "latest" $podValues.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" $podValues.scoutapm.image.imagePullPolicy }}
+          restartPolicy: "Always"
+      {{- end }}
       {{- with $podValues.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -667,3 +667,7 @@ env:
   # use this to override default - one entry per line
   # DATATRACKER_CSRF_TRUSTED_ORIGINS: |-
   #   https://datatracker.staging.ietf.org
+
+  # Scout configuration
+  DATATRACKER_SCOUT_KEY: "this-is-the-scout-key"
+  DATATRACKER_SCOUT_NAME: "StagingDatatracker"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -166,6 +166,12 @@ datatracker:
   nodeSelector: {}
 
   affinity: {}
+  
+  # Set this to enable a Scout APM Core Agent sidecar
+  scoutapm:
+    image:
+      repository: "scoutapp/scoutapm"
+      tag: "version-1.4.0"
 
 # -------------------------------------------------------------
 # CELERY


### PR DESCRIPTION
This adds a ScoutAPM core agent sidecar container to the datatracker deployment.

At least, I think it does - the `scoutapp/scoutapm` image is not available for arm64, so I've only actually verified that it fails to start due to an architecture mismatch on my dev laptop.