### PR TITLE
fix: return to ballotpopup

### DIFF
--- a/ietf/doc/templatetags/ballot_icon.py
+++ b/ietf/doc/templatetags/ballot_icon.py
@@ -96,9 +96,14 @@ def ballot_icon(context, doc):
     positions = list(ballot.active_balloter_positions().items())
     positions.sort(key=sort_key)
 
+    request = context.get("request")
+    ballot_edit_return_point_param = f"?ballot_edit_return_point={request.path}"
+
     right_click_string = ''
     if has_role(user, "Area Director"):
-        right_click_string = 'oncontextmenu="window.location.href=\'%s\';return false;"' %  urlreverse('ietf.doc.views_ballot.edit_position', kwargs=dict(name=doc.name, ballot_id=ballot.pk))
+        right_click_string = 'oncontextmenu="window.location.href=\'%s%s\';return false;"' % (
+            urlreverse('ietf.doc.views_ballot.edit_position', kwargs=dict(name=doc.name, ballot_id=ballot.pk)),
+            ballot_edit_return_point_param)
 
     my_blocking = False
     for i, (balloter, pos) in enumerate(positions):
@@ -113,10 +118,14 @@ def ballot_icon(context, doc):
         typename = "RSAB"
     else:
         typename = "IESG"
+    
+    modal_url = '%s%s' % (
+        urlreverse("ietf.doc.views_doc.ballot_popup", kwargs=dict(name=doc.name, ballot_id=ballot.pk)),
+        ballot_edit_return_point_param)
 
     res = ['<a %s href="%s" data-bs-toggle="modal" data-bs-target="#modal-%d" aria-label="%s positions" title="%s positions (click to show more)" class="ballot-icon"><table' % (
             right_click_string,
-            urlreverse("ietf.doc.views_doc.ballot_popup", kwargs=dict(name=doc.name, ballot_id=ballot.pk)),
+            modal_url,
             ballot.pk,
             typename,
             typename,)]

--- a/ietf/doc/templatetags/ballot_icon.py
+++ b/ietf/doc/templatetags/ballot_icon.py
@@ -97,11 +97,11 @@ def ballot_icon(context, doc):
     positions.sort(key=sort_key)
 
     request = context.get("request")
-    ballot_edit_return_point_param = f"?ballot_edit_return_point={request.path}"
+    ballot_edit_return_point_param = f"ballot_edit_return_point={request.path}"
 
     right_click_string = ''
     if has_role(user, "Area Director"):
