### PR TITLE
fix: signal rejected IPR response emails

### DIFF
--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -789,7 +789,9 @@ Subject: test
         
         mock_process_response_email.side_effect = None
         mock_process_response_email.return_value = None  # rejected message
-        ingest_response_email(message)  # should _not_ send an exception email on a clean rejection
+        with self.assertRaises(EmailIngestionError) as context:
+            ingest_response_email(message)
+        self.assertIsNone(context.exception.as_emailmessage())  # should not send an email on a clean rejection
         self.assertTrue(mock_process_response_email.called)
         self.assertEqual(mock_process_response_email.call_args, mock.call(message))
         mock_process_response_email.reset_mock()

--- a/ietf/ipr/utils.py
+++ b/ietf/ipr/utils.py
@@ -92,8 +92,10 @@ def generate_draft_recursive_txt():
 def ingest_response_email(message: bytes):
     from ietf.api.views import EmailIngestionError  # avoid circular import
     try:
-        process_response_email(message)
+        result = process_response_email(message)
     except Exception as err:
+        # Message was rejected due to an unhandled exception. This is likely something
+        # the admins need to address, so send them a copy of the email.
         raise EmailIngestionError(
             "Datatracker IPR email ingestion error",
             email_body=dedent("""\
@@ -104,3 +106,8 @@ def ingest_response_email(message: bytes):
             email_original_message=message,
             email_attach_traceback=True,
         ) from err
+
+    if result is None:
+        # Message was rejected due to some problem the sender can fix, so bounce but don't send
+        # an email to the admins
+        raise EmailIngestionError("IPR response rejected", email_body=None)


### PR DESCRIPTION
Fixes #7563 

Will signal to the sender (by way of the ingestion API) that their message was rejected but not email the admins.

If the message triggers an unhandled exception, an email to the admins will be sent along with the rejection to the sender.