### PR TITLE
ci: replace nginx default.conf

### DIFF
--- a/k8s/auth.yaml
+++ b/k8s/auth.yaml
@@ -84,7 +84,7 @@ spec:
               mountPath: /etc/nginx/conf.d/00logging.conf
               subPath: nginx-logging.conf
             - name: dt-cfg
-              mountPath: /etc/nginx/conf.d/auth.conf
+              mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx-auth.conf
         # -----------------------------------------------------
         # ScoutAPM Container

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -84,7 +84,8 @@ spec:
               mountPath: /etc/nginx/conf.d/00logging.conf
               subPath: nginx-logging.conf
             - name: dt-cfg
-              mountPath: /etc/nginx/conf.d/datatracker.conf
+              # Replaces the original default.conf
+              mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx-datatracker.conf
         # -----------------------------------------------------
         # ScoutAPM Container


### PR DESCRIPTION
In deployments to date, we've put the datatracker's nginx configurations in `/etc/nginx/conf.d/` alongside the default configuration from the docker image. The `default_server` option on the `listen` directive in our configuration normally causes our server to take precedence.

This PR goes one step further and places our configuration _over_ the default config. This eliminates the default "localhost" server that otherwise is still listening. Given how we route traffic, I don't think this is exposed in a harmful way, but better to replace it more thoroughly since it's never intended to be used.