### PR TITLE
ci: run migrations via init container

### DIFF
--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -17,6 +17,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/s
 COPY . .
 COPY ./dev/build/start.sh ./start.sh
 COPY ./dev/build/datatracker-start.sh ./datatracker-start.sh
+COPY ./dev/build/migration-start.sh ./migration-start.sh
 COPY ./dev/build/celery-start.sh ./celery-start.sh
 COPY ./dev/build/gunicorn.conf.py ./gunicorn.conf.py
 
@@ -27,6 +28,7 @@ RUN pip3 --disable-pip-version-check --no-cache-dir install -r requirements.txt 
 
 RUN chmod +x start.sh && \
     chmod +x datatracker-start.sh && \
+    chmod +x migration-start.sh && \
     chmod +x celery-start.sh && \
     chmod +x docker/scripts/app-create-dirs.sh && \
     sh ./docker/scripts/app-create-dirs.sh

--- a/dev/build/celery-start.sh
+++ b/dev/build/celery-start.sh
@@ -13,6 +13,8 @@ if ! ietf/manage.py migrate --skip-checks --check ; then
     done
 fi
 
+echo "Starting Celery..."
+
 cleanup () {
   # Cleanly terminate the celery app by sending it a TERM, then waiting for it to exit.
   if [[ -n "${celery_pid}" ]]; then

--- a/dev/build/celery-start.sh
+++ b/dev/build/celery-start.sh
@@ -8,7 +8,8 @@ echo "Running Datatracker checks..."
 if ! ietf/manage.py migrate --skip-checks --check ; then
     echo "Unapplied migrations found, waiting to start..."
     sleep 5
-    while ! ietf/manage.py migrate --skip-checks --check ; do 
+    while ! ietf/manage.py migrate --skip-checks --check ; do
+        echo "... still waiting for migrations..."
         sleep 5
     done
 fi

--- a/dev/build/datatracker-start.sh
+++ b/dev/build/datatracker-start.sh
@@ -7,6 +7,7 @@ if ! ietf/manage.py migrate --skip-checks --check ; then
     echo "Unapplied migrations found, waiting to start..."
     sleep 5
     while ! ietf/manage.py migrate --skip-checks --check ; do 
+        echo "... still waiting for migrations..."
         sleep 5
     done
 fi

--- a/dev/build/datatracker-start.sh
+++ b/dev/build/datatracker-start.sh
@@ -3,8 +3,13 @@
 echo "Running Datatracker checks..."
 ./ietf/manage.py check
 
-echo "Running Datatracker migrations..."
-./ietf/manage.py migrate --skip-checks --settings=settings_local
+if ! ietf/manage.py migrate --skip-checks --check ; then
+    echo "Unapplied migrations found, waiting to start..."
+    sleep 5
+    while ! ietf/manage.py migrate --skip-checks --check ; do 
+        sleep 5
+    done
+fi
 
 echo "Starting Datatracker..."
 

--- a/dev/build/migration-start.sh
+++ b/dev/build/migration-start.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-echo "Running Datatracker checks..."
-./ietf/manage.py check
-
 echo "Running Datatracker migrations..."
 ./ietf/manage.py migrate --skip-checks --settings=settings_local
 

--- a/dev/build/migration-start.sh
+++ b/dev/build/migration-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Running Datatracker checks..."
+./ietf/manage.py check
+
+echo "Running Datatracker migrations..."
+./ietf/manage.py migrate --skip-checks --settings=settings_local
+
+echo "Done!"

--- a/dev/build/start.sh
+++ b/dev/build/start.sh
@@ -5,14 +5,20 @@
 #  CONTAINER_ROLE - datatracker, celery, or beat (defaults to datatracker)
 #
 case "${CONTAINER_ROLE:-datatracker}" in
-    datatracker)
+    auth)
         exec ./datatracker-start.sh
+        ;;
+    beat)
+        exec ./celery-start.sh --app=ietf beat
         ;;
     celery)
         exec ./celery-start.sh --app=ietf worker
         ;;
-    beat)
-        exec ./celery-start.sh --app=ietf beat
+    datatracker)
+        exec ./datatracker-start.sh
+        ;;
+    migrations)
+        exec ./migration-start.sh
         ;;
     *)
         echo "Unknown role '${CONTAINER_ROLE}'"

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -82,6 +82,35 @@ spec:
             readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 1000
+      initContainers:
+        - name: migration
+          image: "ghcr.io/ietf-tools/datatracker:$APP_IMAGE_TAG"
+          env:
+            - name: "CONTAINER_ROLE"
+              value: "migrations"
+          envFrom:
+            - configMapRef:
+                name: django-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          volumeMounts:
+            - name: dt-vol
+              mountPath: /a
+            - name: dt-tmp
+              mountPath: /tmp
+            - name: dt-home
+              mountPath: /home/datatracker
+            - name: dt-xml2rfc-cache
+              mountPath: /var/cache/xml2rfc
+            - name: dt-cfg
+              mountPath: /workspace/ietf/settings_local.py
+              subPath: settings_local.py
       volumes:
         # To be overriden with the actual shared volume
         - name: dt-vol


### PR DESCRIPTION
This splits migrations out of the datatracker pod into an init container and uses this to ensure that only datatracker pods (and not auth pods) run the migrations.

Alternatives would be to give the auth pod its own startup script that skips the migrations or to add conditionals to `datatracker-start.sh` that skip the migrations for the auth pods. I don't like introducing the conditionals down into the scripts, hence the approach here. (Though I don't like that we have to reproduce the container config for the datatracker container _again_ in the init container, either.)