### PR TITLE
fix: Set overflow-y to clip for pre

### DIFF
--- a/ietf/static/css/document_html_txt.scss
+++ b/ietf/static/css/document_html_txt.scss
@@ -344,7 +344,7 @@ div:is(.artwork, .sourcecode) pre {
   flex: 0 0 content;
   margin: 0;
   max-width: 72ch;
-  overflow: auto;
+  overflow: auto clip;
 }
 div:is(.artwork, .sourcecode) .pilcrow {
   flex: 0 0 1ch;


### PR DESCRIPTION
Browsers treat an overflow: auto directive as a request to make an element scrollable, even if the element does not need it. This results in scrolling being confined to that element sometimes, such as when a document is scrolled using a mouse wheel if the document scrolls the pointer into that element. The result is that scrolling can be "trapped" on an element that doesn't really need to scroll.

This disables vertical scrolling for those pre elements that might trap scrolling in this way.