### PR TITLE
chore: remove syslog handler from settings.py

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -252,7 +252,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.security': {
-	    'handlers': ['debug_console', ],
+            'handlers': ['debug_console', ],
             'level': 'INFO',
         },
         'oidc_provider': {
@@ -260,11 +260,11 @@ LOGGING = {
             'level': 'DEBUG',
         },
         'datatracker': {
-            'handlers': ['syslog'],
+            'handlers': ['debug_console'],
             'level': 'INFO',
         },
         'celery': {
-            'handlers': ['syslog'],
+            'handlers': ['debug_console'],
             'level': 'INFO',
         },
     },
@@ -288,13 +288,6 @@ LOGGING = {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'django.server',
-        },
-        'syslog': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.SysLogHandler',
-            'facility': 'user',
-            'formatter': 'plain',
-            'address': '/dev/log',
         },
         'mail_admins': {
             'level': 'ERROR',


### PR DESCRIPTION
System-level integration like this really needs to be in settings_local. This was causing problems when running in the dev environment.

To get the effect we want on ietfa, we should add the following to settings_local.py:
```python
LOGGING["handlers"]["syslog"] = {
    'level': 'DEBUG',
    'class': 'logging.handlers.SysLogHandler',
    'facility': 'user',
    'formatter': 'plain',
    'address': '/dev/log',
}
LOGGING["loggers"]["datatracker"]["handlers"] = ["syslog"]
LOGGING["loggers"]["celery"]["handlers"] = ["syslog"]
```
