### PR TITLE
fix: correct headers for charter evaluation email

### DIFF
--- a/ietf/templates/doc/charter/issue_ballot_mail.txt
+++ b/ietf/templates/doc/charter/issue_ballot_mail.txt
@@ -1,6 +1,6 @@
-{% load ietf_filters %}{% autoescape off %}To: {{ to }} {% if cc %}
-Cc: {{ cc }}
-{% endif %}From: IESG Secretary <iesg-secretary@ietf.org>
+{% load ietf_filters %}{% autoescape off %}To: {{ to }}{% if cc %}
+Cc: {{ cc }}{% endif %}
+From: IESG Secretary <iesg-secretary@ietf.org>
 Reply-To: IESG Secretary <iesg-secretary@ietf.org>
 Subject: Evaluation: {{ doc.name }}
 


### PR DESCRIPTION
To date, in production, a side-effect of the bad construction and older behavior of parseaddr let this succeed as it was interpreted as having no From and was sent with the default from header value instead of what was intended here.