### PR TITLE
feat: Agenda proposed badge

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -83,6 +83,14 @@
                 template(#trigger)
                   span.badge.is-bof BoF
                 span #[a(href='https://www.ietf.org/how/bofs/', target='_blank') Birds of a Feather] sessions (BoFs) are initial discussions about a particular topic of interest to the IETF community.
+              n-popover(
+                v-if='item.isProposed'
+                trigger='hover'
+                :width='250'
+                )
+                template(#trigger)
+                  span.badge.is-proposed Proposed
+                span #[a(href='https://www.ietf.org/process/wgs/', target='_blank') Proposed WGs] are groups in the process of being chartered. If the charter is not approved by the IESG before the IETF meeting, the session may be canceled.
               .agenda-table-note(v-if='item.note')
                 i.bi.bi-arrow-return-right.me-1
                 span {{item.note}}
@@ -468,6 +476,7 @@ const meetingEvents = computed(() => {
       // groupParentName: item.groupParent?.name,
       icon,
       isBoF: item.isBoF,
+      isProposed: item.isProposed,
       isSessionEvent: item.type === 'regular',
       links,
       location: item.location,
@@ -1012,9 +1021,24 @@ onBeforeUnmount(() => {
         word-wrap: break-word;
       }
 
-      .badge.is-bof {
-        background-color: $teal-500;
+      .badge {
         margin: 0 8px;
+
+        &.is-bof {
+          background-color: $teal-500;
+
+          @at-root .theme-dark & {
+            background-color: $teal-700;
+          }
+        }
+
+        &.is-proposed {
+          background-color: $gray-500;
+
+          @at-root .theme-dark & {
+            background-color: $gray-700;
+          }
+        }
 
         @media screen and (max-width: $bs5-break-md) {
           width: 30px;

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -1786,6 +1786,7 @@ def agenda_extract_schedule (item):
         "type": item.session.type.slug,
         "purpose": item.session.purpose.slug,
         "isBoF": item.session.group_at_the_time().state_id == "bof",
+        "isProposed": item.session.group_at_the_time().state_id == "proposed",
         "filterKeywords": item.filter_keywords,
         "groupAcronym": item.session.group_at_the_time().acronym,
         "groupName": item.session.group_at_the_time().name,


### PR DESCRIPTION
* Adds a grey 'Proposed' badge to sessions with a state of proposed. 
![Screenshot from 2024-11-15 09-14-37](https://github.com/user-attachments/assets/b25bb906-78ba-4aa4-9723-b75b18ab71e3)
* In dark mode darkens the 'BoF' badge to make it more readable. Before: ![Screenshot from 2024-11-06 10-49-49](https://github.com/user-attachments/assets/fe754d9e-a625-4eb5-b80e-f01177e8542f). After: ![Screenshot from 2024-11-06 10-48-43](https://github.com/user-attachments/assets/d462f721-651a-4c6f-9c5d-104621cf3bd9) .

fixes #8026