### PR TITLE
feat: use surname/initials for author name

### DIFF
--- a/ietf/templates/submit/announce_to_lists.txt
+++ b/ietf/templates/submit/announce_to_lists.txt
@@ -1,7 +1,7 @@
 {% autoescape off %}{% filter wordwrap:78 %}Internet-Draft {{ submission.name }}-{{ submission.rev }}.txt is now available.{% if submission.group %} It is a work item of the {{ submission.group.name }} ({{ submission.group.acronym|upper }}){% if submission.group.type.name %} {{ submission.group.type.name }}{% endif %} of the {% if submission.group.type_id == "rg" %}IRTF{% else %}IETF{% endif %}.{% endif %}{% endfilter %}
 
    Title:   {{ submission.title }}
-   Author{{ submission.authors|pluralize:",s" }}: {% if submission.authors|length == 1 %} {% endif %}{% for author in submission.authors %}{{ author.name }}{% if not forloop.last %}
+   Author{{ submission.authors|pluralize:",s" }}: {% if submission.authors|length == 1 %} {% endif %}{% for author in submission.authors %}{% firstof author.name author.affiliation "Unknown" %}{% if not forloop.last %}
             {% endif %}{% endfor %}
    Name:    {{ submission.name }}-{{ submission.rev }}.txt
    Pages:   {{ submission.pages }}

--- a/ietf/templates/submit/approval_request.txt
+++ b/ietf/templates/submit/approval_request.txt
@@ -24,7 +24,7 @@ To approve the Internet-Draft, go to this URL (note: you need to login to be abl
 
 
   Authors:
-{% for author in submission.authors %}    {{ author.name }}{% if author.email %} <{{ author.email }}>{% endif%}
+{% for author in submission.authors %}    {% if author.name or author.affiliation %}{% firstof author.name author.affiliation %} {% endif %}{% if author.email %}<{{ author.email }}>{% endif %}
 {% endfor %}
 {% endautoescape %}
 

--- a/ietf/templates/submit/manual_post_request.txt
+++ b/ietf/templates/submit/manual_post_request.txt
@@ -33,7 +33,7 @@ I-D Submission Tool URL:
 
 
   Authors:
-{% for author in submission.authors %}    {{ author.name }}{% if author.email %} <{{ author.email }}>{% endif%}
+{% for author in submission.authors %}    {% if author.name or author.affiliation %}{% firstof author.name author.affiliation %} {% endif %}{% if author.email %}<{{ author.email }}>{% endif %}
 {% endfor %}
 
   Comment to the secretariat:

--- a/ietf/templates/submit/submission_status.html
+++ b/ietf/templates/submit/submission_status.html
@@ -285,7 +285,7 @@
                 <tr>
                     <th scope="row">Author {{ forloop.counter }}</th>
                     <td>
-                        {{ author.name }}
+                        {% if author.name %}{{ author.name }}{% endif %}
                         {% if author.email %}&lt;{{ author.email|linkify }}&gt;{% endif %}
                         <br>
                         {% if author.affiliation %}

--- a/ietf/templates/submit/submitter_form.html
+++ b/ietf/templates/submit/submitter_form.html
@@ -11,12 +11,14 @@
 </p>
 {% load ietf_filters %}
 {% for author in submission.authors %}
-    <button type="button"
-           class="author btn btn-primary mb-3"
-           data-name="{{ author.name }}"
-           data-email="{% if author.email %}{{ author.email }}{% endif %}">
-        {{ author.name }}
-    </button>
+    {% if author.name %}
+        <button type="button"
+                class="author btn btn-primary mb-3"
+                data-name="{{ author.name }}"
+                data-email="{% if author.email %}{{ author.email }}{% endif %}">
+            {{ author.name }}
+        </button>
+    {% endif %}
 {% endfor %}
 {% bootstrap_form_errors submitter_form %}
 {% bootstrap_field submitter_form.name %}

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -486,6 +486,51 @@ class XMLDraftTests(TestCase):
             ("-01", None),
         )
 
+    def test_render_author_name(self):
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element("author", fullname="Joanna Q. Public")),
+            "Joanna Q. Public",
+        )
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element(
+                "author",
+                fullname="Joanna Q. Public",
+                asciiFullname="Not the Same at All",
+            )),
+            "Joanna Q. Public",
+        )
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element(
+                "author",
+                fullname="Joanna Q. Public",
+                initials="J. Q.",
+                surname="Public-Private",
+            )),
+            "Joanna Q. Public",
+        )
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element(
+                "author",
+                initials="J. Q.",
+                surname="Public",
+            )),
+            "J. Q. Public",
+        )
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element(
+                "author",
+                surname="Public",
+            )),
+            "Public",
+        )
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element(
+                "author",
+                initials="J. Q.",
+            )),
+            "J. Q.",
+        )
+
 
 class NameTests(TestCase):
 

--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -179,6 +179,29 @@ class XMLDraft(Draft):
     #     abstract = self.xmlroot.findtext('front/abstract')
     #     return abstract.strip() if abstract else ''
 
+    @staticmethod
+    def render_author_name(author_elt):
+        """Get a displayable name for an author, if possible
+        
+        Based on TextWriter.render_author_name() from xml2rfc. If fullname is present, uses that.
+        If not, uses either initials + surname or just surname. Finally, returns None because this
+        author is evidently an organization, not a person.
+        
+        Does not involve ascii* attributes because rfc7991 requires fullname if any of those are
+        present.
+        """
+        # Use fullname attribute, if present
+        fullname = author_elt.attrib.get("fullname", "").strip()
+        if fullname:
+            return fullname
+        surname = author_elt.attrib.get("surname", "").strip()
+        initials = author_elt.attrib.get("initials", "").strip()
+        if surname or initials:
+            # This allows the possibility that only initials are used, which is a bit nonsensical
+            # but seems to be technically allowed by RFC 7991.
+            return f"{initials} {surname}".strip()
+        return None
+        
     def get_author_list(self):
         """Get detailed author list
 
@@ -197,7 +220,7 @@ class XMLDraft(Draft):
 
         for author in self.xmlroot.findall('front/author'):
             info = {
-                'name': author.attrib.get('fullname'),
+                'name': self.render_author_name(author),
                 'email': author.findtext('address/email'),
                 'affiliation': author.findtext('organization'),
             }


### PR DESCRIPTION
This adds logic similar to what is used in xml2rfc's `TextWriter` to render an author name from the `initials` and/or `surname` fields when `fullname` is not present.

I've also updated places where we display the name to account for the possibility that the name is absent. If possible, I show the affiliation instead. This again matches what `TextWriter` does when rendering an RFC.

@russhousley 