### PR TITLE
fix: fewer ipr bounce alerts

### DIFF
--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -789,12 +789,7 @@ Subject: test
         
         mock_process_response_email.side_effect = None
         mock_process_response_email.return_value = None  # rejected message
-        with self.assertRaises(EmailIngestionError) as context:
-            ingest_response_email(message)
-        self.assertIsNone(context.exception.email_recipients)  # default recipients
-        self.assertIsNotNone(context.exception.email_body)  # body set
-        self.assertIsNotNone(context.exception.email_original_message)  # original message attached
-        self.assertEqual(context.exception.email_attach_traceback, True)
+        ingest_response_email(message)  # should _not_ send an exception email on a clean rejection
         self.assertTrue(mock_process_response_email.called)
         self.assertEqual(mock_process_response_email.call_args, mock.call(message))
         mock_process_response_email.reset_mock()

--- a/ietf/ipr/utils.py
+++ b/ietf/ipr/utils.py
@@ -92,7 +92,7 @@ def generate_draft_recursive_txt():
 def ingest_response_email(message: bytes):
     from ietf.api.views import EmailIngestionError  # avoid circular import
     try:
-        result = process_response_email(message)
+        process_response_email(message)
     except Exception as err:
         raise EmailIngestionError(
             "Datatracker IPR email ingestion error",
@@ -104,15 +104,3 @@ def ingest_response_email(message: bytes):
             email_original_message=message,
             email_attach_traceback=True,
         ) from err
-    
-    if result is None:
-        raise EmailIngestionError(
-            "Datatracker IPR email ingestion rejected",
-            email_body=dedent("""\
-            A message was rejected while ingesting IPR email into the Datatracker. The original message is attached.
-
-            {error_summary}
-            """),
-            email_original_message=message,
-            email_attach_traceback=True,
-        )


### PR DESCRIPTION
This should send IPR delivery failed alerts to the admins in the same circumstances that the old management command did. I.e., it will only send the alert on an unhandled exception, not on any failure to accept the IPR message.