### PR TITLE
test: drf URL names + API tests

### DIFF
--- a/ietf/api/routers.py
+++ b/ietf/api/routers.py
@@ -1,0 +1,16 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+"""Custom django-rest-framework routers"""
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import routers
+
+class PrefixedSimpleRouter(routers.SimpleRouter):
+    """SimpleRouter that adds a dot-separated prefix to its basename"""
+    def __init__(self, name_prefix="", *args, **kwargs):
+        self.name_prefix = name_prefix
+        if len(self.name_prefix) == 0 or self.name_prefix[-1] == ".":
+            raise ImproperlyConfigured("Cannot use a name_prefix that is empty or ends with '.'")
+        super().__init__(*args, **kwargs)
+
+    def get_default_basename(self, viewset):
+        basename = super().get_default_basename(viewset)
+        return f"{self.name_prefix}.{basename}"

--- a/ietf/api/tests_core.py
+++ b/ietf/api/tests_core.py
@@ -83,7 +83,87 @@ class PersonTests(CoreApiTestCase):
 
 class EmailTests(CoreApiTestCase):
     def test_email_update(self):
-        self.fail("not implemented")
+        email = EmailFactory(
+            address="original@example.org", primary=False, active=True, origin="factory"
+        )
+        person = email.person
+        other_person = PersonFactory()
+        url = urlreverse(
+            "ietf.api.core_api.email-detail", kwargs={"pk": "original@example.org"}
+        )
+        bad_url = urlreverse(
+            "ietf.api.core_api.email-detail",
+            kwargs={"pk": "not-original@example.org"},
+        )
+
+        r = self.client.put(
+            bad_url, data={"primary": True, "active": False}, format="json"
+        )
+        self.assertEqual(r.status_code, 403, "Must be logged in preferred to 404")
+        r = self.client.put(url, data={"primary": True, "active": False}, format="json")
+        self.assertEqual(r.status_code, 403, "Must be logged in")
+
+        self.client.login(
+            username=other_person.user.username,
+            password=other_person.user.username + "+password",
+        )
+        r = self.client.put(
+            bad_url, data={"primary": True, "active": False}, format="json"
+        )
+        self.assertEqual(r.status_code, 404, "No such address")
+        r = self.client.put(url, data={"primary": True, "active": False}, format="json")
+        self.assertEqual(r.status_code, 403, "Can only access own addresses")
+
+        self.client.login(
+            username=person.user.username, password=person.user.username + "+password"
+        )
+        r = self.client.put(url, data={"primary": True, "active": False}, format="json")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.data,
+            {
+                "person": person.pk,
+                "address": "original@example.org",
+                "primary": True,
+                "active": False,
+                "origin": "factory",
+            },
+        )
+        email.refresh_from_db()
+        self.assertEqual(email.person, person)
+        self.assertEqual(email.address, "original@example.org")
+        self.assertTrue(email.primary)
+        self.assertFalse(email.active)
+        self.assertEqual(email.origin, "factory")
+
+        # address / origin should be immutable
+        r = self.client.put(
+            url,
+            data={
+                "address": "modified@example.org",
+                "primary": True,
+                "active": False,
+                "origin": "hacker",
+            },
+            format="json",
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.data,
+            {
+                "person": person.pk,
+                "address": "original@example.org",
+                "primary": True,
+                "active": False,
+                "origin": "factory",
+            },
+        )
+        email.refresh_from_db()
+        self.assertEqual(email.person, person)
+        self.assertEqual(email.address, "original@example.org")
+        self.assertTrue(email.primary)
+        self.assertFalse(email.active)
+        self.assertEqual(email.origin, "factory")
 
     def test_email_partial_update(self):
         self.fail("not implemented")

--- a/ietf/api/tests_core.py
+++ b/ietf/api/tests_core.py
@@ -22,6 +22,10 @@ class PersonTests(CoreApiTestCase):
         bad_pk = person.pk + 10000
         if Person.objects.filter(pk=bad_pk).exists():
             bad_pk += 10000  # if this doesn't get us clear, something is wrong...
+            self.assertFalse(
+                Person.objects.filter(pk=bad_pk).exists(),
+                "Failed to find a non-existent person pk",
+            )
         bad_url = urlreverse("ietf.api.core_api.person-detail", kwargs={"pk": bad_pk})
         r = self.client.get(bad_url, format="json")
         self.assertEqual(r.status_code, 403, "Must be logged in preferred to 404")

--- a/ietf/api/tests_core.py
+++ b/ietf/api/tests_core.py
@@ -14,9 +14,15 @@ class CoreApiTestCase(TestCase):
 class PersonTests(CoreApiTestCase):
     def test_person_detail(self):
         person = PersonFactory()
+        other_person = PersonFactory()
         url = urlreverse("ietf.api.core_api.person-detail", kwargs={"pk": person.pk})
         r = self.client.get(url, format="json")
-        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.status_code, 403, "Must be logged in")
+        self.client.login(
+            username=other_person.user.username, password=other_person.user.username + "+password"
+        )
+        r = self.client.get(url, format="json")
+        self.assertEqual(r.status_code, 403, "Can only retrieve self")
         self.client.login(
             username=person.user.username, password=person.user.username + "+password"
         )

--- a/ietf/api/tests_core.py
+++ b/ietf/api/tests_core.py
@@ -1,9 +1,11 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 """Core API tests"""
+from unittest.mock import patch, call
+
 from django.urls import reverse as urlreverse
 from rest_framework.test import APIClient
 
