### PR TITLE
chore: clarify transaction-related comments

### DIFF
--- a/ietf/community/models.py
+++ b/ietf/community/models.py
@@ -117,7 +117,7 @@ def notify_events(sender, instance, **kwargs):
     # start a Celery task during tests. To prevent this, don't queue a celery task if we're running
     # tests.
     if settings.SERVER_MODE != "test":
-        # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+        # Wrap in on_commit in case a transaction is open
         transaction.on_commit(
             lambda: notify_event_to_subscribers_task.delay(event_id=instance.pk)
         )

--- a/ietf/submit/tests.py
+++ b/ietf/submit/tests.py
@@ -2334,8 +2334,8 @@ class ApprovalsTestCase(BaseSubmitTestCase):
         self.assertEqual(len(Preapproval.objects.filter(name=preapproval.name)), 0)
 
 
-# Transaction.on_commit() requires use of TransactionTestCase, but that has a performance penalty. Replace it
-# with a no-op for testing purposes.
+# Transaction.on_commit() interacts badly with TestCase's transaction behavior. Replace it
+# with a pass-through for testing purposes.
 @mock.patch.object(transaction, 'on_commit', lambda x: x())
 @override_settings(IDTRACKER_BASE_URL='https://datatracker.example.com')
 class ApiSubmissionTests(BaseSubmitTestCase):

--- a/ietf/submit/views.py
+++ b/ietf/submit/views.py
@@ -90,7 +90,8 @@ def upload_submission(request):
             clear_existing_files(form)
             save_files(form)
             create_submission_event(request, submission, desc="Uploaded submission")
-            # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+            # Wrap in on_commit in case a transaction is open
+            # (As of 2024-11-08, this only runs in a transaction during tests)
             transaction.on_commit(
                 lambda: process_uploaded_submission_task.delay(submission.pk)
             )
@@ -166,7 +167,8 @@ def api_submission(request):
                 save_files(form)
                 create_submission_event(request, submission, desc="Uploaded submission through API")
 
-                # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+                # Wrap in on_commit in case a transaction is open
+                # (As of 2024-11-08, this only runs in a transaction during tests)
                 transaction.on_commit(
                     lambda: process_and_accept_uploaded_submission_task.delay(submission.pk)
                 )

--- a/ietf/sync/views.py
+++ b/ietf/sync/views.py
@@ -80,25 +80,29 @@ def notify(request, org, notification):
     if request.method == "POST":
         if notification == "index":
             log("Queuing RFC Editor index sync from notify view POST")
-            # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+            # Wrap in on_commit in case a transaction is open
+            # (As of 2024-11-08, this only runs in a transaction during tests)
             transaction.on_commit(
                 lambda: tasks.rfc_editor_index_update_task.delay()
             )
         elif notification == "queue":
             log("Queuing RFC Editor queue sync from notify view POST")
-            # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+            # Wrap in on_commit in case a transaction is open
+            # (As of 2024-11-08, this only runs in a transaction during tests)
             transaction.on_commit(
                 lambda: tasks.rfc_editor_queue_updates_task.delay()
             )
         elif notification == "changes":
             log("Queuing IANA changes sync from notify view POST")
-            # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+            # Wrap in on_commit in case a transaction is open
+            # (As of 2024-11-08, this only runs in a transaction during tests)
             transaction.on_commit(
                 lambda: tasks.iana_changes_update_task.delay()
             )
         elif notification == "protocols":
             log("Queuing IANA protocols sync from notify view POST")
-            # Wrap in on_commit so the delayed task cannot start until the view is done with the DB
+            # Wrap in on_commit in case a transaction is open
+            # (As of 2024-11-08, this only runs in a transaction during tests)
             transaction.on_commit(
                 lambda: tasks.iana_protocols_update_task.delay()
             )


### PR DESCRIPTION
Better reflects actual transaction handling, hopefully to reduce future confusion. No code changes, only comments. 