### PR TITLE
chore: Remove obsolete `version` attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     app:
         build:

--- a/docker/docker-compose.celery.yml
+++ b/docker/docker-compose.celery.yml
@@ -1,7 +1,3 @@
-version: '2.4'
-# Use version 2.4 for mem_limit setting. Version 3+ uses deploy.resources.limits.memory
-# instead, but that only works for swarm with docker-compose 1.25.1.
-
 services:
   mq:
     image: rabbitmq:3-alpine

--- a/docker/docker-compose.extend.yml
+++ b/docker/docker-compose.extend.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     app:
         ports:


### PR DESCRIPTION
`version` top-level element in `docker compose` files are obsolete [^1].

[^1]: https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete