### PR TITLE
ci: run rabbitmq as non-root

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -61,3 +61,9 @@ data:
     # absolute number because relative will be proprtional to the full machine
     # memory.
     vm_memory_high_watermark.absolute = 1600MB
+    
+    # Logging
+    log.file = false
+    log.console = true
+    log.console.level = info
+    log.console.formatter = json

--- a/helm/templates/statefulsets/rabbitmq.yaml
+++ b/helm/templates/statefulsets/rabbitmq.yaml
@@ -26,6 +26,20 @@ spec:
       serviceAccountName: {{ include "datatracker.serviceAccountName.rabbitmq" . }}
       securityContext:
         {{- toYaml $podValues.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: init-rabbitmq
+          image: busybox:stable
+          command:
+            - "sh"
+            - "-c"
+            - "mkdir -p -m700 /mnt/rabbitmq && chown 100:101 /mnt/rabbitmq"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "rabbitmq-data"
+              mountPath: "/mnt"
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -405,7 +405,6 @@ rabbitmq:
     repository: "ghcr.io/ietf-tools/datatracker-mq"
     pullPolicy: IfNotPresent
     tag: "3.12-alpine"
-
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: ""
@@ -478,6 +477,9 @@ rabbitmq:
     - name: "rabbitmq-config"
       configMap:
         name: "rabbitmq-configmap"
+    - name: "rabbitmq-tmp"
+      emptyDir:
+        sizeLimit: 50Mi
     # - name: foo
     #   secret:
     #     secretName: mysecret
@@ -489,9 +491,8 @@ rabbitmq:
       mountPath: "/var/lib/rabbitmq/mnesia"
     - name: "rabbitmq-config"
       mountPath: "/etc/rabbitmq"
-    # - name: foo
-    #   mountPath: "/etc/foo"
-    #   readOnly: true
+    - name: "rabbitmq-tmp"
+      mountPath: "/tmp"
 
   tolerations: []
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -419,9 +419,6 @@ rabbitmq:
   podAnnotations: {}
   podLabels: {}
 
-  podSecurityContext: {}
-    # fsGroup: 2000
-
   replicaCount: 1
 
   resources: {}
@@ -436,13 +433,18 @@ rabbitmq:
     #   cpu: 100m
     #   memory: 128Mi
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  podSecurityContext:
+    runAsNonRoot: true
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    # rabbitmq image sets up uid/gid 100/101
+    runAsUser: 100
+    runAsGroup: 101
 
   service:
     type: ClusterIP
@@ -531,8 +533,6 @@ memcached:
 
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 11211
-    runAsGroup: 11211
 
   securityContext:
     allowPrivilegeEscalation: false
@@ -540,6 +540,9 @@ memcached:
       drop:
       - ALL
     readOnlyRootFilesystem: true
+    # memcached image sets up uid/gid 11211
+    runAsUser: 11211
+    runAsGroup: 11211
 
   service:
     type: ClusterIP

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -488,7 +488,8 @@ rabbitmq:
     # Additional volumeMounts on the output Deployment definition.
   volumeMounts:
     - name: "rabbitmq-data"
-      mountPath: "/var/lib/rabbitmq/mnesia"
+      mountPath: "/var/lib/rabbitmq"
+      subPath: "rabbitmq"
     - name: "rabbitmq-config"
       mountPath: "/etc/rabbitmq"
     - name: "rabbitmq-tmp"


### PR DESCRIPTION
Sets securityContexts for the rabbitmq pod so it does not run as root.

This creates a permissions issue with the `rabbitmq-data` volume, which is mounted at `/var/lib/rabbitmq`. The permissions on that volume require root, at least with the `hostPath` driver I use in my dev testing. I tried using `fsGroup` in the pod `seurityContext` to fix this but that does not seem to work with `hostPath`. While it might work for production use, I've instead added an `initContainer` to create a subdirectory in the `rabbitmq-data` volume with the necessary permissions, then mount this via `subPath` at `/var/lib/rabbitmq`.