### PR TITLE
fix: Scroll metadata sidebar tab content

### DIFF
--- a/ietf/templates/doc/document_html.html
+++ b/ietf/templates/doc/document_html.html
@@ -205,7 +205,7 @@
                             HTML is available for this document.
                         </div>
                         {% endif %}
-                        <ul class="nav nav-tabs nav-fill small" role="tablist">
+                        <ul class="nav nav-tabs nav-fill small me-2" role="tablist">
                             <li class="nav-item" role="presentation" title="Document information">
                                 <button class="nav-link px-2"
                                         id="docinfo-tab"
@@ -243,7 +243,7 @@
                                 </button>
                             </li>
                         </ul>
-                        <div class="overflow-auto tab-content pt-2">
+                        <div class="overflow-auto tab-content pt-2 me-2">
                             <div class="tab-pane"
                                  id="docinfo-tab-pane"
                                  role="tabpanel"

--- a/ietf/templates/doc/document_html.html
+++ b/ietf/templates/doc/document_html.html
@@ -172,9 +172,10 @@
             </div>
             <div class="d-print-none col-md-3 bg-light-subtle collapse{% if request.COOKIES.sidebar != 'off'%} show{% endif %}" id="sidebar">
                 <div class="position-fixed border-start sidebar overflow-scroll overscroll-none no-scrollbar">
-                    <div class="pt-2 pt-lg-3 px-md-2 px-lg-3">
-                        <a class="btn btn-primary btn-sm" href="{% url 'ietf.doc.views_doc.document_main' name=doc.name %}">Datatracker</a>
-                        <p class="fw-bold pt-2">
+                    <div class="d-flex flex-column vh-100 pt-2 pt-lg-3 ps-3 pl-md-2 pl-lg-3">
+                        <div>
+                            <a class="btn btn-primary btn-sm" href="{% url 'ietf.doc.views_doc.document_main' name=doc.name %}">Datatracker</a>
+                            <p class="fw-bold pt-2">
                                 {% if doc.type_id == "rfc" %}
                                     RFC {{ doc.rfc_number }}
                                 {% else %}
@@ -188,8 +189,8 @@
                                         Internet-Draft
                                     {% endif %}
                                 </span>
-
-                        </p>
+                            </p>
+                        </div>
                         {% if request.COOKIES.htmlconf and request.COOKIES.htmlconf != 'html' and html %}
                         <div class="alert alert-info small">
                             You are viewing the legacy <code><a class="text-decoration-none text-reset" href="https://github.com/ietf-tools/rfc2html">rfc2html</a></code>
@@ -242,7 +243,7 @@
                                 </button>
                             </li>
                         </ul>
-                        <div class="tab-content pt-2">
+                        <div class="overflow-auto tab-content pt-2">
                             <div class="tab-pane"
                                  id="docinfo-tab-pane"
                                  role="tabpanel"


### PR DESCRIPTION
An attempt at addressing https://github.com/ietf-tools/datatracker/issues/7390 which looks like,

**Chrome**
![Screenshot from 2024-06-05 14-24-13](https://github.com/ietf-tools/datatracker/assets/620580/57dfe4f6-f8bc-4238-8550-719be71cf437)

**Firefox**
![Screenshot from 2024-06-05 14-24-50](https://github.com/ietf-tools/datatracker/assets/620580/40528431-8673-4d0f-ae1e-6666a0fde057)

For UX reasons just the tab content in the sidebar has been made scrollable. Is that ok? The UX reason are that if the sidebar had a full scrollbar it would look like the page itself had 2 scrollbars, whereas this is more clearly just making the tab content scrollable. This does mean that very short screens might not have enough visible scrolling area but such a small screen is probably mobile/tablet which needs a different responsive approach anyway.

Thoughts?

@larseggert @martinthomson 

