### PR TITLE
refactor: clean up logging

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -256,7 +256,7 @@ LOGGING = {
 	        'level': 'DEBUG',
 	    },
         'datatracker': {
-            'handlers': ['console', ],
+            'handlers': ['syslog'],
             'level': 'INFO',
         },
     },

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -236,7 +236,7 @@ LOGGING = {
     #
     'loggers': {
         'django': {
-            'handlers': ['console', 'mail_admins',],
+            'handlers': ['debug_console', 'mail_admins',],
             'level': 'INFO',
         },
         'django.request': {
@@ -248,7 +248,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.security': {
-	        'handlers': ['console', ],
+	        'handlers': ['debug_console', ],
             'level': 'INFO',
         },
  	    'oidc_provider': {
@@ -280,6 +280,13 @@ LOGGING = {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'django.server',
+        },
+        'syslog': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.SysLogHandler',
+            'facility': 'user',
+            'formatter': 'plain',
+            'address': '/dev/log',
         },
         'mail_admins': {
             'level': 'ERROR',

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -328,15 +328,6 @@ LOGGING = {
     },
 }
 
-# This should be overridden by settings_local for any logger where debug (or
-# other) custom log settings are wanted.  Use "ietf/manage.py showloggers -l"
-# to show registered loggers.  The content here should match the levels above
-# and is shown as an example:
-UTILS_LOGGER_LEVELS: Dict[str, str] = {
-#    'django':           'INFO',
-#    'django.server':    'INFO',
-}
-
 # End logging
 # ------------------------------------------------------------------------
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -236,7 +236,7 @@ LOGGING = {
     #
     'loggers': {
         'django': {
-            'handlers': ['debug_console', 'mail_admins'],
+            'handlers': ['console', 'mail_admins',],
             'level': 'INFO',
         },
         'django.request': {
@@ -248,13 +248,17 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.security': {
-	    'handlers': ['debug_console', ],
+	        'handlers': ['console', ],
             'level': 'INFO',
         },
- 	'oidc_provider': {
-	    'handlers': ['debug_console', ],
-	    'level': 'DEBUG',
-	},
+ 	    'oidc_provider': {
+	        'handlers': ['debug_console', ],
+	        'level': 'DEBUG',
+	    },
+        'datatracker': {
+            'handlers': ['console', ],
+            'level': 'INFO',
+        },
     },
     #
     # No logger filters
@@ -263,14 +267,7 @@ LOGGING = {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-            'formatter': 'plain',
-        },
-        'syslog': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.SysLogHandler',
-            'facility': 'user',
-            'formatter': 'plain',
-            'address': '/dev/log',
+            'formatter': 'json',
         },
         'debug_console': {
             # Active only when DEBUG=True
@@ -325,6 +322,9 @@ LOGGING = {
             'style': '{',
             'format': '{levelname}: {name}:{lineno}: {message}',
         },
+        'json' : {
+            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter'
+        }
     },
 }
 

--- a/ietf/utils/log.py
+++ b/ietf/utils/log.py
@@ -10,30 +10,19 @@ import os.path
 import traceback
 
 from typing import Callable         # pyflakes:ignore
-
-try:
-    import syslog
-    logfunc = syslog.syslog             # type: Callable
-except ImportError:                     # import syslog will fail on Windows boxes
-    logging.basicConfig(filename='tracker.log',level=logging.INFO)
-    logfunc = logging.info
-    pass
-
 from django.conf import settings
+from pythonjsonlogger import jsonlogger
 
 import debug                            # pyflakes:ignore
 
-formatter = logging.Formatter('{levelname}: {name}:{lineno}: {message}', style='{')
+formatter = jsonlogger.JsonFormatter
 for name, level in settings.UTILS_LOGGER_LEVELS.items():
     logger = logging.getLogger(name)
     if not logger.hasHandlers():
         debug.say(' Adding handlers to logger %s' % logger.name)
-        
         handlers = [
-                logging.StreamHandler(),
-                logging.handlers.SysLogHandler(address='/dev/log',
-                    facility=logging.handlers.SysLogHandler.LOG_USER),
-            ]
+            logging.StreamHandler(),
+        ]
         for h in handlers:
             h.setFormatter(formatter)
             h.setLevel(level)
@@ -56,20 +45,9 @@ def getcaller():
     return (pmodule, pclass, pfunction, pfile, pline)
 
 def log(msg, e=None):
-    "Uses syslog by preference.  Logs the given calling point and message."
-    global logfunc
-    def _flushfunc():
-        pass
-    _logfunc = logfunc
-    if settings.SERVER_MODE == 'test':
-        if getattr(settings, 'show_logging', False) is True:
-            _logfunc = debug.say
-            _flushfunc = sys.stdout.flush   # pyflakes:ignore (intentional redefinition)
-        else:
+    "Logs the given calling point and message to the logging framework's datatracker handler at severity INFO"
+    if settings.SERVER_MODE == 'test' and not getattr(settings, 'show_logging',False):
             return
