### PR TITLE
feat: allow blanket IPR disclosures

### DIFF
--- a/ietf/ipr/forms.py
+++ b/ietf/ipr/forms.py
@@ -341,7 +341,7 @@ class IprDisclosureFormBase(forms.ModelForm):
 
 class HolderIprDisclosureForm(IprDisclosureFormBase):
     is_blanket_disclosure = forms.BooleanField(
-        label="Blanket IPR Disclosure",
+        label="This is a blanket IPR disclosure",
         help_text="In satisfaction of its disclosure obligations, Patent Holder commits to license all of "
         "IPR (as defined in RFC 8179) that would have required disclosure under RFC 8179 on a "
         "royalty-free (and otherwise reasonable and non-discriminatory) basis. Patent Holder "

--- a/ietf/ipr/forms.py
+++ b/ietf/ipr/forms.py
@@ -341,11 +341,14 @@ class IprDisclosureFormBase(forms.ModelForm):
 
 class HolderIprDisclosureForm(IprDisclosureFormBase):
     is_blanket_disclosure = forms.BooleanField(
-        label="This is a blanket IPR disclosure",
+        label=mark_safe(
+            'This is a blanket IPR disclosure '
+            '(see Section 5.4.3 of <a href="https://www.ietf.org/rfc/rfc8179.txt">RFC 8179</a>)'
+        ),
         help_text="In satisfaction of its disclosure obligations, Patent Holder commits to license all of "
-        "IPR (as defined in RFC 8179) that would have required disclosure under RFC 8179 on a "
-        "royalty-free (and otherwise reasonable and non-discriminatory) basis. Patent Holder "
-        "confirms that all other terms and conditions are described in this IPR disclosure.",
+                  "IPR (as defined in RFC 8179) that would have required disclosure under RFC 8179 on a "
+                  "royalty-free (and otherwise reasonable and non-discriminatory) basis. Patent Holder "
+                  "confirms that all other terms and conditions are described in this IPR disclosure.",
         required=False,
     )
     licensing = CustomModelChoiceField(IprLicenseTypeName.objects.all(),

--- a/ietf/ipr/forms.py
+++ b/ietf/ipr/forms.py
@@ -338,7 +338,16 @@ class IprDisclosureFormBase(forms.ModelForm):
 
         return cleaned_data
 
+
 class HolderIprDisclosureForm(IprDisclosureFormBase):
+    is_blanket_disclosure = forms.BooleanField(
+        label="Blanket IPR Disclosure",
+        help_text="In satisfaction of its disclosure obligations, Patent Holder commits to license all of "
+        "IPR (as defined in RFC 8179) that would have required disclosure under RFC 8179 on a "
+        "royalty-free (and otherwise reasonable and non-discriminatory) basis. Patent Holder "
+        "confirms that all other terms and conditions are described in this IPR disclosure.",
+        required=False,
+    )
     licensing = CustomModelChoiceField(IprLicenseTypeName.objects.all(),
         widget=forms.RadioSelect,empty_label=None)
 
@@ -356,6 +365,15 @@ class HolderIprDisclosureForm(IprDisclosureFormBase):
         else:
             # entering new disclosure
             self.fields['licensing'].queryset = IprLicenseTypeName.objects.exclude(slug='none-selected')
+        
+        if self.data.get("is_blanket_disclosure", False):
+            # for a blanket disclosure, patent details are not required
+            self.fields["patent_number"].required = False
+            self.fields["patent_inventor"].required = False
+            self.fields["patent_title"].required = False
+            self.fields["patent_date"].required = False
+            # n.b., self.fields["patent_notes"] is never required
+
             
     def clean(self):
         cleaned_data = super(HolderIprDisclosureForm, self).clean()

--- a/ietf/ipr/migrations/0004_holderiprdisclosure_is_blanket_disclosure.py
+++ b/ietf/ipr/migrations/0004_holderiprdisclosure_is_blanket_disclosure.py
@@ -1,0 +1,16 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ipr", "0003_alter_iprdisclosurebase_docs"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="holderiprdisclosure",
+            name="is_blanket_disclosure",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/ietf/ipr/models.py
+++ b/ietf/ipr/models.py
@@ -137,6 +137,7 @@ class HolderIprDisclosure(IprDisclosureBase):
     licensing = ForeignKey(IprLicenseTypeName)
     licensing_comments = models.TextField(blank=True)
     submitter_claims_all_terms_disclosed = models.BooleanField(default=False)
+    is_blanket_disclosure = models.BooleanField(default=False)
 
 
 class ThirdPartyIprDisclosure(IprDisclosureBase):

--- a/ietf/ipr/models.py
+++ b/ietf/ipr/models.py
@@ -124,17 +124,20 @@ class IprDisclosureBase(models.Model):
 
 
 class HolderIprDisclosure(IprDisclosureBase):
-    ietfer_name              = models.CharField(max_length=255, blank=True) # "Whose Personal Belief Triggered..."
-    ietfer_contact_email     = models.EmailField(blank=True)
-    ietfer_contact_info      = models.TextField(blank=True)
-    patent_info              = models.TextField()
-    has_patent_pending       = models.BooleanField(default=False)
-    holder_contact_email     = models.EmailField()
-    holder_contact_name      = models.CharField(max_length=255)
-    holder_contact_info      = models.TextField(blank=True, help_text="Address, phone, etc.")
-    licensing                = ForeignKey(IprLicenseTypeName)
-    licensing_comments       = models.TextField(blank=True)
+    ietfer_name = models.CharField(
+        max_length=255, blank=True
+    )  # "Whose Personal Belief Triggered..."
+    ietfer_contact_email = models.EmailField(blank=True)
+    ietfer_contact_info = models.TextField(blank=True)
+    patent_info = models.TextField()
+    has_patent_pending = models.BooleanField(default=False)
+    holder_contact_email = models.EmailField()
+    holder_contact_name = models.CharField(max_length=255)
+    holder_contact_info = models.TextField(blank=True, help_text="Address, phone, etc.")
+    licensing = ForeignKey(IprLicenseTypeName)
+    licensing_comments = models.TextField(blank=True)
     submitter_claims_all_terms_disclosed = models.BooleanField(default=False)
+
 
 class ThirdPartyIprDisclosure(IprDisclosureBase):
     ietfer_name              = models.CharField(max_length=255) # "Whose Personal Belief Triggered..."

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -1025,15 +1025,11 @@ class DraftFormTests(TestCase):
 
 
 class HolderIprDisclosureFormTests(TestCase):
-    def test_blanket_disclosure_licensing_restrictions(self):
-        """when is_blanket_disclosure is True only royalty-free licensing is valid
-        
-        Most of the form functionality is tested via the views in IprTests above. More thorough testing
-        of validation ought to move here so we don't have to exercise the whole Django plumbing repeatedly.
-        """
+    def setUp(self):
+        super().setUp()
         # Checkboxes that are False are left out of the Form data, not sent back at all. These are
         # commented out - if they were checked, their value would be "on".
-        data = {
+        self.data = {
             "holder_legal_name": "Test Legal",
             "holder_contact_name": "Test Holder",
             "holder_contact_email": "test@holder.com",
@@ -1055,10 +1051,15 @@ class HolderIprDisclosureFormTests(TestCase):
             "submitter_name": "Test Holder",
             "submitter_email": "test@holder.com",
         }
-        self.assertTrue(HolderIprDisclosureForm(data=data).is_valid())       
-        data["is_blanket_disclosure"] = "on"
-        self.assertFalse(HolderIprDisclosureForm(data=data).is_valid())       
-        data["licensing"] = "royalty-free"
-        self.assertTrue(HolderIprDisclosureForm(data=data).is_valid())       
-
         
+    def test_blanket_disclosure_licensing_restrictions(self):
+        """when is_blanket_disclosure is True only royalty-free licensing is valid
+        
+        Most of the form functionality is tested via the views in IprTests above. More thorough testing
+        of validation ought to move here so we don't have to exercise the whole Django plumbing repeatedly.
+        """       
+        self.assertTrue(HolderIprDisclosureForm(data=self.data).is_valid())       
+        self.data["is_blanket_disclosure"] = "on"
+        self.assertFalse(HolderIprDisclosureForm(data=self.data).is_valid())       
+        self.data["licensing"] = "royalty-free"
+        self.assertTrue(HolderIprDisclosureForm(data=self.data).is_valid())       

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -1063,3 +1063,20 @@ class HolderIprDisclosureFormTests(TestCase):
         self.assertFalse(HolderIprDisclosureForm(data=self.data).is_valid())       
         self.data["licensing"] = "royalty-free"
         self.assertTrue(HolderIprDisclosureForm(data=self.data).is_valid())       
+
+    def test_patent_details_required_unless_blanket(self):
+        self.assertTrue(HolderIprDisclosureForm(data=self.data).is_valid())
+        patent_fields = ["patent_number", "patent_inventor", "patent_title", "patent_date"]
+        # any of the fields being missing should invalidate the form
+        for pf in patent_fields:
+            val = self.data.pop(pf)
+            self.assertFalse(HolderIprDisclosureForm(data=self.data).is_valid())
+            self.data[pf] = val
+
+        # should be optional if is_blanket_disclosure is True
+        self.data["is_blanket_disclosure"] = "on"
+        self.data["licensing"] = "royalty-free"  # also needed for a blanket disclosure
+        for pf in patent_fields:
+            val = self.data.pop(pf)
+            self.assertTrue(HolderIprDisclosureForm(data=self.data).is_valid())
+            self.data[pf] = val

--- a/ietf/ipr/tests.py
+++ b/ietf/ipr/tests.py
@@ -278,16 +278,16 @@ class IprTests(TestCase):
 
     def test_new_generic(self):
         """Ensure new-generic redirects to new-general"""
-        url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "generic" })
+        url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "generic" })
         r = self.client.get(url)
         self.assertEqual(r.status_code,302)
