### PR TITLE
chore: Bypass Firefox for Playwright test due to flakiness

### DIFF
--- a/playwright/tests/status/status.spec.js
+++ b/playwright/tests/status/status.spec.js
@@ -20,6 +20,10 @@ test.describe('site status', () => {
     by: 'Exile is a cool Amiga game'
   }
 
+  test.beforeEach(({ browserName }) => {
+    test.skip(browserName === 'firefox', 'bypassing flaky tests on Firefox')
+  })
+
   test('Renders server status as Notification', async ({ page }) => {
     await page.route('/status/latest.json', route => {
       route.fulfill({


### PR DESCRIPTION
These tests don't test anything Firefox-specific (it's conventional JavaScript mostly dependant on a 3rd-party library) so we've decided to bypass these tests in Firefox and just rely on Chrome.