### PR TITLE
feat: add support for display of differing fullname and asciiFullname

### DIFF
--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -637,6 +637,14 @@ class XMLDraftTests(TestCase):
                 fullname="Joanna Q. Public",
                 asciiFullname="Not the Same at All",
             )),
+            "Joanna Q. Public (Not the Same at All)",
+        )
+        self.assertEqual(
+            XMLDraft.render_author_name(lxml.etree.Element(
+                "author",
+                fullname="Joanna Q. Public",
+                asciiFullname="Joanna Q. Public",
+            )),
             "Joanna Q. Public",
         )
         self.assertEqual(

--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -193,6 +193,9 @@ class XMLDraft(Draft):
         # Use fullname attribute, if present
         fullname = author_elt.attrib.get("fullname", "").strip()
         if fullname:
+            asciifullname = author_elt.attrib.get("asciiFullname", "").strip()
+            if asciifullname and asciifullname != fullname:
+                fullname = fullname + ' (' + asciifullname + ')'
             return fullname
         surname = author_elt.attrib.get("surname", "").strip()
         initials = author_elt.attrib.get("initials", "").strip()


### PR DESCRIPTION
This is used, for example, when the fullname uses extended UTF-8 characters and it's helpful to also include the asciiFullname for those who cannot read the UTF-8 name. The form is:

fullname (asciiFullname)

This came up in issue #7167, which noted that the announcement email generated when a new Internet-Draft is uploaded, it only showed the fullname despite the draft itself containing both name forms.

Change the render_author_name test set for the revised name format.