### PR TITLE
ci: do not re-run yarn / collectstatics

### DIFF
--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -23,12 +23,6 @@ RUN chmod +x start.sh && \
     chmod +x docker/scripts/app-create-dirs.sh && \
     sh ./docker/scripts/app-create-dirs.sh
 
-RUN yarn rebuild && \
-    yarn build && \
-    yarn legacy:build
-
-RUN echo "yes" | /bin/bash dev/build/collectstatics.sh
-
 RUN mkdir -p /a
 
 VOLUME [ "/a" ]


### PR DESCRIPTION
Counts on build-push-action's `context: .` to use the `static/` files
built earlier in the GHA process.