-        self.assertEqual(urlparse(r["Location"]).path, urlreverse("ietf.ipr.views.new", kwargs={ "type": "general"}))
+        self.assertEqual(urlparse(r["Location"]).path, urlreverse("ietf.ipr.views.new", kwargs={ "_type": "general"}))
 
 
     def test_new_general(self):
         """Add a new general disclosure.  Note: submitter does not need to be logged in.
         """
-        url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "general" })
+        url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "general" })
 
         # invalid post
         r = self.client.post(url, {
@@ -325,7 +325,7 @@ class IprTests(TestCase):
         """
         draft = WgDraftFactory()
         rfc = WgRfcFactory()
-        url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "specific" })
+        url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "specific" })
 
         # successful post
         empty_outbox()
@@ -381,7 +381,7 @@ class IprTests(TestCase):
     def test_new_specific_no_revision(self):
         draft = WgDraftFactory()
         rfc = WgRfcFactory()
-        url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "specific" })
+        url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "specific" })
 
         # successful post
         empty_outbox()
@@ -415,7 +415,7 @@ class IprTests(TestCase):
         """
         draft = WgDraftFactory()
         rfc = WgRfcFactory()
-        url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "third-party" })
+        url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "third-party" })
 
         # successful post
         empty_outbox()
@@ -462,7 +462,7 @@ class IprTests(TestCase):
         r = self.client.get(url)
         self.assertContains(r, original_ipr.holder_legal_name)
 
