### PR TITLE
fix: turn off automatic escaping in session request templates

### DIFF
--- a/ietf/secr/sreq/tests.py
+++ b/ietf/secr/sreq/tests.py
@@ -15,7 +15,7 @@ from ietf.meeting.factories import MeetingFactory, SessionFactory
 from ietf.name.models import ConstraintName, TimerangeName
 from ietf.person.models import Person
 from ietf.secr.sreq.forms import SessionForm
-from ietf.utils.mail import outbox, empty_outbox, get_payload_text
+from ietf.utils.mail import outbox, empty_outbox, get_payload_text, send_mail
 from ietf.utils.timezone import date_today
 
 
@@ -77,6 +77,34 @@ class SessionRequestTestCase(TestCase):
         r = self.client.get(url)
         self.assertRedirects(r,reverse('ietf.secr.sreq.views.main'))
         self.assertEqual(SchedulingEvent.objects.filter(session=session).order_by('-id')[0].status_id, 'deleted')
+
+    def test_cancel_notification_msg(self):
+        to = "<iesg-secretary@ietf.org>"
+        subject = "Dummy subject"
+        template = "sreq/session_cancel_notification.txt"
+        requester = Person.objects.get(user__username="ad_2")
+        context = {
+            "meeting": MeetingFactory(type_id="ietf", date=date_today()),
+            "requester": requester,
+        }
+        cc = "cc.a@example.com, cc.b@example.com"
+        bcc = "bcc@example.com"
+
+        msg = send_mail(
+            None,
+            to,
+            None,
+            subject,
+            template,
+            context,
+            cc=cc,
+            bcc=bcc,
+        )
+        self.assertIn("'", requester.name)  # James O'Rourke
+        self.assertIn(
+            f"A request to cancel a meeting session has just been submitted by {requester.name}.",
+            get_payload_text(msg),
+        )
 
     def test_edit(self):
         meeting = MeetingFactory(type_id='ietf', date=date_today())
@@ -700,6 +728,36 @@ class SubmitRequestCase(TestCase):
         self.assertIn('1 Hour, 1 Hour', notification_payload)
         self.assertNotIn('1 Hour, 1 Hour, 1 Hour', notification_payload)
         self.assertNotIn('The third session requires your approval', notification_payload)
+
+    def test_request_notification_msg(self):
+        to = "<iesg-secretary@ietf.org>"
+        subject = "Dummy subject"
+        template = "sreq/session_request_notification.txt"
+        header = "A new"
+        requester = Person.objects.get(user__username="ad_2")
+        context = {
+            "header": header,
+            "meeting": MeetingFactory(type_id="ietf", date=date_today()),
+            "requester": requester,
+        }
+        cc = "cc.a@example.com, cc.b@example.com"
+        bcc = "bcc@example.com"
+
+        msg = send_mail(
+            None,
+            to,
+            None,
+            subject,
+            template,
+            context,
+            cc=cc,
+            bcc=bcc,
+        )
+        self.assertIn("'", requester.name)  # James O'Rourke
+        self.assertIn(
+            f"{header} meeting session request has just been submitted by {requester.name}.",
+            get_payload_text(msg),
+        )
 
     def test_request_notification_third_session(self):
         meeting = MeetingFactory(type_id='ietf', date=date_today())

--- a/ietf/secr/sreq/tests.py
+++ b/ietf/secr/sreq/tests.py
@@ -83,11 +83,9 @@ class SessionRequestTestCase(TestCase):
         to = "<iesg-secretary@ietf.org>"
         subject = "Dummy subject"
         template = "sreq/session_cancel_notification.txt"
+        meeting = MeetingFactory(type_id="ietf", date=date_today())
         requester = PersonFactory(name="James O'Rourke", user__username="jimorourke")
-        context = {
-            "meeting": MeetingFactory(type_id="ietf", date=date_today()),
-            "requester": requester,
-        }
+        context = {"meeting": meeting, "requester": requester}
         cc = "cc.a@example.com, cc.b@example.com"
         bcc = "bcc@example.com"
 
@@ -735,12 +733,9 @@ class SubmitRequestCase(TestCase):
         subject = "Dummy subject"
         template = "sreq/session_request_notification.txt"
         header = "A new"
+        meeting = MeetingFactory(type_id="ietf", date=date_today())
         requester = PersonFactory(name="James O'Rourke", user__username="jimorourke")
-        context = {
-            "header": header,
-            "meeting": MeetingFactory(type_id="ietf", date=date_today()),
-            "requester": requester,
-        }
+        context = {"header": header, "meeting": meeting, "requester": requester}
         cc = "cc.a@example.com, cc.b@example.com"
         bcc = "bcc@example.com"
 

