### PR TITLE
fix: versioned href for slides URL

### DIFF
--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1840,7 +1840,7 @@ def agenda_extract_slide(item):
         "id": item.id,
         "title": item.title,
         "rev": item.rev,
-        "url": item.get_versionless_href(),
+        "url": item.get_href(),
         "ext": item.file_extension(),
     }
 

--- a/ietf/utils/meetecho.py
+++ b/ietf/utils/meetecho.py
@@ -481,12 +481,10 @@ class ConferenceManager(Manager):
 class SlidesManager(Manager):
     """Interface between Datatracker models and Meetecho API
     
-    Note: The URL we send comes from get_versionless_href(). This should match what we use as the
-    URL in api_get_session_materials(). Additionally, it _must_ give the right result for a Document
-    instance that has not yet been persisted to the database. This is because upload_session_slides()
-    (as of 2024-03-07) SessionPresentations before saving its updated Documents. This means, for
-    example, using get_absolute_url() will cause bugs. (We should refactor upload_session_slides() to
-    avoid this requirement.) 
+    Note: the URL sent for a slide deck comes from DocumentInfo.get_href() and includes the revision
+    of the slides being sent. Be sure that 1) the URL matches what api_get_session_materials() returns
+    for the slides; and 2) the URL is valid if it is fetched immediately - possibly even before the call
+    to SlidesManager.add() or send_update() returns.
     """
 
     def __init__(self, api_config):
@@ -521,7 +519,7 @@ class SlidesManager(Manager):
             deck={
                 "id": slides.pk,
                 "title": slides.title,
-                "url": slides.get_versionless_href(),  # see above note re: get_versionless_href()
+                "url": slides.get_href(),
                 "rev": slides.rev,
                 "order": order,
             }
@@ -575,7 +573,7 @@ class SlidesManager(Manager):
                 {
                     "id": deck.document.pk,
                     "title": deck.document.title,
-                    "url": deck.document.get_versionless_href(),  # see note above re: get_versionless_href()
+                    "url": deck.document.get_href(),
                     "rev": deck.document.rev,
                     "order": deck.order,
                 }

--- a/ietf/utils/tests_meetecho.py
+++ b/ietf/utils/tests_meetecho.py
@@ -558,7 +558,7 @@ class SlidesManagerTests(TestCase):
                 deck={
                     "id": slides_doc.pk,
                     "title": slides_doc.title,
-                    "url": slides_doc.get_versionless_href(),
+                    "url": slides_doc.get_href(session.meeting),
                     "rev": slides_doc.rev,
                     "order": 13,
                 },
@@ -597,7 +597,7 @@ class SlidesManagerTests(TestCase):
                     {
                         "id": slides_doc.pk,
                         "title": slides_doc.title,
-                        "url": slides_doc.get_versionless_href(),
+                        "url": slides_doc.get_href(session.meeting),
                         "rev": slides_doc.rev,
                         "order": 1,
                     },
@@ -635,7 +635,7 @@ class SlidesManagerTests(TestCase):
                 deck={
                     "id": slides_doc.pk,
                     "title": slides_doc.title,
-                    "url": slides_doc.get_versionless_href(),
+                    "url": slides_doc.get_href(slides.session.meeting),
                     "rev": slides_doc.rev,
                     "order": 23,
                 },
@@ -660,7 +660,7 @@ class SlidesManagerTests(TestCase):
                     {
                         "id": slides.document_id,
                         "title": slides.document.title,
-                        "url": slides.document.get_versionless_href(),
+                        "url": slides.document.get_href(slides.session.meeting),
                         "rev": slides.document.rev,
                         "order": 0,
                     }


### PR DESCRIPTION
Sends a versioned URL constructed by `DocumentInfo.get_href()` instead of `get_versionless_href()`. This should avoid cache-related issues when Meetecho updates their slides. It also fixes a bug (which, afaik, has not been encountered) where the latest slides would always be shown, even if a specific version was selected.

The comment about why `get_versionless_href()` was used appears to be stale - I think it was fixed in #7172, which was committed before any of this ever hit the main branch to begin with. I checked all the uses and do not see any situations where it a slides document (or related `SessionPresentation`) is changed/saved after a `SlidesManager()` method is called.