### PR TITLE
fix: Hide last modified field in agenda when unavailable

### DIFF
--- a/client/agenda/Agenda.vue
+++ b/client/agenda/Agenda.vue
@@ -323,7 +323,7 @@ const meetingUpdated = computed(() => {
   if (!agendaStore.meeting.updated) { return false }
   
   const updatedDatetime = DateTime.fromISO(agendaStore.meeting.updated).setZone(agendaStore.timezone)
-  if (!updatedDatetime.isValid || updatedDatetime < DateTime.fromISO('1980-01-01')) {
+  if (!updatedDatetime.isValid) {
     return false
   }
   

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -375,9 +375,8 @@ class Meeting(models.Model):
         if self.schedule:
             assignments_updated = SchedTimeSessAssignment.objects.filter(schedule__in=[self.schedule, self.schedule.base if self.schedule else None]).aggregate(Max('modified'))["modified__max"]
         dts = [timeslots_updated, sessions_updated, assignments_updated]
-        if valid_only := [dt for dt in dts if dt is not None]:
-            return max(valid_only)
-        return None
+        valid_only = [dt for dt in dts if dt is not None]
+        return max(valid_only) if valid_only else None
 
     @memoize
     def previous_meeting(self):

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -369,7 +369,6 @@ class MeetingTests(BaseMeetingTestCase):
         self.assertContains(r, session.materials.get(type='agenda').uploaded_filename)
         self.assertContains(r, session.materials.filter(type='slides').exclude(states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
         self.assertNotContains(r, session.materials.filter(type='slides',states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
-        self.assertNotContains(r, "Updated ")  # Updated not used in CSV version
 
         # CSV, utc
         r = self.client.get(urlreverse(
@@ -391,7 +390,6 @@ class MeetingTests(BaseMeetingTestCase):
         self.assertContains(r, session.materials.get(type='agenda').uploaded_filename)
         self.assertContains(r, session.materials.filter(type='slides').exclude(states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
         self.assertNotContains(r, session.materials.filter(type='slides',states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
-        self.assertNotContains(r, "Updated ")  # Updated not used in CSV version
 
         # iCal, no session filtering
         ical_url = urlreverse("ietf.meeting.views.agenda_ical", kwargs=dict(num=meeting.number))

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -294,6 +294,8 @@ class MeetingTests(BaseMeetingTestCase):
             (slot.time + slot.duration).astimezone(meeting.tz()).strftime("%H%M"),
         ))
         self.assertContains(r, f"shown in the {meeting.tz()} time zone")
+        updated = meeting.updated().astimezone(meeting.tz()).strftime("%Y-%m-%d %H:%M:%S %Z")
+        self.assertContains(r, f"Updated {updated}")
 
         # text, UTC
         r = self.client.get(urlreverse(
@@ -309,6 +311,8 @@ class MeetingTests(BaseMeetingTestCase):
             (slot.time + slot.duration).astimezone(datetime.timezone.utc).strftime("%H%M"),
         ))
         self.assertContains(r, "shown in UTC")
+        updated = meeting.updated().astimezone(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
+        self.assertContains(r, f"Updated {updated}")
 
         # future meeting, no agenda
         r = self.client.get(urlreverse("ietf.meeting.views.agenda_plain", kwargs=dict(num=future_meeting.number, ext=".txt")))
@@ -332,6 +336,7 @@ class MeetingTests(BaseMeetingTestCase):
         self.assertContains(r, session.materials.get(type='agenda').uploaded_filename)
         self.assertContains(r, session.materials.filter(type='slides').exclude(states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
         self.assertNotContains(r, session.materials.filter(type='slides',states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
+        self.assertNotContains(r, "Updated ")  # Updated not used in CSV version
 
         # CSV, utc
         r = self.client.get(urlreverse(
@@ -353,6 +358,7 @@ class MeetingTests(BaseMeetingTestCase):
         self.assertContains(r, session.materials.get(type='agenda').uploaded_filename)
         self.assertContains(r, session.materials.filter(type='slides').exclude(states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
         self.assertNotContains(r, session.materials.filter(type='slides',states__type__slug='slides',states__slug='deleted').first().uploaded_filename)
+        self.assertNotContains(r, "Updated ")  # Updated not used in CSV version
 
         # iCal, no session filtering
         ical_url = urlreverse("ietf.meeting.views.agenda_ical", kwargs=dict(num=meeting.number))

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -314,38 +314,13 @@ class MeetingTests(BaseMeetingTestCase):
         updated = meeting.updated().astimezone(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
         self.assertContains(r, f"Updated {updated}")
 
-        # text, invalid updated (1)
-        with patch(
-            "ietf.meeting.models.Meeting.updated",
-            return_value=pytz.utc.localize(datetime.datetime(1970, 1, 1, 0, 0, 0)),
-        ):
+        # text, invalid updated (none)
+        with patch("ietf.meeting.models.Meeting.updated", return_value=None):
             r = self.client.get(urlreverse(
                 "ietf.meeting.views.agenda_plain",
                 kwargs=dict(num=meeting.number, ext=".txt", utc="-utc"),
             ))
             self.assertNotContains(r, "Updated ")
-
-        # text, invalid updated (2)
-        with patch(
-            "ietf.meeting.models.Meeting.updated",
-            return_value=pytz.utc.localize(datetime.datetime(1979, 12, 31, 23, 59, 59)),
-        ):
-            r = self.client.get(urlreverse(
-                "ietf.meeting.views.agenda_plain",
-                kwargs=dict(num=meeting.number, ext=".txt", utc="-utc"),
-            ))
-            self.assertNotContains(r, "Updated ")
-
-        # text, valid updated
-        with patch(
-            "ietf.meeting.models.Meeting.updated",
-            return_value=pytz.utc.localize(datetime.datetime(1980, 1, 1, 0, 0, 0)),
-        ):
-            r = self.client.get(urlreverse(
-                "ietf.meeting.views.agenda_plain",
-                kwargs=dict(num=meeting.number, ext=".txt", utc="-utc"),
-            ))
-            self.assertContains(r, "Updated 1980-01-01 00:00:00 UTC")
 
         # future meeting, no agenda
         r = self.client.get(urlreverse("ietf.meeting.views.agenda_plain", kwargs=dict(num=future_meeting.number, ext=".txt")))
@@ -895,6 +870,24 @@ class MeetingTests(BaseMeetingTestCase):
         r = self.client.get(url)
         for d in meeting.importantdate_set.all():
             self.assertContains(r, d.date.isoformat())
+
+        updated = meeting.updated()
+        self.assertIsNotNone(updated)
+        expected_updated = updated.astimezone(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        self.assertContains(r, f"DTSTAMP:{expected_updated}")
+        dtstamps_count = r.content.decode("utf-8").count(f"DTSTAMP:{expected_updated}")
+        self.assertEqual(dtstamps_count, meeting.importantdate_set.count())
+
+        # With default cached_updated, 1970-01-01
+        with patch("ietf.meeting.models.Meeting.updated", return_value=None):
+            r = self.client.get(url)
+            for d in meeting.importantdate_set.all():
+                self.assertContains(r, d.date.isoformat())
+
+            expected_updated = "19700101T000000Z"
+            self.assertContains(r, f"DTSTAMP:{expected_updated}")
+            dtstamps_count = r.content.decode("utf-8").count(f"DTSTAMP:{expected_updated}")
+            self.assertEqual(dtstamps_count, meeting.importantdate_set.count())
 
     def test_group_ical(self):
         meeting = make_meeting_test_data()
@@ -4989,7 +4982,23 @@ class InterimTests(TestCase):
                                       expected_event_count=len(expected_event_summaries))
         self.assertNotContains(r, 'Remote instructions:')
 
-    def test_upcoming_ical_filter(self):
+        updated = meeting.updated()
+        self.assertIsNotNone(updated)
+        expected_updated = updated.astimezone(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        self.assertContains(r, f"DTSTAMP:{expected_updated}")
+
+        # With default cached_updated, 1970-01-01
+        with patch("ietf.meeting.models.Meeting.updated", return_value=None):
+            r = self.client.get(url)
+            self.assertEqual(r.status_code, 200)
+
+            self.assertEqual(meeting.type_id, "ietf")
+
+            expected_updated = "19700101T000000Z"
+            self.assertEqual(1, r.content.decode("utf-8").count(f"DTSTAMP:{expected_updated}"))
+
+    @patch("ietf.meeting.utils.preprocess_meeting_important_dates")
+    def test_upcoming_ical_filter(self, mock_preprocess_meeting_important_dates):
         # Just a quick check of functionality - details tested by test_js.InterimTests
         make_meeting_test_data(create_interims=True)
         url = urlreverse("ietf.meeting.views.upcoming_ical")
@@ -5011,6 +5020,8 @@ class InterimTests(TestCase):
                                       ],
                                       expected_event_count=2)
 
+        # Verify preprocess_meeting_important_dates isn't being called
+        mock_preprocess_meeting_important_dates.assert_not_called()
 
     def test_upcoming_json(self):
         make_meeting_test_data(create_interims=True)

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -609,7 +609,8 @@ def bulk_create_timeslots(meeting, times, locations, other_props):
 
 def preprocess_meeting_important_dates(meetings):
     for m in meetings:
-        m.cached_updated = m.updated()
+        # cached_updated must be present, set it to 1970-01-01 if necessary
+        m.cached_updated = m.updated() or pytz.utc.localize(datetime.datetime(1970, 1, 1, 0, 0, 0))
         m.important_dates = m.importantdate_set.prefetch_related("name")
         for d in m.important_dates:
             d.midnight_cutoff = "UTC 23:59" in d.name.name

--- a/ietf/templates/meeting/agenda.txt
+++ b/ietf/templates/meeting/agenda.txt
@@ -7,7 +7,9 @@
 {% filter center:72 %}{{ schedule.meeting.agenda_info_note|striptags|wordwrap:72|safe }}{% endfilter %}
 {% endif %}
 {% filter center:72 %}{{ schedule.meeting.date|date:"F j" }}-{% if schedule.meeting.date.month != schedule.meeting.end_date.month %}{{ schedule.meeting.end_date|date:"F " }}{% endif %}{{ schedule.meeting.end_date|date:"j, Y" }}{% endfilter %}
+{% if updated|date:"Y-m-d" >= "1980-01-01" %}
 {% filter center:72 %}Updated {{ updated|date:"Y-m-d H:i:s T" }}{% endfilter %}
+{% endif %}
 
 {% filter center:72 %}IETF agendas are subject to change, up to and during the meeting.{% endfilter %}
 {% filter center:72 %}Times are shown in {% if display_timezone.lower == "utc" %}UTC{% else %}the {{ display_timezone }} time zone{% endif %}.{% endfilter %}

--- a/ietf/templates/meeting/agenda.txt
+++ b/ietf/templates/meeting/agenda.txt
@@ -7,7 +7,7 @@
 {% filter center:72 %}{{ schedule.meeting.agenda_info_note|striptags|wordwrap:72|safe }}{% endfilter %}
 {% endif %}
 {% filter center:72 %}{{ schedule.meeting.date|date:"F j" }}-{% if schedule.meeting.date.month != schedule.meeting.end_date.month %}{{ schedule.meeting.end_date|date:"F " }}{% endif %}{{ schedule.meeting.end_date|date:"j, Y" }}{% endfilter %}
-{% if updated|date:"Y-m-d" >= "1980-01-01" %}
+{% if updated %}
 {% filter center:72 %}Updated {{ updated|date:"Y-m-d H:i:s T" }}{% endfilter %}
 {% endif %}
 


### PR DESCRIPTION
Fixes #3849 

The cut-over date is set to `1980-01-01` to be consistent with the behaviour of the JS client.

``` javascript
const updatedDatetime = DateTime.fromISO(agendaStore.meeting.updated).setZone(agendaStore.timezone)
if (!updatedDatetime.isValid || updatedDatetime < DateTime.fromISO('1980-01-01')) {
  return false
}
```
(in `client/agenda/Agenda.vue`)