### PR TITLE
fix: Disallow header wrapping CSS

### DIFF
--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -46,7 +46,7 @@
                     {% endif %}
                 </a>
                 <div class="collapse navbar-collapse" id="navbar-collapse">
-                    <ul class="nav navbar-nav">
+                    <ul class="nav navbar-nav flex-nowrap">
                         {% include "base/menu.html" with flavor="top" %}
                     </ul>
                 </div>


### PR DESCRIPTION
Although it's rare for header nav items to wrap they can and this would overlap and obscure page content. This only occurs on the desktop responsive mode. This one-liner fix prevents wrapping because our layout doesn't support wrapping anyway. This fixes #7920.

**screenshot from #7920 where a user triggered this bug**
![header](https://github.com/user-attachments/assets/430613f8-c012-4df4-85c9-f275d9ca4e5b)

In the following screenshots I modified the template to add the text "wrapping" to trigger the bug more easily.

**before the fix**
![Screenshot from 2024-11-03 11-06-22](https://github.com/user-attachments/assets/df3c2369-71cc-47ab-b3cb-6dc32f9a2094)

**after the fix**
![Screenshot from 2024-11-03 11-06-00](https://github.com/user-attachments/assets/4298f572-0f95-4aa4-9465-14893bfe1cd9)

The header (`<nav>`) and page content (`<main>`) are in separate [CSS flow layouts](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout) because the header is `position:fixed` so when the header wraps it can't push the page content down. They only appear to be adjacent due to the `navbar-offset` CSS on `<body>`.

This wrapping bug can be caused in several ways
1. a narrow browser width or zoom level to be in desktop responsive mode and nearly in mobile mode. The zoom level is more than 175% and less than 200%, so around 180%.
2. a long username (username text appears in the header so longer text will cause wrapping)
3. OS font rendering that's slightly wider than usual.

This CSS fix could cause horizontal scrolling but it doesn't for me, and that seem preferable to obscuring the page content.

I considered another approach to allow wrapping and use JS to measure the height of the header (repeatedly as the user may resize their browser) and use the header height to set the `navbar-offset` but that seemed unnecessarily complicated.

You may be asking yourself whether this is a lot of text for a one-liner fix, and yes — yes it is. You're welcome.