### PR TITLE
fix: Dark mode bug, pinia store reset across Vite entry points

### DIFF
--- a/client/embedded.js
+++ b/client/embedded.js
@@ -1,11 +1,11 @@
 import { createApp } from 'vue'
-import { createPinia } from 'pinia'
 import piniaPersist from 'pinia-plugin-persist'
 import Embedded from './Embedded.vue'
+import { createPiniaSingleton } from './shared/create-pinia-singleton'
 
 // Initialize store (Pinia)
 
-const pinia = createPinia()
+const pinia = createPiniaSingleton()
 pinia.use(piniaPersist)
 
 // Mount App

--- a/client/main.js
+++ b/client/main.js
@@ -1,14 +1,14 @@
 import { createApp } from 'vue'
-import { createPinia } from 'pinia'
 import piniaPersist from 'pinia-plugin-persist'
 import App from './App.vue'
 import router from './router'
+import { createPiniaSingleton } from './shared/create-pinia-singleton'
 
 const app = createApp(App, {})
 
 // Initialize store (Pinia)
 
-const pinia = createPinia()
+const pinia = createPiniaSingleton()
 pinia.use(piniaPersist)
 app.use(pinia)
 

--- a/client/shared/create-pinia-singleton.js
+++ b/client/shared/create-pinia-singleton.js
@@ -1,0 +1,6 @@
+import { createPinia } from 'pinia'
+
+export function createPiniaSingleton(){
+  window.pinia = window.pinia ?? createPinia()
+  return window.pinia
+}


### PR DESCRIPTION
The IETF meeting agenda's dark mode is broken in some configurations and it looks like this:

![Screenshot from 2024-08-22 21-21-23](https://github.com/user-attachments/assets/02646e0e-25e8-48bd-b475-db11761116bd)

The bug is caused by not setting `theme-dark` CSS class on the `<body>`.

That's caused by the Pinia store `theme` variable being correctly set to `'dark'` but then incorrectly set to `null`.

That was caused by two Vite entry points (`main.js` and `embedded.js`) both calling `createPinia()` which seems to reset the Pinia store state, restoring the theme to the default `null` which broke dark mode.

Fixed version:

![Screenshot from 2024-08-22 21-25-37](https://github.com/user-attachments/assets/4deb3af2-3126-4a2c-b346-45f13dadfaf4)