-        #url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "specific" })
+        #url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "specific" })
         # successful post
         empty_outbox()
         post_data = {
@@ -509,7 +509,7 @@ class IprTests(TestCase):
         r = self.client.get(url)
         self.assertContains(r, original_ipr.title)
 
-        #url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "specific" })
+        #url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "specific" })
         # successful post
         empty_outbox()
         r = self.client.post(url, {
@@ -549,7 +549,7 @@ class IprTests(TestCase):
 
     def test_update_bad_post(self):
         draft = WgDraftFactory()
-        url = urlreverse("ietf.ipr.views.new", kwargs={ "type": "specific" })
+        url = urlreverse("ietf.ipr.views.new", kwargs={ "_type": "specific" })
 
         empty_outbox()
         r = self.client.post(url, {

--- a/ietf/ipr/urls.py
+++ b/ietf/ipr/urls.py
@@ -25,6 +25,6 @@ urlpatterns = [
     url(r'^(?P<id>\d+)/state/$', views.state),
     url(r'^update/$', RedirectView.as_view(url=reverse_lazy('ietf.ipr.views.showlist'), permanent=True)),
     url(r'^update/(?P<id>\d+)/$', views.update),
-    url(r'^new-(?P<type>(specific|generic|general|third-party))/$', views.new),
+    url(r'^new-(?P<_type>(specific|generic|general|third-party))/$', views.new),
     url(r'^search/$', views.search),
 ]

--- a/ietf/static/js/ipr-edit.js
+++ b/ietf/static/js/ipr-edit.js
@@ -70,9 +70,9 @@ $(document)
                 .each(updateRevisions);
         }, 10);
 
-        // Manage "required" fields in section V - patent info is required unless it's a blanket disclosure
-        const blanketDisclosureCheckbox = document.getElementById('id_is_blanket_disclosure') 
-        if (blanketDisclosureCheckbox) {
+        // Manage fields that depend on the Blanket IPR Disclosure choice
+        const blanketCheckbox = document.getElementById('id_is_blanket_disclosure') 
+        if (blanketCheckbox) {
             const patentDetailInputs = [
                 // The ids are from the HolderIprDisclosureForm and its base form class,
                 // intentionally excluding patent_notes because it's never required
@@ -84,8 +84,17 @@ $(document)
             const patentDetailRowDivs = patentDetailInputs.map(
                 (elt) => elt.closest('div.row')
             )
-            const updateRequiredPatentDetails = () => {
-                const isBlanket = blanketDisclosureCheckbox.checked
+            const royaltyFreeLicensingRadio = document.querySelector(
+                '#id_licensing input[value="royalty-free"]'
+            )
+            let lastSelectedLicensingRadio
+            const otherLicensingRadios = document.querySelectorAll(
+                '#id_licensing input:not([value="royalty-free"])'
+            ) 
+            
+            const handleBlanketCheckboxChange = () => {
+                const isBlanket = blanketCheckbox.checked
+                // Update required fields
                 for (elt of patentDetailInputs) {
                     // disable the input element
                     elt.required = !isBlanket
@@ -98,11 +107,31 @@ $(document)
                         elt.classList.add('required')
                     }
                 }
+                // Update licensing selection
+                if (isBlanket) {
+                    lastSelectedLicensingRadio = document.querySelector(
+                        '#id_licensing input:checked'
+                    )
+                    royaltyFreeLicensingRadio.checked = true
+                    otherLicensingRadios
+                        .forEach(
+                            (elt) => elt.setAttribute('disabled', '')
+                        )
+                } else {
+                    royaltyFreeLicensingRadio.checked = false
+                    if (lastSelectedLicensingRadio) {
+                        lastSelectedLicensingRadio.checked = true
+                    }
+                    otherLicensingRadios
+                        .forEach(
+                            (elt) => elt.removeAttribute('disabled')
+                        )
+                }
             }
-            updateRequiredPatentDetails()
-            blanketDisclosureCheckbox.addEventListener(
+            handleBlanketCheckboxChange()
+            blanketCheckbox.addEventListener(
                 'change', 
-                (evt) => updateRequiredPatentDetails()
+                (evt) => handleBlanketCheckboxChange()
             )
         }
     });

--- a/ietf/static/js/ipr-edit.js
+++ b/ietf/static/js/ipr-edit.js
@@ -69,4 +69,40 @@ $(document)
             form.find(".draft-row")
                 .each(updateRevisions);
         }, 10);
+
+        // Manage "required" fields in section V - patent info is required unless it's a blanket disclosure
+        const blanketDisclosureCheckbox = document.getElementById('id_is_blanket_disclosure') 
+        if (blanketDisclosureCheckbox) {
+            const patentDetailInputs = [
+                // The ids are from the HolderIprDisclosureForm and its base form class,
+                // intentionally excluding patent_notes because it's never required
+                'id_patent_number',
+                'id_patent_inventor',
+                'id_patent_title',
+                'id_patent_date'
+            ].map((id) => document.getElementById(id))
+            const patentDetailRowDivs = patentDetailInputs.map(
+                (elt) => elt.closest('div.row')
+            )
+            const updateRequiredPatentDetails = () => {
+                const isBlanket = blanketDisclosureCheckbox.checked
+                for (elt of patentDetailInputs) {
+                    // disable the input element
+                    elt.required = !isBlanket
+                }
+                for (elt of patentDetailRowDivs) {
+                    // update the styling on the row that indicates required field
+                    if (isBlanket) {
+                        elt.classList.remove('required')
+                    } else {
+                        elt.classList.add('required')
+                    }
+                }
+            }
+            updateRequiredPatentDetails()
+            blanketDisclosureCheckbox.addEventListener(
+                'change', 
+                (evt) => updateRequiredPatentDetails()
+            )
+        }
     });

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -153,11 +153,13 @@
             <small>i.e., patents or patent applications required to be disclosed by Section 5 of RFC8179</small>
         </h2>
         {% if form.patent_number %}
