### PR TITLE
feat: mark bofreqs as spam

### DIFF
--- a/ietf/doc/migrations/0023_bofreqspamstate.py
+++ b/ietf/doc/migrations/0023_bofreqspamstate.py
@@ -1,0 +1,30 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+
+from django.db import migrations
+
+
+def forward(apps, schema_editor):
+    State = apps.get_model("doc", "State")
+    State.objects.get_or_create(
+        type_id="bofreq",
+        slug="spam",
+        defaults={"name": "Spam", "desc": "The BOF request is spam", "order": 5},
+    )
+
+
+def reverse(apps, schema_editor):
+    State = apps.get_model("doc", "State")
+    Document = apps.get_model("doc", "Document")
+    assert not Document.objects.filter(
+        states__type="bofreq", states__slug="spam"
+    ).exists()
+    State.objects.filter(type_id="bofreq", slug="spam").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("doc", "0022_remove_dochistory_internal_comments_and_more"),
+    ]
+
+    operations = [migrations.RunPython(forward, reverse)]

--- a/ietf/doc/tests_bofreq.py
+++ b/ietf/doc/tests_bofreq.py
@@ -54,8 +54,8 @@ This test section has some text.
         self.assertEqual(r.status_code, 200)
         q = PyQuery(r.content)
         for state in states:
-            self.assertEqual(len(q(f'#bofreqs-{state.slug}')), 1)
-            self.assertEqual(len(q(f'#bofreqs-{state.slug} tbody tr')), 3)
+            self.assertEqual(len(q(f'#bofreqs-{state.slug}')), 1 if state.slug!="spam" else 0)
+            self.assertEqual(len(q(f'#bofreqs-{state.slug} tbody tr')), 3 if state.slug!="spam" else 0)
         self.assertFalse(q('#start_button'))
         PersonFactory(user__username='nobody')
         self.client.login(username='nobody', password='nobody+password')
@@ -63,6 +63,13 @@ This test section has some text.
         self.assertEqual(r.status_code, 200)
         q = PyQuery(r.content)
         self.assertTrue(q('#start_button'))
+        self.client.logout()
+        self.client.login(username='secretary', password='secretary+password')
+        r = self.client.get(url)
+        q = PyQuery(r.content)
+        for state in states:
+            self.assertEqual(len(q(f'#bofreqs-{state.slug}')), 1)
+            self.assertEqual(len(q(f'#bofreqs-{state.slug} tbody tr')), 3)
 
 
     def test_bofreq_main_page(self):

--- a/ietf/name/fixtures/names.json
+++ b/ietf/name/fixtures/names.json
@@ -2619,6 +2619,19 @@
   },
   {
     "fields": {
+      "desc": "The BOF request is spam",
+      "name": "Spam",
+      "next_states": [],
+      "order": 5,
+      "slug": "spam",
+      "type": "bofreq",
+      "used": true
+    },
+    "model": "doc.state",
+    "pk": 182
+  },
+  {
+    "fields": {
       "label": "State"
     },
     "model": "doc.statetype",

--- a/ietf/templates/doc/bofreq/bof_requests.html
+++ b/ietf/templates/doc/bofreq/bof_requests.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {# Copyright The IETF Trust 2021 All Rights Reserved #}
 {% load origin %}
-{% load person_filters %}
+{% load person_filters ietf_filters %}
 {% load static %}
 {% block pagehead %}
     <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
@@ -26,40 +26,42 @@
     {% else %}
         {% regroup reqs by get_state_slug as grouped_reqs %}
         {% for req_group in grouped_reqs %}
-            <h2 class="mt-5">{{ req_group.grouper|capfirst }} BOF Requests</h2>
-            <table id="bofreqs-{{ req_group.grouper }}"
-                   class="table table-sm table-striped tablesorter">
-                <thead>
-                    <tr>
-                        <th scope="col" data-sort="name">Name</th>
-                        <th scope="col" class="d-none d-sm-table-cell" data-sort="date">Date</th>
-                        <th scope="col" data-sort="title">Title</th>
-                        <th scope="col" data-sort="responsible">Responsible</th>
-                        <th scope="col" data-sort="editors">Editors</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for req in req_group.list %}
+            {% if req_group.grouper != "spam" or request.user|has_role:"Secretariat" %}
+                <h2 class="mt-5">{{ req_group.grouper|capfirst }} BOF Requests</h2>
+                <table id="bofreqs-{{ req_group.grouper }}"
+                    class="table table-sm table-striped tablesorter">
+                    <thead>
                         <tr>
-                            <td>
-                                <a href="{% url 'ietf.doc.views_doc.document_main' name=req.name %}">{{ req.name }}-{{ req.rev }}</a>
-                            </td>
-                            <td class="d-none d-sm-table-cell">{{ req.latest_revision_event.time|date:"Y-m-d" }}</td>
-                            <td>{{ req.title }}</td>
-                            <td>
-                                {% for person in req.responsible %}
-                                    {% person_link person %}{% if not forloop.last %},{% endif %}
-                                {% endfor %}
-                            </td>
-                            <td>
-                                {% for person in req.editors %}
-                                    {% person_link person %}{% if not forloop.last %},{% endif %}
-                                {% endfor %}
-                            </td>
+                            <th scope="col" data-sort="name">Name</th>
+                            <th scope="col" class="d-none d-sm-table-cell" data-sort="date">Date</th>
+                            <th scope="col" data-sort="title">Title</th>
+                            <th scope="col" data-sort="responsible">Responsible</th>
+                            <th scope="col" data-sort="editors">Editors</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {% for req in req_group.list %}
+                            <tr>
+                                <td>
+                                    <a href="{% url 'ietf.doc.views_doc.document_main' name=req.name %}">{{ req.name }}-{{ req.rev }}</a>
+                                </td>
+                                <td class="d-none d-sm-table-cell">{{ req.latest_revision_event.time|date:"Y-m-d" }}</td>
+                                <td>{{ req.title }}</td>
+                                <td>
+                                    {% for person in req.responsible %}
+                                        {% person_link person %}{% if not forloop.last %},{% endif %}
+                                    {% endfor %}
+                                </td>
+                                <td>
+                                    {% for person in req.editors %}
+                                        {% person_link person %}{% if not forloop.last %},{% endif %}
+                                    {% endfor %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
         {% endfor %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
This is an incremental improvement, allowing the bofreqs to be marked as spam. A future enhancement will gate bofreqs so spam bofreqs are never accepted in the first place.

Note that this does not _delete_ the bofreq marked as spam - it only causes it to not appear on the bofreq listing (unless logged in as the secretariat where it will still show, but in a spam section). The spam-marked bofreq will still be available if its name is known.

cc: @cindymorgan 

Fixes #7862