-from ietf.person.factories import PersonFactory
+from ietf.person.factories import PersonFactory, EmailFactory
 from ietf.utils.test_utils import TestCase
 
 
@@ -19,7 +21,8 @@ class PersonTests(CoreApiTestCase):
         r = self.client.get(url, format="json")
         self.assertEqual(r.status_code, 403, "Must be logged in")
         self.client.login(
-            username=other_person.user.username, password=other_person.user.username + "+password"
+            username=other_person.user.username,
+            password=other_person.user.username + "+password",
         )
         r = self.client.get(url, format="json")
         self.assertEqual(r.status_code, 403, "Can only retrieve self")
@@ -45,3 +48,42 @@ class PersonTests(CoreApiTestCase):
                 ],
             },
         )
+
+    @patch("ietf.person.api.send_new_email_confirmation_request")
+    def test_add_email(self, send_confirmation_mock):
+        email = EmailFactory(address="old@example.org")
+        person = email.person
+        other_person = PersonFactory()
+        url = urlreverse("ietf.api.core_api.person-email", kwargs={"pk": person.pk})
+        post_data = {"address": "new@example.org"}
+
+        r = self.client.post(url, data=post_data, format="json")
+        self.assertEqual(r.status_code, 403, "Must be logged in")
+        self.assertFalse(send_confirmation_mock.called)
+
+        self.client.login(
+            username=other_person.user.username,
+            password=other_person.user.username + "+password",
+        )
+        r = self.client.post(url, data=post_data, format="json")
+        self.assertEqual(r.status_code, 403, "Can only retrieve self")
+        self.assertFalse(send_confirmation_mock.called)
+
+        self.client.login(
+            username=person.user.username, password=person.user.username + "+password"
+        )
+        r = self.client.post(url, data=post_data, format="json")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data, {"address": "new@example.org"})
+        self.assertTrue(send_confirmation_mock.called)
+        self.assertEqual(
+            send_confirmation_mock.call_args, call(person, "new@example.org")
+        )
+
+
+class EmailTests(CoreApiTestCase):
+    def test_email_update(self):
+        self.fail("not implemented")
+
+    def test_email_partial_update(self):
+        self.fail("not implemented")

--- a/ietf/api/tests_core.py
+++ b/ietf/api/tests_core.py
@@ -1,0 +1,41 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+"""Core API tests"""
+from django.urls import reverse as urlreverse
+from rest_framework.test import APIClient
+
+from ietf.person.factories import PersonFactory
+from ietf.utils.test_utils import TestCase
+
+
+class CoreApiTestCase(TestCase):
+    client_class = APIClient
+
+
+class PersonTests(CoreApiTestCase):
+    def test_person_detail(self):
+        person = PersonFactory()
+        url = urlreverse("ietf.api.core_api.person-detail", kwargs={"pk": person.pk})
+        r = self.client.get(url, format="json")
+        self.assertEqual(r.status_code, 403)
+        self.client.login(
+            username=person.user.username, password=person.user.username + "+password"
+        )
+        r = self.client.get(url, format="json")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.data,
+            {
+                "id": person.pk,
+                "name": person.name,
+                "emails": [
+                    {
+                        "person": person.pk,
+                        "address": email.address,
+                        "primary": email.primary,
+                        "active": email.active,
+                        "origin": email.origin,
+                    }
+                    for email in person.email_set.all()
+                ],
+            },
+        )

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -1,22 +1,22 @@
 # Copyright The IETF Trust 2017-2024, All Rights Reserved
 from drf_spectacular.views import SpectacularAPIView
-from rest_framework import routers
-
 
 from django.conf import settings
 from django.urls import include, path
 from django.views.generic import TemplateView
 
 from ietf import api
-from ietf.api import views as api_views
 from ietf.doc import views_ballot
 from ietf.meeting import views as meeting_views
 from ietf.person import api as person_api
 from ietf.submit import views as submit_views
 from ietf.utils.urls import url
 
+from . import views as api_views
+from .routers import PrefixedSimpleRouter 
+
 # DRF API routing
-core_router = routers.DefaultRouter()  # core api router
+core_router = PrefixedSimpleRouter(name_prefix="ietf.api.core_api")  # core api router
 core_router.register("email", person_api.EmailViewSet)
 core_router.register("person", person_api.PersonViewSet)
 

--- a/ietf/person/api.py
+++ b/ietf/person/api.py
@@ -2,6 +2,7 @@
 """DRF API Views"""
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from ietf.api.permissions import BelongsToOwnPerson, IsOwnPerson
@@ -16,7 +17,7 @@ class EmailViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
     
     Only allows updating an existing email for now.
     """
-    permission_classes = [BelongsToOwnPerson]
+    permission_classes = [IsAuthenticated & BelongsToOwnPerson]
     queryset = Email.objects.all()
     serializer_class = EmailSerializer
     lookup_value_regex = '.+@.+'  # allow @-sign in the pk
@@ -24,7 +25,7 @@ class EmailViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
 
 class PersonViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     """Person viewset"""
-    permission_classes = [IsOwnPerson]
+    permission_classes = [IsAuthenticated & IsOwnPerson]
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
 


### PR DESCRIPTION
The custom `SimpleRouter` gives DRF API views names like `ietf.api.core_api.email-detail` or `...email-list`. Adds tests of the person / email endpoints.