### PR TITLE
chore: scoutapm shutdown fix

### DIFF
--- a/k8s/celery.yaml
+++ b/k8s/celery.yaml
@@ -26,6 +26,15 @@ spec:
         - name: scoutapm
           image: "scoutapp/scoutapm:version-1.4.0"
           imagePullPolicy: IfNotPresent
+          # Replace command with one that will shut down on a TERM signal
+          # The ./core-agent start command line is from the scoutapm docker image
+          command:
+            - "sh"
+            - "-c"
+            - >-
+              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
+              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
+              wait $!
           livenessProbe:
             exec:
               command:

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -24,6 +24,15 @@ spec:
         - name: scoutapm
           image: "scoutapp/scoutapm:version-1.4.0"
           imagePullPolicy: IfNotPresent
+          # Replace command with one that will shut down on a TERM signal
+          # The ./core-agent start command line is from the scoutapm docker image
+          command:
+            - "sh"
+            - "-c"
+            - >-
+              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
+              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
+              wait $!
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
Shuts down the core agent in response to a TERM signal for compatibility with Docker's shutdown protocol.