-            <p>
-                This IPR disclosure must either identify a specific patent or patents in sections V(A) and V(B)
-                below, or be made as a blanket IPR disclosure. 
-            </p>
-            {% bootstrap_field form.is_blanket_disclosure layout='horizontal' %}
+            {% if form.is_blanket_disclosure %}
+                <p>
+                    This IPR disclosure must either identify a specific patent or patents in sections V(A) and V(B)
+                    below, or be made as a blanket IPR disclosure. 
+                </p>
+                {% bootstrap_field form.is_blanket_disclosure layout='horizontal' %}
+            {% endif %}
             <p>
                 A. For granted patents or published pending patent applications,
                 please provide the following information:

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -32,7 +32,7 @@
             regarding an IETF document or contribution when the person letting the
             IETF know about the patent has no relationship with the patent owners.
             Click
-            <a href="{% url 'ietf.ipr.views.new' type='specific' %}">here</a>
+            <a href="{% url 'ietf.ipr.views.new' 'specific' %}">here</a>
             if you want to disclose information about patents or patent
             applications where you do have a relationship to the patent owners or
             patent applicants.

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -121,12 +121,11 @@
         {% endif %}
         {% if type != "generic" %}
             <h2 class="mt-4">{% cycle section %}. IETF document or other contribution to which this IPR disclosure relates</h2>
