### PR TITLE
fix: move future meetings button in group meetings page to the left

### DIFF
--- a/ietf/templates/group/meetings.html
+++ b/ietf/templates/group/meetings.html
@@ -40,7 +40,7 @@
     {% if future %}
         <h2 class="mt-5" id="futuremeets">
             Future Meetings
-            <a class="float-end"
+            <a class="ms-2"
                aria-label="icalendar entry for all scheduled future {{ group.acronym }} meetings"
                title="icalendar entry for all scheduled future {{ group.acronym }} meetings"
                href="{% url 'ietf.meeting.views.upcoming_ical' %}?show={{ group.acronym }}">


### PR DESCRIPTION
Move the webcal link icon in the group meetings page to the left:

![image](https://github.com/user-attachments/assets/267a61de-0624-4d7b-9f9d-413c0f3b7f22)

Right now it's completely to the right which makes it hard to find and you might not even realize it's a button.