### PR TITLE
fix: remove is_secure() check

### DIFF
--- a/ietf/sync/views.py
+++ b/ietf/sync/views.py
@@ -52,6 +52,8 @@ def notify(request, org, notification):
     password = request.POST.get("password") or request.GET.get("password")
 
     if username != None and password != None:
+        # Used to reject non-https traffic here, but that's now enforced by a domain-wide upgrade
+        # from http to https. Django's request.is_secure() is always False now.
         if not user.is_authenticated:
             try:
                 user = User.objects.get(username__iexact=username)


### PR DESCRIPTION
The real work happened in a previous commit, just nudging the patch version with this CC message.