### PR TITLE
fix: Agenda mobile goto now

### DIFF
--- a/client/agenda/AgendaMobileBar.vue
+++ b/client/agenda/AgendaMobileBar.vue
@@ -3,11 +3,13 @@
   n-dropdown(
     :options='jumpToDayOptions'
     size='huge'
+    :show='isDropdownOpenRef'
     :show-arrow='true'
     trigger='click'
     @select='jumpToDay'
+    @clickoutside='handleCloseDropdown'
     )
-    button
+    button(@click='handleOpenDropdown')
       i.bi.bi-arrow-down-circle
   button(@click='agendaStore.$patch({ filterShown: true })')
     i.bi.bi-funnel
@@ -28,7 +30,7 @@
 </template>
 
 <script setup>
-import { computed, h } from 'vue'
+import { computed, h, ref } from 'vue'
 import {
   NBadge,
   NDropdown,
@@ -78,6 +80,12 @@ function optionToLink(opts){
   }
 }
 
+const isDropdownOpenRef = ref(false)
+
+const handleOpenDropdown = () => isDropdownOpenRef.value = true
+
+const handleCloseDropdown = () => isDropdownOpenRef.value = false
+
 const jumpToDayOptions = computed(() => {
   const days = []
   if (agendaStore.isMeetingLive) {
@@ -125,6 +133,7 @@ function jumpToDay (dayId) {
   } else {
     document.getElementById(dayId)?.scrollIntoView(true)
   }
+  isDropdownOpenRef.value = false
 }
 
 function downloadIcs (key) {

--- a/client/agenda/AgendaMobileBar.vue
+++ b/client/agenda/AgendaMobileBar.vue
@@ -61,7 +61,8 @@ function optionToLink(opts){
       {
         class: 'dropdown-link',
         'data-testid': 'mobile-link',
-        href: `#${key}`
+        href: `#${key}`,
+        onClick: () => jumpToDay(key)
       },
       [
         h(


### PR DESCRIPTION
[The previous change](https://github.com/ietf-tools/datatracker/pull/7772) to the mobile menu days worked because there were ids in the page for days, but there wasn't an id in the page for 'now'. `jumpToDay` was never called so this adds an onClick handler to call `jumpToDay` as it was before.

Also, because we're using links in the dropdown rather than buttons we need to manually show the dropdown, and there's code for that too.