### PR TITLE
Add copyrights

### DIFF
--- a/dev/build/collectstatics.sh
+++ b/dev/build/collectstatics.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright The IETF Trust 2024. All Rights Reserved.
 
 # Copy temp local settings
 cp dev/build/settings_local_collectstatics.py ietf/settings_local.py

--- a/ietf/secr/templates/includes/sessions_request_form.html
+++ b/ietf/secr/templates/includes/sessions_request_form.html
@@ -1,4 +1,5 @@
 <span class="required">*</span> Required Field
+<!-- Copyright The IETF Trust 2024. All Rights Reserved. -->
 <form id="session-request-form" action="." method="post" name="form_post">{% csrf_token %}
     {{ form.session_forms.management_form }}
     {% if form.non_field_errors %}

--- a/ietf/secr/templates/telechat/group.html
+++ b/ietf/secr/templates/telechat/group.html
@@ -1,4 +1,5 @@
 <form id="dummy" method="post">{% csrf_token %}
+    <!-- Copyright The IETF Trust 2024. All Rights Reserved. -->
     {% if header.2 == "4.1.1 Proposed for IETF Review" %}
         <b>Does anyone have an objection to the creation of this working group being sent for EXTERNAL REVIEW?</b><br><br>
         <input type="radio" name="wg_action_status" value="1"> External Review APPROVED; "The Secretariat will send a Working Group Review announcement with a copy to new-work and place it back on the agenda for the next telechat."<br><br>

--- a/ietf/templates/group/meetings-row.html
+++ b/ietf/templates/group/meetings-row.html
@@ -1,4 +1,5 @@
 {% load origin tz %}
+<!-- Copyright The IETF Trust 2024. All Rights Reserved. -->
 {% origin %}
 {% for s in sessions %}
     <tr>

--- a/ietf/templates/group/meetings.html
+++ b/ietf/templates/group/meetings.html
@@ -1,4 +1,5 @@
 {% extends "group/group_base.html" %}
+<!-- Copyright The IETF Trust 2024. All Rights Reserved. -->
 {% load origin static %}
 {% block title %}
     Meetings

--- a/ietf/templates/meeting/session_details_panel.html
+++ b/ietf/templates/meeting/session_details_panel.html
@@ -1,4 +1,5 @@
 {% load origin ietf_filters textfilters tz dateformat %}
+<!-- Copyright The IETF Trust 2024. All Rights Reserved. -->
 {% origin %}
 {% for session in sessions %}
     {% with item=session.official_timeslotassignment %} {% with timeslot=item.timeslot %}

--- a/ietf/templates/person/person_link.html
+++ b/ietf/templates/person/person_link.html
@@ -1,3 +1,4 @@
+<!-- Copyright The IETF Trust 2024. All Rights Reserved. -->
 {% if email and email == "system@datatracker.ietf.org" or name and name == "(System)" %}<span class="text-body-secondary">(System)</span>{% else %}<span {% if class %}class="{{ class }}"
       {% endif %}>{% if email or name %}<a {% if class %}class="text-reset"{% endif %}
            title="{% if title %}{{ title }}{% else %}Datatracker profile of {{ name }}{% endif %}"

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,4 +1,5 @@
 # Kustomize deployment
+# Copyright The IETF Trust 2024. All Rights Reserved.
 
 ## Run locally
 

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,3 +1,4 @@
+# Copyright The IETF Trust 2024. All Rights Reserved.
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
This is dependant on #7717.  It adds a script to add copyrights, and includes a commit to manually add them to some particularly troublesome files.

Think of this as WIP, because this PR does not include the changes for the rest of the files that don't have a copyright. You can run the ietf/add-copyright script by hand and review the changes.