--- a/ietf/secr/sreq/tests.py
+++ b/ietf/secr/sreq/tests.py
@@ -13,6 +13,7 @@ from ietf.group.factories import GroupFactory, RoleFactory
 from ietf.meeting.models import Session, ResourceAssociation, SchedulingEvent, Constraint
 from ietf.meeting.factories import MeetingFactory, SessionFactory
 from ietf.name.models import ConstraintName, TimerangeName
+from ietf.person.factories import PersonFactory
 from ietf.person.models import Person
 from ietf.secr.sreq.forms import SessionForm
 from ietf.utils.mail import outbox, empty_outbox, get_payload_text, send_mail
@@ -82,7 +83,7 @@ class SessionRequestTestCase(TestCase):
         to = "<iesg-secretary@ietf.org>"
         subject = "Dummy subject"
         template = "sreq/session_cancel_notification.txt"
-        requester = Person.objects.get(user__username="ad_2")
+        requester = PersonFactory(name="James O'Rourke", user__username="jimorourke")
         context = {
             "meeting": MeetingFactory(type_id="ietf", date=date_today()),
             "requester": requester,
@@ -100,7 +101,7 @@ class SessionRequestTestCase(TestCase):
             cc=cc,
             bcc=bcc,
         )
-        self.assertIn("'", requester.name)  # James O'Rourke
+        self.assertEqual(requester.name, "James O'Rourke")  # note ' (single quote) in the name
         self.assertIn(
             f"A request to cancel a meeting session has just been submitted by {requester.name}.",
             get_payload_text(msg),
@@ -734,7 +735,7 @@ class SubmitRequestCase(TestCase):
         subject = "Dummy subject"
         template = "sreq/session_request_notification.txt"
         header = "A new"
-        requester = Person.objects.get(user__username="ad_2")
+        requester = PersonFactory(name="James O'Rourke", user__username="jimorourke")
         context = {
             "header": header,
             "meeting": MeetingFactory(type_id="ietf", date=date_today()),
@@ -753,7 +754,7 @@ class SubmitRequestCase(TestCase):
             cc=cc,
             bcc=bcc,
         )
-        self.assertIn("'", requester.name)  # James O'Rourke
+        self.assertEqual(requester.name, "James O'Rourke")  # note ' (single quote) in the name
         self.assertIn(
             f"{header} meeting session request has just been submitted by {requester.name}.",
             get_payload_text(msg),

--- a/ietf/secr/templates/sreq/session_cancel_notification.txt
+++ b/ietf/secr/templates/sreq/session_cancel_notification.txt
@@ -1,4 +1,3 @@
-{% load ams_filters %}
+{% autoescape off %}{% load ams_filters %}
 
-A request to cancel a meeting session has just been submitted by {{ requester }}.
-
+A request to cancel a meeting session has just been submitted by {{ requester }}.{% endautoescape %}

--- a/ietf/secr/templates/sreq/session_request_notification.txt
+++ b/ietf/secr/templates/sreq/session_request_notification.txt
@@ -1,5 +1,5 @@
-{% load ams_filters %}
+{% autoescape off %}{% load ams_filters %}
 
 {% filter wordwrap:78 %}{{ header }} meeting session request has just been submitted by {{ requester }}.{% endfilter %}
 
-{% include "includes/session_info.txt" %}
+{% include "includes/session_info.txt" %}{% endautoescape %}

--- a/ietf/utils/test_data.py
+++ b/ietf/utils/test_data.py
@@ -107,6 +107,7 @@ def make_immutable_base_data():
     # one area
     area = create_group(name="Far Future", acronym="farfut", type_id="area", parent=ietf)
     create_person(area, "ad", name="Areað Irector", username="ad", email_address="aread@example.org")
+    create_person(area, "ad", name="James O'Rourke", username="ad_2", email_address="aread_2@example.org")
 
     # second area
     opsarea = create_group(name="Operations", acronym="ops", type_id="area", parent=ietf)

--- a/ietf/utils/test_data.py
+++ b/ietf/utils/test_data.py
@@ -107,7 +107,6 @@ def make_immutable_base_data():
     # one area
     area = create_group(name="Far Future", acronym="farfut", type_id="area", parent=ietf)
     create_person(area, "ad", name="Areað Irector", username="ad", email_address="aread@example.org")
-    create_person(area, "ad", name="James O'Rourke", username="ad_2", email_address="aread_2@example.org")
 
     # second area
     opsarea = create_group(name="Operations", acronym="ops", type_id="area", parent=ietf)


### PR DESCRIPTION
fixes #7993 