-        right_click_string = 'oncontextmenu="window.location.href=\'%s%s\';return false;"' % (
+        right_click_string = 'oncontextmenu="window.location.href=\'{}?{}\';return false;"'.format(
             urlreverse('ietf.doc.views_ballot.edit_position', kwargs=dict(name=doc.name, ballot_id=ballot.pk)),
             ballot_edit_return_point_param)
 
@@ -119,7 +119,7 @@ def ballot_icon(context, doc):
     else:
         typename = "IESG"
     
-    modal_url = '%s%s' % (
+    modal_url = "{}?{}".format(
         urlreverse("ietf.doc.views_doc.ballot_popup", kwargs=dict(name=doc.name, ballot_id=ballot.pk)),
         ballot_edit_return_point_param)
 

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1455,18 +1455,14 @@ class BallotContentTests(TestCase):
 
 class ReturnToUrlTests(TestCase):
     def test_invalid_return_to_url(self):
-        self.assertRaises(
-            Exception,
-            lambda: parse_ballot_edit_return_point('/', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718'),
-        )
-        self.assertRaises(
-            Exception,
-            lambda: parse_ballot_edit_return_point('/a-route-that-does-not-exist/', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718'),
-        )
-        self.assertRaises(
-            Exception,
-            lambda: parse_ballot_edit_return_point('https://example.com/phishing', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718'),
-        )
+        with self.assertRaises(ValueError):
+            parse_ballot_edit_return_point('/', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718')
+
+        with self.assertRaises(ValueError):
+            parse_ballot_edit_return_point('/a-route-that-does-not-exist/', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718')
+
+        with self.assertRaises(ValueError):
+            parse_ballot_edit_return_point('https://example.com/phishing', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718')
 
     def test_valid_default_return_to_url(self):
         self.assertEqual(parse_ballot_edit_return_point(

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1481,3 +1481,11 @@ class ReturnToUrlTests(TestCase):
             'draft-ietf-opsawg-ipfix-tcpo-v6eh',
             '998718'
         ), '/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/ballot/998718/')
+
+        self.assertEqual(parse_ballot_edit_return_point(
+            '/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/ballotpopup/998718/',
+            'draft-ietf-opsawg-ipfix-tcpo-v6eh',
+            '998718'
+        ), '/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/ballotpopup/998718/')
+
+

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1481,11 +1481,3 @@ class ReturnToUrlTests(TestCase):
             'draft-ietf-opsawg-ipfix-tcpo-v6eh',
             '998718'
         ), '/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/ballot/998718/')
-
-        self.assertEqual(parse_ballot_edit_return_point(
-            '/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/ballotpopup/998718/',
-            'draft-ietf-opsawg-ipfix-tcpo-v6eh',
-            '998718'
-        ), '/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/ballotpopup/998718/')
-
-

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -1457,7 +1457,7 @@ class ReturnToUrlTests(TestCase):
     def test_invalid_return_to_url(self):
         self.assertRaises(
             Exception,
-            lambda: parse_ballot_edit_return_point('/doc/', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718'),
+            lambda: parse_ballot_edit_return_point('/', 'draft-ietf-opsawg-ipfix-tcpo-v6eh', '998718'),
         )
         self.assertRaises(
             Exception,

--- a/ietf/doc/views_ballot.py
+++ b/ietf/doc/views_ballot.py
@@ -1315,7 +1315,6 @@ def parse_ballot_edit_return_point(path, doc_name, ballot_id):
     get_default_path = lambda: urlreverse("ietf.doc.views_doc.document_ballot", kwargs=dict(name=doc_name, ballot_id=ballot_id))
     allowed_path_handlers = {
         "ietf.community.views.view_list",
-        "ietf.community.views.view_list"
         "ietf.doc.views_doc.document_ballot",
         "ietf.doc.views_doc.document_irsg_ballot",
         "ietf.doc.views_doc.document_rsab_ballot",
@@ -1331,7 +1330,7 @@ def parse_ballot_edit_return_point(path, doc_name, ballot_id):
         "ietf.iesg.views.agenda",
         "ietf.iesg.views.agenda_documents",
         "ietf.iesg.views.discusses",
-        "ietf.iesg.views.past_documents"
+        "ietf.iesg.views.past_documents",
     }
     return validate_return_to_path(path, get_default_path, allowed_path_handlers)
 

--- a/ietf/doc/views_ballot.py
+++ b/ietf/doc/views_ballot.py
@@ -1314,16 +1314,24 @@ def rsab_ballot_status(request):
 def parse_ballot_edit_return_point(path, doc_name, ballot_id):
     get_default_path = lambda: urlreverse("ietf.doc.views_doc.document_ballot", kwargs=dict(name=doc_name, ballot_id=ballot_id))
     allowed_path_handlers = {
+        "ietf.community.views.view_list",
+        "ietf.community.views.view_list"
         "ietf.doc.views_doc.document_ballot",
         "ietf.doc.views_doc.document_irsg_ballot",
         "ietf.doc.views_doc.document_rsab_ballot",
         "ietf.doc.views_ballot.irsg_ballot_status",
         "ietf.doc.views_ballot.rsab_ballot_status",
         "ietf.doc.views_search.search",
+        "ietf.doc.views_search.docs_for_ad",
+        "ietf.doc.views_search.drafts_in_last_call",
+        "ietf.doc.views_search.recent_drafts",
+        "ietf.group.views.chartering_groups",
+        "ietf.group.views.group_documents",
+        "ietf.group.views.stream_documents",
         "ietf.iesg.views.agenda",
         "ietf.iesg.views.agenda_documents",
         "ietf.iesg.views.discusses",
-        "ietf.iesg.views.past_documents",
+        "ietf.iesg.views.past_documents"
     }
     return validate_return_to_path(path, get_default_path, allowed_path_handlers)
 

--- a/ietf/doc/views_ballot.py
+++ b/ietf/doc/views_ballot.py
@@ -1317,10 +1317,13 @@ def parse_ballot_edit_return_point(path, doc_name, ballot_id):
         "ietf.doc.views_doc.document_ballot",
         "ietf.doc.views_doc.document_irsg_ballot",
         "ietf.doc.views_doc.document_rsab_ballot",
-        "ietf.doc.views_doc.ballot_popup",
+        "ietf.doc.views_ballot.irsg_ballot_status",
+        "ietf.doc.views_ballot.rsab_ballot_status",
+        "ietf.doc.views_search.search",
         "ietf.iesg.views.agenda",
         "ietf.iesg.views.agenda_documents",
+        "ietf.iesg.views.discusses",
+        "ietf.iesg.views.past_documents",
     }
     return validate_return_to_path(path, get_default_path, allowed_path_handlers)
-
 

--- a/ietf/doc/views_ballot.py
+++ b/ietf/doc/views_ballot.py
@@ -1317,7 +1317,10 @@ def parse_ballot_edit_return_point(path, doc_name, ballot_id):
         "ietf.doc.views_doc.document_ballot",
         "ietf.doc.views_doc.document_irsg_ballot",
         "ietf.doc.views_doc.document_rsab_ballot",
+        "ietf.doc.views_doc.ballot_popup",
         "ietf.iesg.views.agenda",
         "ietf.iesg.views.agenda_documents",
     }
     return validate_return_to_path(path, get_default_path, allowed_path_handlers)
+
+

--- a/ietf/templates/doc/ballot_popup.html
+++ b/ietf/templates/doc/ballot_popup.html
@@ -27,7 +27,7 @@
             {% if editable and user|has_role:"Area Director,Secretariat,IRSG Member,RSAB Member" %}
                 {% if user|can_ballot:doc %}
                     <a class="btn btn-primary"
-                       href="{% url "ietf.doc.views_ballot.edit_position" name=doc.name ballot_id=ballot_id %}?ballot_edit_return_point={{ request.path|urlencode }}">
+                       href="{% url "ietf.doc.views_ballot.edit_position" name=doc.name ballot_id=ballot_id %}?ballot_edit_return_point={{ ballot_edit_return_point|urlencode }}">
                         Edit position
                     </a>
                 {% endif %}


### PR DESCRIPTION
* update the modal template route to take a param, rather than using request.path
* ensure every place that uses the ballot_icon template tag is added to the allow list of valid 'return to' route handlers.