### PR TITLE
feat: config celery logging via Django

### DIFF
--- a/ietf/celeryapp.py
+++ b/ietf/celeryapp.py
@@ -1,14 +1,20 @@
 import os
 import scout_apm.celery
 
-from celery import Celery
+import celery
 from scout_apm.api import Config
+
+
+# Disable celery's internal logging configuration, we set it up via Django
+@celery.signals.setup_logging.connect
+def on_setup_logging(**kwargs):
+    pass
 
 
 # Set the default Django settings module for the 'celery' program
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ietf.settings')
 
-app = Celery('ietf')
+app = celery.Celery('ietf')
 
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -252,17 +252,21 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.security': {
-	        'handlers': ['console', ],
+            'handlers': ['console', ],
             'level': 'INFO',
         },
- 	    'oidc_provider': {
-	        'handlers': ['debug_console', ],
-	        'level': 'DEBUG',
-	    },
+        'oidc_provider': {
+            'handlers': ['debug_console', ],
+            'level': 'DEBUG',
+        },
         'datatracker': {
             'handlers': ['console', ],
             'level': 'INFO',
         },
+        'celery': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        }
     },
     #
     # No logger filters


### PR DESCRIPTION
This disables Celery's own logging configuration in favor of using Django's config method. This works because Django and Celery both use Python's `logging` module, so we just add a `celery` logger to our `settings.py` and Celery automatically uses it.