### PR TITLE
fix: display session lengths and conflicts in sess scheduled emails

### DIFF
--- a/ietf/secr/meetings/views.py
+++ b/ietf/secr/meetings/views.py
@@ -168,7 +168,7 @@ def send_notifications(meeting, groups, person):
 
         context['session_lengths'] = [s.requested_duration for s in sessions]
 
-        outbound_conflicts: list[str] = [
+        outbound_conflicts = [
             ConstraintName.objects.get(slug=k.removeprefix('constraint_')).name + ": " + v
             for k, v in context['session'].items()
             if k.startswith('constraint_')


### PR DESCRIPTION
fixes #7874 

In draft currently to get some feedback. Also, to discuss how to write unit tests for email content in general.

---

The `session_info.txt` inner template is being loaded in multiple templates.

``` example
ietf/secr/templates/meetings/session_schedule_notification.txt
19:{% include "includes/session_info.txt" %}{% endtimezone %}

ietf/secr/templates/sreq/session_approval_notification.txt
15:{% include "includes/session_info.txt" %}

ietf/secr/templates/sreq/session_request_notification.txt
5:{% include "includes/session_info.txt" %}
```

The following keys were missing for session schedule emails:

- `session_lengths`

- `session.outbound_conflicts` (nested)

With the change, the `context` dictionary looks like the following.

``` python
{'agenda_note': '',
 'baseurl': 'https://datatracker.ietf.org',
 'group': <Group: Measurement and Analysis for Protocols>,
 'items': [{'duration': '2:00',
            'period': '0930-1130 America/Vancouver',
            'session': <Session: IETF-120: maprg  Wed-1630>,
            'timeslot': <TimeSlot: 120: 07-24 16:30-18:30 Session I, Georgia B>}],
 'login': <Person: Mirja Kühlewind>,
 'meeting': <Meeting: IETF-120>,
 'session': {'adjacent_with_wg': None,
             'attendees': 100,
             'bethere': [],
             'comments': 'Please also deconflict the sconepro BoF',
             'constraint_chair_conflict': 'tcpm iabopen quic taps masque '
                                          'privacypass webtrans moq mimi',
             'constraint_tech_overlap': 'v6ops tsvwg tls secdispatch saag '
                                        'rtgarea panrg opsawg irtfopen intarea '
                                        'iccrg httpbis dnsop dispatch bmwg '
                                        'artarea 6man gendispatch iotops ippm '
                                        'ppm openpgp pearg',
             'num_session': 1,
             'outbound_conflicts': ['Chair conflict: tcpm iabopen quic taps '
                                    'masque privacypass webtrans moq mimi',
                                    'Technology overlap: v6ops tsvwg tls '
                                    'secdispatch saag rtgarea panrg opsawg '
                                    'irtfopen intarea iccrg httpbis dnsop '
                                    'dispatch bmwg artarea 6man gendispatch '
                                    'iotops ippm ppm openpgp pearg'],  # added
             'resources': <QuerySet []>,
             'session_time_relation': None,
             'session_time_relation_display': None,
             'third_session': False,
             'timeranges': [],
             'timeranges_display': []},
 'session_lengths': [datetime.timedelta(seconds=7200)],  # added
 'to_name': 'Mirja Kühlewind'}
```
