### PR TITLE
fix: Sort RFCs by date

### DIFF
--- a/ietf/static/js/list.js
+++ b/ietf/static/js/list.js
@@ -5,8 +5,10 @@ import {
 function text_sort(a, b, options) {
 
     function prep(e, options) {
-        return $($.parseHTML(e.values()[options.valueName]))
-            .text()
+        const el = $($.parseHTML(e.values()[options.valueName]));
+        const cell_el = e.elm.querySelector(`.${options.valueName}`)
+        const sort_by_number = cell_el?.getAttribute('data-sort-number')
+        return sort_by_number ?? el.text()
             .trim()
             .replaceAll(/\s+/g, ' ');
     }

--- a/ietf/templates/group/concluded_groups.html
+++ b/ietf/templates/group/concluded_groups.html
@@ -40,8 +40,8 @@
                         <tr>
                             <th scope="col" data-sort="group">Group</th>
                             <th scope="col" data-sort="name">Name</th>
-                            <th scope="col" data-sort="date">Start</th>
-                            <th scope="col" data-sort="date">Concluded</th>
+                            <th scope="col" data-sort="date-start">Start</th>
+                            <th scope="col" data-sort="date-concluded">Concluded</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -51,8 +51,8 @@
                                     <a href="{{ g.about_url }}">{{ g.acronym }}</a>
                                 </td>
                                 <td>{{ g.name }}</td>
-                                <td>{{ g.start_date|date:"Y-m" }}</td>
-                                <td>{{ g.conclude_date|date:"Y-m" }}</td>
+                                <td data-sort-number="{{ g.start_date|date:"U" }}">{{ g.start_date|date:"Y-m" }}</td>
+                                <td data-sort-number="{{ g.conclude_date|date:"U" }}">{{ g.conclude_date|date:"Y-m" }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/ietf/templates/person/profile.html
+++ b/ietf/templates/person/profile.html
@@ -106,7 +106,7 @@
                             <td>
                                 <a class="text-nowrap" href="{{ doc.get_absolute_url }}">RFC {{ doc.rfc_number }}</a>
                             </td>
-                            <td>{{ doc.pub_date|date:"b Y"|title }}</td>
+                            <td data-sort-number="{{ doc.pub_date|date:"U" }}">{{ doc.pub_date|date:"b Y"|title }}</td>
                             <td>{{ doc.title|urlize_ietf_docs }}</td>
                             <td class="text-end">
                                 {% with doc.referenced_by_rfcs_as_rfc_or_draft.count as refbycount %}


### PR DESCRIPTION
Fixes #7740

Allows sorting by `data-sort-number` attribute on the cell, rather than by the content of the cell which might be formatted.