### PR TITLE
fix: Install weasyprint as a xml2rfc extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,5 +71,5 @@ tqdm>=4.64.0
 Unidecode>=1.3.4
 urllib3>=2
 weasyprint>=59
-xml2rfc>=3.12.4
+xml2rfc[pdf]>=3.23.0
 xym>=0.6,<1.0


### PR DESCRIPTION
Since xml2rfc v3.23.0, WeasyPrint version is pinned.

This will also enforce the `pydyf` version[^1].

[^1]: https://github.com/ietf-tools/xml2rfc/blob/main/setup.cfg#L59-L60