### PR TITLE
fix: Formatting blockquotes in datatrackers rendered markdown

### DIFF
--- a/dev/legacy/notes/notes.html
+++ b/dev/legacy/notes/notes.html
@@ -355,7 +355,7 @@ have been written, has been sent by email and thus don't exist as a collection
 in one place.</p>
 <p>With my recent investigations of code analysis tools, I thought it might be
 a good idea to start collecting these in one place for the project.</p>
-<blockquote>
+<blockquote style="border-left: 0">
 <cite>Henrik &lt;henrik&#64;levkowetz.com&gt;, 23 Mar 2014</cite></blockquote>
 </div>
 <div class="section" id="code-analysis-tools">
@@ -398,8 +398,9 @@ the possibility of triggering unwanted side effects of doing an analysis run.</p
 do the right thing, but once it was made to run on the datatracker code, and
 ignore the django code, it didn't report anything that PyFlakes hadn't already
 caught.</p>
-<blockquote>
-<cite>Henrik &lt;henrik&#64;levkowetz.com&gt;, 23 Mar 2014</cite></blockquote>
+<blockquote style="border-left: 0">
+    <cite>Henrik &lt;henrik&#64;levkowetz.com&gt;, 23 Mar 2014</cite>
+</blockquote>
 </div>
 </div>
 </div>

--- a/ietf/secr/templates/telechat/group.html
+++ b/ietf/secr/templates/telechat/group.html
@@ -3,7 +3,7 @@
         <b>Does anyone have an objection to the creation of this working group being sent for EXTERNAL REVIEW?</b><br><br>
         <input type="radio" name="wg_action_status" value="1"> External Review APPROVED; "The Secretariat will send a Working Group Review announcement with a copy to new-work and place it back on the agenda for the next telechat."<br><br>
         <input type="radio" name="wg_action_status" value="2"> External Review NOT APPROVED;
-        <blockquote>
+        <blockquote style="border-left: 0">
             <input type="radio" name="wg_action_status_sub" value="1"> The Secretariat will wait for instructions from <select name="note_draft_by"></select><br>
             <input type="radio" name="wg_action_status_sub" value="2"> The IESG decides the document needs more time in INTERNAL REVIEW.  The Secretariat will put it back on the agenda for the next teleconference in the same category.<br>
             <input type="radio" name="wg_action_status_sub" value="3"> The IESG has made changes since the charter was seen in INTERNAL REVIEW, and decides to send it back to INTERNAL REVIEW the charter again.

--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -1184,10 +1184,7 @@ td.position-empty {
     }
 }
 
-/* For formatting dynamic HTML blobs */
-.richtext {
-    blockquote {
-        padding-left: 1rem;
-        border-left: solid 1px var(--bs-card-cap-color);
-    }
+blockquote {
+    padding-left: 1rem;
+    border-left: solid 1px var(--bs-body-color);
 }

--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -1183,3 +1183,11 @@ td.position-empty {
         }
     }
 }
+
+/* For formatting dynamic HTML blobs */
+.richtext {
+    blockquote {
+        padding-left: 1rem;
+        border-left: solid 1px var(--bs-card-cap-color);
+    }
+}

--- a/ietf/templates/doc/document_statement.html
+++ b/ietf/templates/doc/document_statement.html
@@ -121,7 +121,7 @@
         <div class="card-header">
             {{ doc.name }}-{{ doc.rev }}
         </div>
-        <div class="card-body text-break">
+        <div class="card-body text-break richtext">
             {{ content }}
         </div>
     </div>

--- a/ietf/templates/doc/document_statement.html
+++ b/ietf/templates/doc/document_statement.html
@@ -121,7 +121,7 @@
         <div class="card-header">
             {{ doc.name }}-{{ doc.rev }}
         </div>
-        <div class="card-body text-break richtext">
+        <div class="card-body text-break">
             {{ content }}
         </div>
     </div>


### PR DESCRIPTION
This adds a utility class for HTML blobs of content (ie dynamic content...content that we can't add classes) to format `<blockquote>`.

In the following example the "text" is a blockquote which has `padding-left` and `border-left`:

![Screenshot from 2024-06-04 13-37-00](https://github.com/ietf-tools/datatracker/assets/620580/5cfd9296-1ea6-4fd8-8e68-f70997cd91f5)

Fixes https://github.com/orgs/ietf-tools/projects/3/views/4?pane=issue&itemId=58443314