### PR TITLE
test: check IPR search results in HTML with whitespace ignored

### DIFF
--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -203,26 +203,20 @@ class IprTests(TestCase):
         self.assertContains(r, "Total number of documents searched: <b>3</b>.")
         self.assertContains(
             r,
-            f"""Results for <a href="/doc/{rfc_new.name}/">{prettify_std_name(rfc_new.name)}</a>
-                        ("{rfc_new.title}")""",
+            f'Results for <a href="/doc/{rfc_new.name}/">{prettify_std_name(rfc_new.name)}</a> ("{rfc_new.title}")',
+            html=True,
         )
         self.assertContains(
             r,
-            f"""Results for <a href="/doc/{rfc.name}/">{prettify_std_name(rfc.name)}</a>
-                        ("{rfc.title}"), which
-                            
-                                was obsoleted by
-                                <a href="/doc/{rfc_new.name}/">{prettify_std_name(rfc_new.name)}</a>
-                                ("{rfc_new.title}")""",
+            f'Results for <a href="/doc/{rfc.name}/">{prettify_std_name(rfc.name)}</a> ("{rfc.title}"), '
+            f'which was obsoleted by <a href="/doc/{rfc_new.name}/">{prettify_std_name(rfc_new.name)}</a> ("{rfc_new.title}")',
+            html=True,
         )
         self.assertContains(
             r,
-            f"""Results for <a href="/doc/{draft.name}/">{prettify_std_name(draft.name)}</a>
-                        ("{draft.title}"), which
-                            
-                                became rfc
-                                <a href="/doc/{rfc.name}/">{prettify_std_name(rfc.name)}</a>
-                                ("{rfc.title}")""",
+            f'Results for <a href="/doc/{draft.name}/">{prettify_std_name(draft.name)}</a> ("{draft.title}"), '
+            f'which became rfc <a href="/doc/{rfc.name}/">{prettify_std_name(rfc.name)}</a> ("{rfc.title}")',
+            html=True,
         )
 
         # find by patent owner


### PR DESCRIPTION
fixes the issue raised in https://github.com/ietf-tools/datatracker/pull/7836#discussion_r1752832327

It's still important to group

- a document
- and its relationship with
- another document

together and test them as a whole for each assertion in the test.

All that was needed was to
1. revert https://github.com/ietf-tools/datatracker/commit/6e4c8038321b6ded5b65ea66ea77143e5d76c06b, and
2. add `html=True` to each of the `self.assertContains` calls

Edit: See the official documentation on `assertContains` below.

https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.SimpleTestCase.assertContains

> Set html to True to handle text as HTML. The comparison with the response content will be based on HTML semantics instead of character-by-character equality. Whitespace is ignored in most cases, attribute ordering is not significant. See [assertHTMLEqual()](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.SimpleTestCase.assertHTMLEqual) for more details.