### PR TITLE
fix: Explicitly set `executable_path` for Selenium

### DIFF
--- a/ietf/utils/jstest.py
+++ b/ietf/utils/jstest.py
@@ -30,7 +30,7 @@ if skip_selenium:
     print("     "+skip_message)
 
 def start_web_driver():
-    service = Service(log_output=f"{executable_name}.log", service_args=['--log-no-truncate'])
+    service = Service(executable_path=f"/usr/bin/geckodriver", log_output=f"{executable_name}.log", service_args=['--log-no-truncate'])
     options = Options()
     options.add_argument("--headless")
     os.environ["MOZ_REMOTE_SETTINGS_DEVTOOLS"] = "1"
@@ -54,14 +54,14 @@ class IetfSeleniumTestCase(IetfLiveServerTestCase):
         super(IetfSeleniumTestCase, self).setUp()
         self.driver = start_web_driver()
         self.driver.set_window_size(1024,768)
-    
+
     def tearDown(self):
         super(IetfSeleniumTestCase, self).tearDown()
         self.driver.close()
 
     def absreverse(self,*args,**kwargs):
         return '%s%s'%(self.live_server_url, urlreverse(*args, **kwargs))
-    
+
     def debug_snapshot(self,filename='debug_this.png'):
         self.driver.execute_script("document.body.bgColor = 'white';")
         self.driver.save_screenshot(filename)

--- a/ietf/utils/jstest.py
+++ b/ietf/utils/jstest.py
@@ -30,7 +30,7 @@ if skip_selenium:
     print("     "+skip_message)
 
 def start_web_driver():
-    service = Service(executable_path=f"/usr/bin/geckodriver", log_output=f"{executable_name}.log", service_args=['--log-no-truncate'])
+    service = Service(executable_path=f"/usr/bin/{executable_name}", log_output=f"{executable_name}.log", service_args=['--log-no-truncate'])
     options = Options()
     options.add_argument("--headless")
     os.environ["MOZ_REMOTE_SETTINGS_DEVTOOLS"] = "1"

--- a/ietf/utils/jstest.py
+++ b/ietf/utils/jstest.py
@@ -54,14 +54,14 @@ class IetfSeleniumTestCase(IetfLiveServerTestCase):
         super(IetfSeleniumTestCase, self).setUp()
         self.driver = start_web_driver()
         self.driver.set_window_size(1024,768)
-
+    
     def tearDown(self):
         super(IetfSeleniumTestCase, self).tearDown()
         self.driver.close()
 
     def absreverse(self,*args,**kwargs):
         return '%s%s'%(self.live_server_url, urlreverse(*args, **kwargs))
-
+    
     def debug_snapshot(self,filename='debug_this.png'):
         self.driver.execute_script("document.body.bgColor = 'white';")
         self.driver.save_screenshot(filename)


### PR DESCRIPTION
So it finds `geckodriver` again.