### PR TITLE
refactor: speed up finalizing proceedings

### DIFF
--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -167,7 +167,6 @@ def bluesheet_data(session):
         .order_by("time")
     )
 
-    meeting = session.meeting
     return [
         {
             "name": attended.person.plain_name(),

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 from django.conf import settings
 from django.contrib import messages
-from django.db.models import Q
+from django.db.models import OuterRef, Subquery, TextField, Q, Value
+from django.db.models.functions import Coalesce
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.encoding import smart_str
@@ -149,19 +150,28 @@ def create_proceedings_templates(meeting):
 
 
 def bluesheet_data(session):
-    def affiliation(meeting, person):
-        # from OidcExtraScopeClaims.scope_registration()
-        email_list = person.email_set.values_list("address")
-        q = Q(person=person, meeting=meeting) | Q(email__in=email_list, meeting=meeting)
-        reg = MeetingRegistration.objects.filter(q).exclude(affiliation="").first()
-        return reg.affiliation if reg else ""
+    attendance = (
+        Attended.objects.filter(session=session)
+        .annotate(
+            affiliation=Coalesce(
+                Subquery(
+                    MeetingRegistration.objects.filter(
+                        Q(meeting=session.meeting),
+                        Q(person=OuterRef("person")) | Q(email=OuterRef("person__email")),
+                    ).values("affiliation")[:1]
+                ),
+                Value(""),
+                output_field=TextField(),
+            )
+        ).distinct()
+        .order_by("time")
+    )
 
-    attendance = Attended.objects.filter(session=session).order_by("time")
     meeting = session.meeting
     return [
         {
             "name": attended.person.plain_name(),
-            "affiliation": affiliation(meeting, attended.person),
+            "affiliation": attended.affiliation,
         }
         for attended in attendance
     ]

--- a/k8s/nginx-auth.conf
+++ b/k8s/nginx-auth.conf
@@ -34,5 +34,9 @@ server {
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $${keepempty}remote_addr;
         proxy_pass http://localhost:8000;
+        # Set timeouts longer than Cloudflare proxy limits
+        proxy_connect_timeout 60;  # nginx default (Cf = 15)
+        proxy_read_timeout 120;  # nginx default = 60 (Cf = 100) 
+        proxy_send_timeout 60;  # nginx default = 60 (Cf = 30)
     }
 }

--- a/k8s/nginx-datatracker.conf
+++ b/k8s/nginx-datatracker.conf
@@ -23,6 +23,10 @@ server {
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $${keepempty}remote_addr;
         proxy_pass http://localhost:8000;
+        # Set timeouts longer than Cloudflare proxy limits
+        proxy_connect_timeout 60;  # nginx default (Cf = 15)
+        proxy_read_timeout 120;  # nginx default = 60 (Cf = 100) 
+        proxy_send_timeout 60;  # nginx default = 60 (Cf = 30)
         client_max_body_size 0;  # disable size check
     }
 }


### PR DESCRIPTION
Proceedings finalization for IETF-120 was timing out after 60s in production and taking almost 100s on my dev machine. Profiling showed almost all the time is spent generating bluesheets, heavily dominated by computing attendee affiliations. This PR rolls the annotation lookup into an `annotate()` call in the query, which drops the total time to about 10s on my dev machine.

For production deployments, this also increases the `proxy_read_timeout` - that should perhaps be pulled out into its own PR.