### PR TITLE
fix: Exclude replaced documents from IESG discusses

### DIFF
--- a/ietf/iesg/tests.py
+++ b/ietf/iesg/tests.py
@@ -52,6 +52,15 @@ class IESGTests(TestCase):
         self.assertContains(r, draft.name)
         self.assertContains(r, escape(pos.balloter.plain_name()))
 
+        # Mark draft as replaced
+        draft.set_state(State.objects.get(type="draft", slug="repl"))
+
+        r = self.client.get(urlreverse("ietf.iesg.views.discusses"))
+        self.assertEqual(r.status_code, 200)
+
+        self.assertNotContains(r, draft.name)
+        self.assertNotContains(r, escape(pos.balloter.plain_name()))
+
     def test_milestones_needing_review(self):
         draft = WgDraftFactory()
         RoleFactory(name_id='ad',group=draft.group,person=Person.objects.get(user__username='ad'))

--- a/ietf/iesg/views.py
+++ b/ietf/iesg/views.py
@@ -483,7 +483,7 @@ def discusses(request):
                                             models.Q(states__type__in=("statchg", "conflrev"),
                                                      states__slug__in=("iesgeval", "defer")),
                                             docevent__ballotpositiondocevent__pos__blocking=True)
-    possible_docs = possible_docs.exclude(states__type="draft", states__slug="repl")
+    possible_docs = possible_docs.exclude(states__in=State.objects.filter(type="draft", slug="repl"))
     possible_docs = possible_docs.select_related("stream", "group", "ad").distinct()
 
     docs = []

--- a/ietf/iesg/views.py
+++ b/ietf/iesg/views.py
@@ -483,6 +483,7 @@ def discusses(request):
                                             models.Q(states__type__in=("statchg", "conflrev"),
                                                      states__slug__in=("iesgeval", "defer")),
                                             docevent__ballotpositiondocevent__pos__blocking=True)
+    possible_docs = possible_docs.exclude(states__type="draft", states__slug="repl")
     possible_docs = possible_docs.select_related("stream", "group", "ad").distinct()
 
     docs = []


### PR DESCRIPTION
Fixes #7179. 

I'm retaining @pselkirk's commit from the PR, https://github.com/ietf-tools/datatracker/pull/7258.

I've updated the existing test, `ietf.iesg.tests.IESGTests.test_feed`, to ensure that replaced documents from IESG discusses are correctly filtered.

```sh
ietf/manage.py test ietf.iesg.tests.IESGTests.test_feed --settings=settings_test
```
```
...
Ran 7 tests in 18.513s

OK
```