### PR TITLE
ci: migrate to using secret instead of configmap

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,5 @@
+# Kustomize deployment
+
+## Run locally
+
+The `secrets.yaml` file is provided as a reference only and must be referenced manually in the `kustomization.yaml` file.

--- a/k8s/auth.yaml
+++ b/k8s/auth.yaml
@@ -19,34 +19,9 @@ spec:
         runAsNonRoot: true
       containers:
         # -----------------------------------------------------
-        # ScoutAPM Container
+        # Auth Container
         # -----------------------------------------------------
-        - name: scoutapm
-          image: "scoutapp/scoutapm:version-1.4.0"
-          imagePullPolicy: IfNotPresent
-          # Replace command with one that will shut down on a TERM signal
-          # The ./core-agent start command line is from the scoutapm docker image
-          command:
-            - "sh"
-            - "-c"
-            - >-
-              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
-              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
-              wait $!
-          livenessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 65534 # "nobody" user by default
-            runAsGroup: 65534  # "nogroup" group by default
-        # -----------------------------------------------------
-        # Datatracker Container
-        # -----------------------------------------------------
-        - name: datatracker
+        - name: auth
           image: "ghcr.io/ietf-tools/datatracker:$APP_IMAGE_TAG"
           imagePullPolicy: Always
           ports:
@@ -72,8 +47,8 @@ spec:
             - name: "DEPLOY_UID"
               value: "$DEPLOY_UID"
           envFrom:
-            - configMapRef:
-                name: django-config
+            - secretRef:
+                name: dt-secrets-env
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -82,6 +57,31 @@ spec:
             readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 1000
+        # -----------------------------------------------------
+        # ScoutAPM Container
+        # -----------------------------------------------------
+        - name: scoutapm
+          image: "scoutapp/scoutapm:version-1.4.0"
+          imagePullPolicy: IfNotPresent
+          # Replace command with one that will shut down on a TERM signal
+          # The ./core-agent start command line is from the scoutapm docker image
+          command:
+            - "sh"
+            - "-c"
+            - >-
+              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
+              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
+              wait $!
+          livenessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 65534 # "nobody" user by default
+            runAsGroup: 65534  # "nogroup" group by default
       volumes:
         # To be overriden with the actual shared volume
         - name: dt-vol

--- a/k8s/beat.yaml
+++ b/k8s/beat.yaml
@@ -20,6 +20,9 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
+        # -----------------------------------------------------
+        # Beat Container
+        # -----------------------------------------------------
         - name: beat
           image: "ghcr.io/ietf-tools/datatracker:$APP_IMAGE_TAG"
           imagePullPolicy: Always
@@ -39,8 +42,8 @@ spec:
             - name: "CONTAINER_ROLE"
               value: "beat"
           envFrom:
-            - configMapRef:
-                name: django-config
+            - secretRef:
+                name: dt-secrets-env
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/k8s/celery.yaml
+++ b/k8s/celery.yaml
@@ -21,31 +21,6 @@ spec:
         runAsNonRoot: true
       containers:
         # -----------------------------------------------------
-        # ScoutAPM Container
-        # -----------------------------------------------------
-        - name: scoutapm
-          image: "scoutapp/scoutapm:version-1.4.0"
-          imagePullPolicy: IfNotPresent
-          # Replace command with one that will shut down on a TERM signal
-          # The ./core-agent start command line is from the scoutapm docker image
-          command:
-            - "sh"
-            - "-c"
-            - >-
-              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
-              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
-              wait $!
-          livenessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 65534 # "nobody" user by default
-            runAsGroup: 65534  # "nogroup" group by default
-        # -----------------------------------------------------
         # Celery Container
         # -----------------------------------------------------
         - name: celery
@@ -71,8 +46,8 @@ spec:
             - name: "CONTAINER_ROLE"
               value: "celery"
           envFrom:
-            - configMapRef:
-                name: django-config
+            - secretRef:
+                name: dt-secrets-env
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -81,6 +56,31 @@ spec:
             readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 1000
+        # -----------------------------------------------------
+        # ScoutAPM Container
+        # -----------------------------------------------------
+        - name: scoutapm
+          image: "scoutapp/scoutapm:version-1.4.0"
+          imagePullPolicy: IfNotPresent
+          # Replace command with one that will shut down on a TERM signal
+          # The ./core-agent start command line is from the scoutapm docker image
+          command:
+            - "sh"
+            - "-c"
+            - >-
+              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
+              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
+              wait $!
+          livenessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 65534 # "nobody" user by default
+            runAsGroup: 65534  # "nogroup" group by default
       volumes:
         # To be overriden with the actual shared volume
         - name: dt-vol

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -19,31 +19,6 @@ spec:
         runAsNonRoot: true
       containers:
         # -----------------------------------------------------
-        # ScoutAPM Container
-        # -----------------------------------------------------
-        - name: scoutapm
-          image: "scoutapp/scoutapm:version-1.4.0"
-          imagePullPolicy: IfNotPresent
-          # Replace command with one that will shut down on a TERM signal
-          # The ./core-agent start command line is from the scoutapm docker image
-          command:
-            - "sh"
-            - "-c"
-            - >-
-              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
-              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
-              wait $!
-          livenessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 65534 # "nobody" user by default
-            runAsGroup: 65534  # "nogroup" group by default
-        # -----------------------------------------------------
         # Datatracker Container
         # -----------------------------------------------------
         - name: datatracker
