### PR TITLE
fix: Missing button text for PostScript in RFC

### DIFF
--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -1046,6 +1046,8 @@ def build_file_urls(doc: Union[Document, DocHistory]):
 
         file_urls = []
         for t in found_types:
+            if t == "ps": # Postscript might have been submitted but should not be displayed in the list of URLs
+                continue
             label = "plain text" if t == "txt" else t
             file_urls.append((label, base + doc.name + "." + t))
 


### PR DESCRIPTION
Skip Postscript file in View.

In #7200, PS file is ignored but only in draft. So I appled also in rfc.

I guess removing 'ps' from `settings.RFC_FILE_TYPES`, `settings.IDSUBMIT_FILE_TYPES` should work, but don't know the side effect.. since I'm pretty new here 😅

Resolves #7879
