### PR TITLE
feat: recognize HTTPS via proxy

### DIFF
--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -17,6 +17,11 @@ def _multiline_to_list(s):
 # Default to "development". Production _must_ set DATATRACKER_SERVER_MODE="production" in the env!
 SERVER_MODE = os.environ.get("DATATRACKER_SERVER_MODE", "development")
 
+# Use X-Forwarded-Proto to determine request.is_secure(). This relies on CloudFlare overwriting the
+# value of the header if an incoming request sets it, which it does:
+# https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#x-forwarded-proto
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # Secrets
 _SECRET_KEY = os.environ.get("DATATRACKER_DJANGO_SECRET_KEY", None)
 if _SECRET_KEY is not None:

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -20,6 +20,8 @@ SERVER_MODE = os.environ.get("DATATRACKER_SERVER_MODE", "development")
 # Use X-Forwarded-Proto to determine request.is_secure(). This relies on CloudFlare overwriting the
 # value of the header if an incoming request sets it, which it does:
 # https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#x-forwarded-proto
+# See also, especially the warnings:
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Secrets


### PR DESCRIPTION
This will cause Django to treat HTTPS connections to CloudFlare as secure. This will cause it to generate `https://...` URLs when generating absolute URLs despite seeing non-TLS proxied requests.

Before deploying this, we should confirm that CloudFlare is behaving as required in the warning at https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header. We also need to be sure we never deploy this setting without a proxy that handles the `X-Forwarded-Proto` header as required.