### PR TITLE
fix: queue tasks in on_commit hook

### DIFF
--- a/ietf/community/models.py
+++ b/ietf/community/models.py
@@ -3,7 +3,7 @@
 
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.db.models import signals
 from django.urls import reverse as urlreverse
 
@@ -117,7 +117,10 @@ def notify_events(sender, instance, **kwargs):
     # start a Celery task during tests. To prevent this, don't queue a celery task if we're running
     # tests.
     if settings.SERVER_MODE != "test":
-        notify_event_to_subscribers_task.delay(event_id=instance.pk)
+        # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+        transaction.on_commit(
+            lambda: notify_event_to_subscribers_task.delay(event_id=instance.pk)
+        )
 
 
 signals.post_save.connect(notify_events)

--- a/ietf/community/tests.py
+++ b/ietf/community/tests.py
@@ -431,8 +431,10 @@ class CommunityListTests(TestCase):
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
 
+    # Mock out the on_commit call so we can tell whether the task was actually queued
+    @mock.patch("ietf.submit.views.transaction.on_commit", side_effect=lambda x: x())
     @mock.patch("ietf.community.models.notify_event_to_subscribers_task")
-    def test_notification_signal_receiver(self, mock_notify_task):
+    def test_notification_signal_receiver(self, mock_notify_task, mock_on_commit):
         """Saving a DocEvent should notify subscribers
         
         This implicitly tests that notify_events is hooked up to the post_save signal.


### PR DESCRIPTION
Queuing a task in a Django view should be done in a `transaction.on_commit()` hook so they see the results of any changes made in the view.