### PR TITLE
chore(deps): pin importlib-metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ gunicorn>=20.1.0
 hashids>=1.3.1
 html2text>=2020.1.16    # Used only to clean comment field of secr/sreq
 html5lib>=1.1    # Only used in tests
+importlib-metadata<8.5.0  # indirect req of Markdown/inflect; https://github.com/ietf-tools/datatracker/issues/7924
 inflect>= 6.0.2
 jsonfield>=3.1.0    # for SubmissionCheck.  This is https://github.com/bradjasper/django-jsonfield/.
 jsonschema[format]>=4.2.1


### PR DESCRIPTION
Fixes #7924 

I haven't looked into a real fix to this, but for now 8.4.0 is fine requirements-wise so this will be sure that things keep working.

The indirect dependency on importlib-metadata goes away with python 3.10, so maybe energy would be better spent moving off of python 3.9?