### PR TITLE
fix: use system temp dir, not /a/tmp

### DIFF
--- a/ietf/idindex/tasks.py
+++ b/ietf/idindex/tasks.py
@@ -57,7 +57,7 @@ def idindex_update_task():
     ftp_path = Path(settings.FTP_DIR) / "internet-drafts"
     all_archive_path = Path(settings.INTERNET_ALL_DRAFTS_ARCHIVE_DIR)
 
-    with TempFileManager("/a/tmp") as tmp_mgr:
+    with TempFileManager() as tmp_mgr:
         # Generate copies of new contents
         all_id_content = all_id_txt()
         all_id_tmpfile = tmp_mgr.make_temp_file(all_id_content)

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -821,8 +821,6 @@ IDSUBMIT_MAX_VALIDATION_TIME = datetime.timedelta(minutes=20)
 # Age at which a submission expires if not posted
 IDSUBMIT_EXPIRATION_AGE = datetime.timedelta(days=14)
 
-IDSUBMIT_MANUAL_STAGING_DIR = '/tmp/'
-
 IDSUBMIT_FILE_TYPES = (
     'txt',
     'html',


### PR DESCRIPTION
n.b., also removes an unused setting that happened to be `/tmp/`