-    elif settings.DEBUG == True:
-        _logfunc = debug.say
-        _flushfunc = sys.stdout.flush   # pyflakes:ignore (intentional redefinition)
     if not isinstance(msg, str):
         msg = msg.encode('unicode_escape')
     try:
@@ -82,11 +60,8 @@ def log(msg, e=None):
             where = " in " + func + "()"
     except IndexError:
         file, line, where = "/<UNKNOWN>", 0, ""
-    _flushfunc()
-    _logfunc("ietf%s(%d)%s: %s" % (file, line, where, msg))
 
-logger = logging.getLogger('django')
-
+    logging.getLogger("datatracker").info(msg=msg, extra = {"file":file, "line":line, "where":where})
 
 
 def exc_parts():
@@ -124,6 +99,7 @@ def assertion(statement, state=True, note=None):
     This acts like an assertion.  It uses the django logger in order to send
     the failed assertion and a backtrace as for an internal server error.
     """
+    logger = logging.getLogger("django") # Note this is a change - before this would have gone to "django"
     frame = inspect.currentframe().f_back
     value = eval(statement, frame.f_globals, frame.f_locals)
     if bool(value) != bool(state):
@@ -148,6 +124,7 @@ def assertion(statement, state=True, note=None):
 
 def unreachable(date="(unknown)"):
     "Raises an assertion or sends traceback to admins if executed."
+    logger = logging.getLogger("django")
     frame = inspect.currentframe().f_back
     if settings.DEBUG is True or settings.SERVER_MODE == 'test':
         raise AssertionError("Arrived at code in %s() which was marked unreachable on %s." % (frame.f_code.co_name, date))

--- a/ietf/utils/log.py
+++ b/ietf/utils/log.py
@@ -15,20 +15,6 @@ from pythonjsonlogger import jsonlogger
 
 import debug                            # pyflakes:ignore
 
-formatter = jsonlogger.JsonFormatter
-for name, level in settings.UTILS_LOGGER_LEVELS.items():
-    logger = logging.getLogger(name)
-    if not logger.hasHandlers():
-        debug.say(' Adding handlers to logger %s' % logger.name)
-        handlers = [
-            logging.StreamHandler(),
-        ]
-        for h in handlers:
-            h.setFormatter(formatter)
-            h.setLevel(level)
-            logger.addHandler(h)
-    debug.say(" Setting %s logging level to %s" % (logger.name, level))
-    logger.setLevel(level)
 
 def getclass(frame):
     cls = None

--- a/ietf/utils/log.py
+++ b/ietf/utils/log.py
@@ -9,9 +9,7 @@ import inspect
 import os.path
 import traceback
 
-from typing import Callable         # pyflakes:ignore
 from django.conf import settings
-from pythonjsonlogger import jsonlogger
 
 import debug                            # pyflakes:ignore
 

--- a/ietf/utils/management/commands/showloggers.py
+++ b/ietf/utils/management/commands/showloggers.py
@@ -11,18 +11,7 @@ from django.core.management.base import BaseCommand
 import debug                            # pyflakes:ignore
 
 class Command(BaseCommand):
-    """
-    Display a list or tree representation of python loggers.
-
-    Add a UTILS_LOGGER_LEVELS setting in settings_local.py to configure
-    non-default logging levels for any registered logger, for instance:
-
-    UTILS_LOGGER_LEVELS = {
-        'oicd_provider': 'DEBUG',
-        'urllib3.connection': 'DEBUG',
-    }
-
-    """
+    """Display a list or tree representation of python loggers"""
 
     help = dedent(__doc__).strip()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ pyopenssl>=22.0.0    # Used by urllib3.contrib, which is used by PyQuery but not
 pyquery>=1.4.3
 python-dateutil>=2.8.2
 types-python-dateutil>=2.8.2
+python-json-logger>=2.0.7
 python-magic==0.4.18    # Versions beyond the yanked .19 and .20 introduce form failures
 pymemcache>=4.0.0  # for django.core.cache.backends.memcached.PyMemcacheCache
 python-mimeparse>=1.6    # from TastyPie


### PR DESCRIPTION
This brings in the logging changes made on feat/helm and feat/k8s and adjusts the log setup to be compatible with current production.

Strips out the `UTILS_LOGGER_LEVEL` mechanism that we're not currently using (explanation in the commit description). 

Rather than bringing back the direct calls to `syslog.syslog` in the `ietf.utils.log` module, this keeps @rjsparks's change directing those logs to the `datatracker` logger. That logger is configured to go to syslog via the `SysLogHandler`.

A change on the k8s `settings_local.py` we deploy will be needed to do this:
```
LOGGING["loggers"]["django"]["handlers"] = ["console", "mail_admins"]
LOGGING["loggers"]["django.security"]["handlers"] = ["console"]
LOGGING["loggers"]["datatracker"]["handlers"] = ["console"]
```
which should preserve its current configuration.