### PR TITLE
fix: start to reconcile internal inconsistencies wrt multiple from values

### DIFF
--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -53,7 +53,7 @@ class SendingMail(TestCase):
 
     def test_send_mail_preformatted(self):
         msg = """To: to1@example.com, to2@example.com
-From: from1@ietf.org, from2@ietf.org
+From: from1@ietf.org
 Cc: cc1@example.com, cc2@example.com
 Bcc: bcc1@example.com, bcc2@example.com
 Subject: subject
@@ -63,7 +63,7 @@ body
         send_mail_preformatted(None, msg, {}, {})
         recv = outbox[-1]
         self.assertSameEmail(recv['To'], '<to1@example.com>, <to2@example.com>')
-        self.assertSameEmail(recv['From'], 'from1@ietf.org, from2@ietf.org')
+        self.assertSameEmail(recv['From'], 'from1@ietf.org')
         self.assertSameEmail(recv['Cc'], 'cc1@example.com, cc2@example.com')
         self.assertSameEmail(recv['Bcc'], None)
         self.assertEqual(recv['Subject'], 'subject')
@@ -71,14 +71,14 @@ body
 
         override = {
             'To': 'oto1@example.net, oto2@example.net',
-            'From': 'ofrom1@ietf.org, ofrom2@ietf.org',
+            'From': 'ofrom1@ietf.org',
             'Cc': 'occ1@example.net, occ2@example.net',
             'Subject': 'osubject',
         }
         send_mail_preformatted(request=None, preformatted=msg, extra={}, override=override)
         recv = outbox[-1]
         self.assertSameEmail(recv['To'], '<oto1@example.net>, <oto2@example.net>')
-        self.assertSameEmail(recv['From'], 'ofrom1@ietf.org, ofrom2@ietf.org')
+        self.assertSameEmail(recv['From'], 'ofrom1@ietf.org')
         self.assertSameEmail(recv['Cc'], 'occ1@example.net, occ2@example.net')
         self.assertSameEmail(recv['Bcc'], None)
         self.assertEqual(recv['Subject'], 'osubject')
@@ -86,14 +86,14 @@ body
 
         override = {
             'To': ['<oto1@example.net>', 'oto2@example.net'],
-            'From': ['<ofrom1@ietf.org>', 'ofrom2@ietf.org'],
+            'From': ['<ofrom1@ietf.org>'],
             'Cc': ['<occ1@example.net>', 'occ2@example.net'],
             'Subject': 'osubject',
         }
         send_mail_preformatted(request=None, preformatted=msg, extra={}, override=override)
         recv = outbox[-1]
         self.assertSameEmail(recv['To'], '<oto1@example.net>, <oto2@example.net>')
-        self.assertSameEmail(recv['From'], '<ofrom1@ietf.org>, ofrom2@ietf.org')
+        self.assertSameEmail(recv['From'], '<ofrom1@ietf.org>')
         self.assertSameEmail(recv['Cc'], '<occ1@example.net>, occ2@example.net')
         self.assertSameEmail(recv['Bcc'], None)
         self.assertEqual(recv['Subject'], 'osubject')


### PR DESCRIPTION
Changes to parseaddr between 3.9.19 and 3.9.20 uncovered errors that have existed in our mail sending code since it was first written, and highlighted that the ietf.utils.mail module is inconsistent in its design for messages with multiple From header values.

This is a stopgap PR to preserve behavior to the extent possible as we upgrade python. More work will be needed to address the inconsistent ideas around multiple from header values.

We have not sent a message from the datatracker with multiple from header values in nearly 15 years, so for the moment, we're warning (in a way that intentionally raises test failures), but otherwise keeping the existing behavior if new attempts to use multiple values occur.

The older test that appeared to be testing multiple values was only passing as a coincidence of bugs in the code. It has been restricted to a single value until the module can be reworked.