### PR TITLE
fix: Send create user email for password resets where we have an email and person, but no user.

### DIFF
--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -542,8 +542,8 @@ class IetfAuthTests(TestCase):
         self.assertEqual(len(outbox), 1)
         lastReceivedEmail = outbox[-1]
         self.assertIn(email.address, lastReceivedEmail.get('To'))
-        self.assertTrue(lastReceivedEmail.get('Subject').startswith('Confirm registration at'))
-        self.assertContains(r, 'We have sent you an email with instructions', status_code=200)
+        self.assertTrue(lastReceivedEmail.get('Subject').startswith("Confirm password reset"))
+        self.assertContains(r, "Your password reset request has been successfully received", status_code=200)
 
     def test_review_overview(self):
         review_req = ReviewRequestFactory()

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -527,6 +527,24 @@ class IetfAuthTests(TestCase):
         self.assertIn(secondary_address, to)
         self.assertNotIn(inactive_secondary_address, to)
 
+    def test_reset_password_without_user(self):
+        """Reset password using email address for person without a user account"""
+        url = urlreverse('ietf.ietfauth.views.password_reset')
+        email = EmailFactory()
+        person = email.person
+        # Remove the user object from the person to get a Email/Person without User:
+        person.user = None
+        person.save()
+        # Remove the remaining User record, since reset_password looks for that by username:
+        User.objects.filter(username__iexact=email.address).delete()
+        empty_outbox()
+        r = self.client.post(url, { 'username': email.address })
+        self.assertEqual(len(outbox), 1)
+        lastReceivedEmail = outbox[-1]
+        self.assertIn(email.address, lastReceivedEmail.get('To'))
+        self.assertTrue(lastReceivedEmail.get('Subject').startswith('Confirm registration at'))
+        self.assertContains(r, 'We have sent you an email with instructions', status_code=200)
+
     def test_review_overview(self):
         review_req = ReviewRequestFactory()
         assignment = ReviewAssignmentFactory(review_request=review_req,reviewer=EmailFactory(person__user__username='reviewer'))

--- a/ietf/ietfauth/views.py
+++ b/ietf/ietfauth/views.py
@@ -491,8 +491,11 @@ def password_reset(request):
             if not user:
                 # try to find user ID from the email address
                 email = Email.objects.filter(address=submitted_username).first()
-                if email and email.person and email.person.user:
-                    user = email.person.user
+                if email and email.person:
+                    if email.person.user:
+                        user = email.person.user
+                    else: 
+                        send_account_creation_email(request, email.email_address())
 
             if user and user.person.email_set.filter(active=True).exists():
                 data = {

--- a/ietf/ietfauth/views.py
+++ b/ietf/ietfauth/views.py
@@ -495,8 +495,15 @@ def password_reset(request):
                     if email.person.user:
                         user = email.person.user
                     else: 
-                        send_account_creation_email(request, email.email_address())
-
+                        # Create a User record with this (conditioned by way of Email) username
+                        # Don't bother setting the name or email fields on User - rely on the
+                        # Person pointer.
+                        user = User.objects.create(
+                            username=email.address.lower(), 
+                            is_active=True,
+                        )
+                        email.person.user = user
+                        email.person.save()
             if user and user.person.email_set.filter(active=True).exists():
                 data = {
                     'username': user.username,


### PR DESCRIPTION
I think this fixes: https://github.com/ietf-tools/datatracker/issues/6458

I've tested manually by deleting my own `auth_user` database entry (and associated entries in `person_historicalperson` and `person_historicalemail`) to simulate a "missing user but known email and person" condition.

I'm not sure how the codebase is tested, since I'm not usually a python developer, however `ietf/manage.py test --settings=settings_test` seems to run fine. Though I do think it'd be good to have some sort of test coverage for exactly this case, since it seems like it's a pretty common issue for new editors/authors to encounter when collaborating with an existing IETF member on an I-D.

Sure, we could use a different email template to be a bit more specific about onboarding, but the overall goal I think here is to get the person setup with an account, and the create account flow does exactly that.

Whilst working on this, I did notice that from within the docker container setup, `Site.objects.get_current().domain` gives `datatracker.ietf.org` instead of `localhost:8000` like I'd have expected, so in the logs the links appeared as:

```
https://datatracker.ietf.org/accounts/reset/confirm/eyJ1c2VybmFtZSI6ImVtZWxpYUBicmFuZGVkY29kZS5jb20i....YCR3KmkLDZw2ArA_lPg/
```

Instead of:

```
http://localhost:8000/accounts/reset/confirm/eyJ1c2VybmFtZSI6ImVtZWxpYUBicmFuZGVkY29kZS5jb20i....YCR3KmkLDZw2ArA_lPg/
```

I also happen to have [Mailpit](https://mailpit.axllent.org/) running in my development environment, on port 2025, however the emails were just logged to the console; I assume this is just a standard development thing in python, but it could be neat to say "actually, yes, send all emails to this test email server"