### PR TITLE
ci: more memcached mem; set securityContext

### DIFF
--- a/helm/templates/deployments/memcached.yaml
+++ b/helm/templates/deployments/memcached.yaml
@@ -31,6 +31,7 @@ spec:
           securityContext:
             {{- toYaml $podValues.securityContext | nindent 12 }}
           image: "{{ $podValues.image.repository }}:{{ default "latest" $podValues.image.tag }}"
+          args: ["-m", "$(MEMCACHED_MEM_LIMIT)"]
           imagePullPolicy: {{ default "IfNotPresent" $podValues.image.imagePullPolicy }}
           env:
             {{- if .Values.env }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -515,9 +515,6 @@ memcached:
   podAnnotations: {}
   podLabels: {}
 
-  podSecurityContext: {}
-    # fsGroup: 2000
-
   replicaCount: 1
 
   resources: {}
@@ -532,13 +529,17 @@ memcached:
     #   cpu: 100m
     #   memory: 128Mi
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 11211
+    runAsGroup: 11211
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
 
   service:
     type: ClusterIP
@@ -674,3 +675,5 @@ env:
   # Scout configuration
   DATATRACKER_SCOUT_KEY: "this-is-the-scout-key"
   DATATRACKER_SCOUT_NAME: "StagingDatatracker"
+
+  MEMCACHED_MEM_LIMIT: "1024"


### PR DESCRIPTION
Guarantees memcached does not run as root and adds setting for memcached memory limit (defaults to `1024`, which is the value on ietfa).