### PR TITLE
fix: Change theme dynamically when system preferences change

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -30,16 +30,23 @@ const appContainer = ref(null)
 // Set user theme
 // --------------------------------------------------------------------
 
-const desiredTheme = window.localStorage?.getItem('theme')
-if (desiredTheme === 'dark') {
-  siteStore.theme = 'dark'
-} else if (desiredTheme === 'light') {
-  siteStore.theme = 'light'
-} else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-  siteStore.theme = 'dark'
-} else {
-  siteStore.theme = 'light'
+function updateTheme() {
+  const desiredTheme = window.localStorage?.getItem('theme')
+  if (desiredTheme === 'dark') {
+    siteStore.theme = 'dark'
+  } else if (desiredTheme === 'light') {
+    siteStore.theme = 'light'
+  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    siteStore.theme = 'dark'
+  } else {
+    siteStore.theme = 'light'
+  }
 }
+
+updateTheme()
+
+// this change event fires for either light or dark changes
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateTheme)
 
 // --------------------------------------------------------------------
 // Handle browser resize


### PR DESCRIPTION
Although the theme was correctly applied on page load we weren't monitoring OS theme preference changes that occur afterwards. This watches for these changes and recalculates the theme

Fixes #7739