### PR TITLE
fix: fix wg anchor tags (case-sensitive)

### DIFF
--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -88,11 +88,11 @@ class GroupPagesTests(TestCase):
             self.assertEqual(r.status_code, 200)
             self.assertContains(r, g.acronym)
             if t == "area":
-                self.assertContains(
-                    r,
-                    f'<a href="/wg/#{g.acronym.upper()}">({g.acronym.upper()})</a>',
-                    html=True,
-                )
+                q = PyQuery(r.content)
+                wg_url = urlreverse("ietf.group.views.active_groups", kwargs=dict(group_type="wg"))
+                href = f"{wg_url}#{g.acronym.upper()}"
+                self.assertEqual(q(f"h2#id-{g.acronym} a").attr("href"), href)
+                self.assertEqual(q(f'h2#id-{g.acronym} a[href="{href}"]').text(), f"({g.acronym.upper()})")
 
         url = urlreverse('ietf.group.views.active_groups', kwargs=dict())
         r = self.client.get(url)

--- a/ietf/group/tests_info.py
+++ b/ietf/group/tests_info.py
@@ -87,6 +87,12 @@ class GroupPagesTests(TestCase):
             r = self.client.get(url)
             self.assertEqual(r.status_code, 200)
             self.assertContains(r, g.acronym)
+            if t == "area":
+                self.assertContains(
+                    r,
+                    f'<a href="/wg/#{g.acronym.upper()}">({g.acronym.upper()})</a>',
+                    html=True,
+                )
 
         url = urlreverse('ietf.group.views.active_groups', kwargs=dict())
         r = self.client.get(url)

--- a/ietf/iesg/tests.py
+++ b/ietf/iesg/tests.py
@@ -412,6 +412,22 @@ class IESGAgendaTests(TestCase):
                 self.assertContains(r, d.name, msg_prefix="%s '%s' not in response" % (k, d.name))
                 self.assertContains(r, d.title, msg_prefix="%s '%s' title not in response" % (k, d.title))
 
+            if d.type_id in ["charter", "draft"]:
+                if d.group.parent is None:
+                    continue
+                if d.type_id == "charter":
+                    self.assertContains(
+                        r,
+                        f'<a href="/wg/#{d.group.parent.acronym.upper()}">{d.group.parent.acronym.upper()}</a>',
+                        html=True,
+                    )
+                elif d.type_id == "draft":
+                    self.assertContains(
+                        r,
+                        f'<a href="/wg/#{d.group.parent.acronym.upper()}">({d.group.parent.acronym.upper()})</a>',
+                        html=True,
+                    )
+
         for i, mi in enumerate(self.mgmt_items, start=1):
             s = "6." + str(i)
             self.assertContains(r, s, msg_prefix="Section '%s' not in response" % s)

--- a/ietf/templates/group/active_areas.html
+++ b/ietf/templates/group/active_areas.html
@@ -65,7 +65,7 @@
     {% for area in areas %}
         <h2 class="mt-5" id="id-{{ area.acronym|slugify }}">
             {{ area.name }}
-            <a href="{% url 'ietf.group.views.active_groups' group_type='wg' %}#{{ area.acronym }}">({{ area.acronym|upper }})</a>
+            <a href="{% url 'ietf.group.views.active_groups' group_type='wg' %}#{{ area.acronym|upper }}">({{ area.acronym|upper }})</a>
         </h2>
         {% if area.description %}
             <p>

--- a/ietf/templates/iesg/agenda_charter.html
+++ b/ietf/templates/iesg/agenda_charter.html
@@ -24,7 +24,7 @@
         <div class="row">
             <div class="col-3 text-end fw-bold">Area</div>
             <div class="col">
-                <a href="{% url 'ietf.group.views.active_groups' group_type='wg' %}#{{ doc.group.parent.acronym }}">
+                <a href="{% url 'ietf.group.views.active_groups' group_type='wg' %}#{{ doc.group.parent.acronym|upper }}">
                     {{ doc.group.parent.acronym|upper }}</a>
                 ({% person_link doc.ad %})
             </div>

--- a/ietf/templates/iesg/agenda_doc.html
+++ b/ietf/templates/iesg/agenda_doc.html
@@ -37,7 +37,7 @@
             <div class="col-3 text-end fw-bold">Token</div>
             <div class="col">
                 {% person_link doc.ad %}
-                <a href="{% url 'ietf.group.views.active_groups' group_type='wg' %}#{{ doc.group.parent.acronym }}">
+                <a href="{% url 'ietf.group.views.active_groups' group_type='wg' %}#{{ doc.group.parent.acronym|upper }}">
                     ({{ doc.group.parent.acronym|upper }})
                 </a>
             </div>


### PR DESCRIPTION
fixes #7994 

In https://github.com/ietf-tools/datatracker/blob/main/ietf/templates/group/active_wgs.html, it uses `upper`,
```jinja
    {% for area in areas %}
        <h2 class="mt-5" id="{{ area.acronym|upper }}">{{ area.name }} ({{ area.acronym|upper }})</h2>
```

so it's now doing the same on the area's side.