-            <p class="form-text">
+            <p>
                 If an Internet-Draft or RFC includes multiple parts and it is not
                 reasonably apparent which part of such Internet-Draft or RFC is alleged
-                to be covered by the patent information disclosed in Section
-                V(A) or V(B), please identify the sections of
-                the Internet-Draft or RFC that are alleged to be so
+                to be covered by the patent information disclosed in Section V,
+                please identify the sections of the Internet-Draft or RFC that are alleged to be so
                 covered.
             </p>
             {{ draft_formset.management_form }}
@@ -155,10 +154,14 @@
         </h2>
         {% if form.patent_number %}
             <p>
+                This IPR disclosure must either identify a specific patent or patents in sections V(A) and V(B)
+                below, or be made as a blanket IPR disclosure. 
+            </p>
+            {% bootstrap_field form.is_blanket_disclosure layout='horizontal' %}
+            <p>
                 A. For granted patents or published pending patent applications,
                 please provide the following information:
             </p>
-            {% bootstrap_field form.is_blanket_disclosure layout='horizontal' %}
             {% bootstrap_field form.patent_number layout='horizontal' %}
             {% bootstrap_field form.patent_inventor layout='horizontal' %}
             {% bootstrap_field form.patent_title layout='horizontal' %}

--- a/ietf/templates/ipr/details_edit.html
+++ b/ietf/templates/ipr/details_edit.html
@@ -158,6 +158,7 @@
                 A. For granted patents or published pending patent applications,
                 please provide the following information:
             </p>
+            {% bootstrap_field form.is_blanket_disclosure layout='horizontal' %}
             {% bootstrap_field form.patent_number layout='horizontal' %}
             {% bootstrap_field form.patent_inventor layout='horizontal' %}
             {% bootstrap_field form.patent_title layout='horizontal' %}


### PR DESCRIPTION
Fixes #7909 

This adds a boolean `is_blanket_disclosure` field to the `HolderIprDisclosure` model and related forms. When set, only "Royalty Free" licensing (option "b" in section VI) is allowed. The UI for this looks like this screenshot:

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/33af7bcc-8d12-4952-83d7-5884ce50e904">

> [!NOTE]
> When "This is a blanket IPR disclosure" is selected, the form is adjusted as follows

1. the fields in V(A) are made non-required (though can still be filled in if desired)
2. the licensing option "b" in section VI is selected and other options are disabled
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/545fa82c-3d9e-44bd-9624-ec439b99fef3">

If the "This is a blanket IPR disclosure" checkbox is then de-selected, those changes are reverted. If a licensing option had been selected before the box was checked, it is restored to that previous value.

The text below the heading in Section IV is changed from
> If an Internet-Draft or RFC includes multiple parts and it is not reasonably apparent which part of such Internet-Draft or RFC is alleged to be covered by the patent information disclosed in Section V(A) or V(B), please identify the sections of the Internet-Draft or RFC that are alleged to be so covered. 

to 

> If an Internet-Draft or RFC includes multiple parts and it is not reasonably apparent which part of such Internet-Draft or RFC is alleged to be covered by the patent information disclosed in Section V, please identify the sections of the Internet-Draft or RFC that are alleged to be so covered. 


This is a draft PR until we get confirmation that the implementation is satisfactory. We'll also need to update tests.