### PR TITLE
fix: Add rows for recordings to interim meeting materials

### DIFF
--- a/ietf/templates/meeting/session_details_panel.html
+++ b/ietf/templates/meeting/session_details_panel.html
@@ -320,7 +320,7 @@
                 </tr>
             {% endif %}
             {# Recordings #}
-            {% if meeting.number|add:"0" >= 80 %}
+            {% if meeting.type.slug == 'interim' or meeting.number|add:"0" >= 80 %}
                 {% with session.recordings as recordings %}
                     {% if recordings %}
                         {# There's no guaranteed order, so this is a bit messy: #}


### PR DESCRIPTION
Add rows for interim meeting recordings. Fixes #7699.