### PR TITLE
feat: async refresh of agenda data

### DIFF
--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -1,0 +1,12 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+#
+# Celery task definitions
+#
+from celery import shared_task
+
+from .views import generate_agenda_data
+
+
+@shared_task
+def agenda_data_refresh():
+    generate_agenda_data(force_refresh=True)


### PR DESCRIPTION
Refreshes the current meeting's agenda data whenever the new task is called. My plan would be to schedule this every 5 minutes, keeping ahead of the 6 minute cache timeout.

We should think about how to handle old meetings and whether we want to be running this task outside of meeting weeks. Old meetings could be more aggressively cached.