### PR TITLE
fix: use BOF states in concluded_groups()

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -355,10 +355,16 @@ def concluded_groups(request):
         for g in groups:
             g.start_date = g.conclude_date = None
 
-        for e in ChangeStateGroupEvent.objects.filter(group__in=groups, state="active").order_by("-time"):
+        for e in ChangeStateGroupEvent.objects.filter(
+            group__in=groups, 
+            state="bof" if name == "BOFs" else "active",
+        ).order_by("-time"):
             d[e.group_id].start_date = e.time
 
-        for e in ChangeStateGroupEvent.objects.filter(group__in=groups, state="conclude").order_by("time"):
+        for e in ChangeStateGroupEvent.objects.filter(
+            group__in=groups,
+            state="bof-conc" if name == "BOFs" else "conclude",
+        ).order_by("time"):
             d[e.group_id].conclude_date = e.time
 
     return render(request, 'group/concluded_groups.html',

--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -334,21 +334,57 @@ def chartering_groups(request):
                   dict(charter_states=charter_states,
                        group_types=group_types))
 
+
 def concluded_groups(request):
     sections = OrderedDict()
 
-    sections['WGs'] = Group.objects.filter(type='wg', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['RGs'] = Group.objects.filter(type='rg', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['BOFs'] = Group.objects.filter(type='wg', state="bof-conc").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['AGs'] = Group.objects.filter(type='ag', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['RAGs'] = Group.objects.filter(type='rag', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['Directorates'] = Group.objects.filter(type='dir', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['Review teams'] = Group.objects.filter(type='review', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['Teams'] = Group.objects.filter(type='team', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
-    sections['Programs'] = Group.objects.filter(type='program', state="conclude").select_related("state", "charter").order_by("parent__name","acronym")
+    sections["WGs"] = (
+        Group.objects.filter(type="wg", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["RGs"] = (
+        Group.objects.filter(type="rg", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["BOFs"] = (
+        Group.objects.filter(type="wg", state="bof-conc")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["AGs"] = (
+        Group.objects.filter(type="ag", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["RAGs"] = (
+        Group.objects.filter(type="rag", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["Directorates"] = (
+        Group.objects.filter(type="dir", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["Review teams"] = (
+        Group.objects.filter(type="review", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["Teams"] = (
+        Group.objects.filter(type="team", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
+    sections["Programs"] = (
+        Group.objects.filter(type="program", state="conclude")
+        .select_related("state", "charter")
+        .order_by("parent__name", "acronym")
+    )
 
     for name, groups in sections.items():
-        
         # add start/conclusion date
         d = dict((g.pk, g) for g in groups)
 
@@ -360,7 +396,7 @@ def concluded_groups(request):
         # events should not be in the "bof-conc" state so this shouldn't cause a problem (if it does,
         # we'll need to clean up the data)
         for e in ChangeStateGroupEvent.objects.filter(
-            group__in=groups, 
+            group__in=groups,
             state__in=["active", "bof"] if name == "BOFs" else ["active"],
         ).order_by("-time"):
             d[e.group_id].start_date = e.time
@@ -376,8 +412,8 @@ def concluded_groups(request):
         ).order_by("time"):
             d[e.group_id].conclude_date = e.time
 
-    return render(request, 'group/concluded_groups.html',
-                  dict(sections=sections))
+    return render(request, "group/concluded_groups.html", dict(sections=sections))
+
 
 def prepare_group_documents(request, group, clist):
     found_docs, meta = prepare_document_table(request, docs_tracked_by_community_list(clist), request.GET, max_results=500)


### PR DESCRIPTION
Fixes #7770 (though database cleanup will also be needed).

This uses `ChangeStateGroupEvent` states `"bof"` and `"bof-conc"` instead of `"active"` and `"concluded"` when displaying BOFs on the `concluded_groups()` view.

This leads to quite a few changes because there seem to be a number of data quality problems. Some that I've noticed:

* aggsrv has no concluded date because its history entry is a `GroupEvent` rather than a `ChangeStateGroupEvent`
* netgraph (and other older groups) have `ChangeStateGroupEvent` records with `"active"` state rather than `"bof"`
* ietfgrow has only a `"conclude"` event
* many groups have only a concluded date