@@ -72,8 +47,8 @@ spec:
             - name: "DEPLOY_UID"
               value: "$DEPLOY_UID"
           envFrom:
-            - configMapRef:
-                name: django-config
+            - secretRef:
+                name: dt-secrets-env
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -82,6 +57,31 @@ spec:
             readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 1000
+        # -----------------------------------------------------
+        # ScoutAPM Container
+        # -----------------------------------------------------
+        - name: scoutapm
+          image: "scoutapp/scoutapm:version-1.4.0"
+          imagePullPolicy: IfNotPresent
+          # Replace command with one that will shut down on a TERM signal
+          # The ./core-agent start command line is from the scoutapm docker image
+          command:
+            - "sh"
+            - "-c"
+            - >-
+              trap './core-agent shutdown --tcp 0.0.0.0:6590' TERM;
+              ./core-agent start --daemonize false --log-level debug --tcp 0.0.0.0:6590 &
+              wait $!
+          livenessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "./core-agent probe --tcp 0.0.0.0:6590 | grep -q 'Agent found'"
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 65534 # "nobody" user by default
+            runAsGroup: 65534  # "nogroup" group by default
       initContainers:
         - name: migration
           image: "ghcr.io/ietf-tools/datatracker:$APP_IMAGE_TAG"

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -9,6 +9,5 @@ resources:
   - beat.yaml
   - celery.yaml
   - datatracker.yaml
-  - django-config.yaml
   - memcached.yaml
   - rabbitmq.yaml

--- a/k8s/memcached.yaml
+++ b/k8s/memcached.yaml
@@ -16,21 +16,9 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-        - image: "quay.io/prometheus/memcached-exporter:v0.14.3"
-          imagePullPolicy: IfNotPresent
-          name: memcached-exporter
-          ports:
-            - name: metrics
-              containerPort: 9150
-              protocol: TCP
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsUser: 65534  # nobody
-            runAsGroup: 65534  # nobody
+        # -----------------------------------------------------
+        # Memcached
+        # -----------------------------------------------------
         - image: "memcached:1.6-alpine"
           imagePullPolicy: IfNotPresent
           args: ["-m", "1024"]
@@ -48,6 +36,24 @@ spec:
             # memcached image sets up uid/gid 11211
             runAsUser: 11211
             runAsGroup: 11211
+        # -----------------------------------------------------
+        # Memcached Exporter for Prometheus
+        # -----------------------------------------------------
+        - image: "quay.io/prometheus/memcached-exporter:v0.14.3"
+          imagePullPolicy: IfNotPresent
+          name: memcached-exporter
+          ports:
+            - name: metrics
+              containerPort: 9150
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: 65534  # nobody
+            runAsGroup: 65534  # nobody
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30

--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -15,23 +15,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-      initContainers:
-        # -----------------------------------------------------
-        # Init RabbitMQ data
-        # -----------------------------------------------------
-        - name: init-rabbitmq
-          image: busybox:stable
-          command:
-            - "sh"
-            - "-c"
-            - "mkdir -p -m700 /mnt/rabbitmq && chown 100:101 /mnt/rabbitmq"
-          securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
-            readOnlyRootFilesystem: true
-          volumeMounts:
-            - name: "rabbitmq-data"
-              mountPath: "/mnt"
       containers:
         # -----------------------------------------------------
         # RabbitMQ Container
@@ -52,8 +35,11 @@ spec:
             - name: rabbitmq-config
               mountPath: "/etc/rabbitmq"
           env:
-            - name: "CELERY_PASSWORD"
-              value: "this-is-a-secret"
+            - name: CELERY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dt-secrets-env
+                  key: CELERY_PASSWORD
           livenessProbe:
             exec:
               command: ["rabbitmq-diagnostics", "-q", "ping"]
@@ -76,6 +62,23 @@ spec:
             # rabbitmq image sets up uid/gid 100/101
             runAsUser: 100
             runAsGroup: 101
+      initContainers:
+        # -----------------------------------------------------
+        # Init RabbitMQ data
+        # -----------------------------------------------------
+        - name: init-rabbitmq
+          image: busybox:stable
+          command:
+            - "sh"
+            - "-c"
+            - "mkdir -p -m700 /mnt/rabbitmq && chown 100:101 /mnt/rabbitmq"
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: "rabbitmq-data"
+              mountPath: "/mnt"
       volumes:
         - name: rabbitmq-tmp
           emptyDir:

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: django-config
-data:
-    # n.b., these are debug values / non-secret secrets
+  name: secrets-env
+type: Opaque
+stringData:
   DATATRACKER_SERVER_MODE: "development"  # development for staging, production for production
   DATATRACKER_ADMINS: |-
     Robert Sparks <rjsparks@nostrum.com>


### PR DESCRIPTION
- Use secret instead of configmap
- Move non-primary containers further down, so that the correct image is displayed in Portainer