### PR TITLE
feat: Expose important library versions

### DIFF
--- a/ietf/__init__.py
+++ b/ietf/__init__.py
@@ -35,21 +35,6 @@ if __version__ == '1.0.0-dev' and __release_hash__ == '' and __release_branch__ 
     __release_branch__ = branch
     __release_hash__ = git_hash
 
-# important libraries
-__version_extra__ = {}
-# xml2rfc
-try:
-    import xml2rfc
-    __version_extra__['xml2rfc'] = xml2rfc.__version__
-except Exception:
-    pass
-
-# weasyprint
-try:
-    import weasyprint
-    __version_extra__['weasyprint'] = weasyprint.__version__
-except Exception:
-    pass
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.

--- a/ietf/__init__.py
+++ b/ietf/__init__.py
@@ -35,6 +35,21 @@ if __version__ == '1.0.0-dev' and __release_hash__ == '' and __release_branch__ 
     __release_branch__ = branch
     __release_hash__ = git_hash
 
+# important libraries
+__version_extra__ = {}
+# xml2rfc
+try:
+    import xml2rfc
+    __version_extra__['xml2rfc'] = xml2rfc.__version__
+except Exception:
+    pass
+
+# weasyprint
+try:
+    import weasyprint
+    __version_extra__['weasyprint'] = weasyprint.__version__
+except Exception:
+    pass
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -936,11 +936,14 @@ class CustomApiTests(TestCase):
         r = self.client.get(url)
         data = r.json()
         self.assertEqual(data['version'], ietf.__version__+ietf.__patch__)
+        self.assertEqual(data['other']['xml2rfc'], ietf.__version_extra__['xml2rfc'])
+        self.assertEqual(data['other']['weasyprint'], ietf.__version_extra__['weasyprint'])
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 +0000")
         DumpInfo.objects.update(tz='PST8PDT')
         r = self.client.get(url)
         data = r.json()        
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 -0700")
+
 
 
     def test_api_appauth(self):

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -936,7 +936,7 @@ class CustomApiTests(TestCase):
         r = self.client.get(url)
         data = r.json()
         self.assertEqual(data['version'], ietf.__version__+ietf.__patch__)
-        for lib in settings.IMPORTANT_LIBRARIES:
+        for lib in settings.ADVERTISE_VERSIONS:
             self.assertIn(lib, data['other'])
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 +0000")
         DumpInfo.objects.update(tz='PST8PDT')

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -936,8 +936,8 @@ class CustomApiTests(TestCase):
         r = self.client.get(url)
         data = r.json()
         self.assertEqual(data['version'], ietf.__version__+ietf.__patch__)
-        self.assertEqual(data['other']['xml2rfc'], ietf.__version_extra__['xml2rfc'])
-        self.assertEqual(data['other']['weasyprint'], ietf.__version_extra__['weasyprint'])
+        for lib in settings.IMPORTANT_LIBRARIES:
+            self.assertIn(lib, data['other'])
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 +0000")
         DumpInfo.objects.update(tz='PST8PDT')
         r = self.client.get(url)

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -945,7 +945,6 @@ class CustomApiTests(TestCase):
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 -0700")
 
 
-
     def test_api_appauth(self):
         for app in ["authortools", "bibxml"]:
             url = urlreverse('ietf.api.views.app_auth', kwargs={"app": app})

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -243,6 +243,7 @@ def version(request):
     return HttpResponse(
             json.dumps({
                         'version': ietf.__version__+ietf.__patch__,
+                        'other': ietf.__version_extra__,
                         'dumptime': dumptime,
                     }),
                 content_type='application/json',

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -244,7 +244,7 @@ def version(request):
 
     # important libraries
     __version_extra__ = {}
-    for lib in settings.IMPORTANT_LIBRARIES:
+    for lib in settings.ADVERTISE_VERSIONS:
         __version_extra__[lib] = metadata_version(lib)
 
     return HttpResponse(

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -23,6 +23,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.gzip import gzip_page
 from django.views.generic.detail import DetailView
 from email.message import EmailMessage
+from importlib.metadata import version as metadata_version
 from jwcrypto.jwk import JWK
 from tastypie.exceptions import BadRequest
 from tastypie.serializers import Serializer
@@ -240,10 +241,16 @@ def version(request):
         if dumpinfo.tz != "UTC":
             dumpdate = pytz.timezone(dumpinfo.tz).localize(dumpinfo.date.replace(tzinfo=None))
     dumptime = dumpdate.strftime('%Y-%m-%d %H:%M:%S %z') if dumpinfo else None
+
+    # important libraries
+    __version_extra__ = {}
+    for lib in settings.IMPORTANT_LIBRARIES:
+        __version_extra__[lib] = metadata_version(lib)
+
     return HttpResponse(
             json.dumps({
                         'version': ietf.__version__+ietf.__patch__,
-                        'other': ietf.__version_extra__,
+                        'other': __version_extra__,
                         'dumptime': dumptime,
                     }),
                 content_type='application/json',

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1279,6 +1279,8 @@ if "CACHES" not in locals():
 
 PUBLISH_IPR_STATES = ['posted', 'removed', 'removed_objfalse']
 
+IMPORTANT_LIBRARIES = ["django", "celery", "lxml", "markdown", "psycopg2", "pyang", "rfc2html", "weasyprint", "xml2rfc"]
+
 # We provide a secret key only for test and development modes.  It's
 # absolutely vital that django fails to start in production mode unless a
 # secret key has been provided elsewhere, not in this file which is

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1279,7 +1279,7 @@ if "CACHES" not in locals():
 
 PUBLISH_IPR_STATES = ['posted', 'removed', 'removed_objfalse']
 
-IMPORTANT_LIBRARIES = ["django", "celery", "lxml", "markdown", "psycopg2", "pyang", "rfc2html", "weasyprint", "xml2rfc"]
+IMPORTANT_LIBRARIES = ["markdown", "pyang", "rfc2html", "xml2rfc"]
 
 # We provide a secret key only for test and development modes.  It's
 # absolutely vital that django fails to start in production mode unless a

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1279,7 +1279,7 @@ if "CACHES" not in locals():
 
 PUBLISH_IPR_STATES = ['posted', 'removed', 'removed_objfalse']
 
-IMPORTANT_LIBRARIES = ["markdown", "pyang", "rfc2html", "xml2rfc"]
+ADVERTISE_VERSIONS = ["markdown", "pyang", "rfc2html", "xml2rfc"]
 
 # We provide a secret key only for test and development modes.  It's
 # absolutely vital that django fails to start in production mode unless a


### PR DESCRIPTION
Update `/api/version` to include

```
"other": {
    "xml2rfc": "<version>",
    "weasyprint": "<version>"
},
```

Fixes #3415