### PR TITLE
fix: flaky playwright status tests

### DIFF
--- a/playwright/tests/status/status.spec.js
+++ b/playwright/tests/status/status.spec.js
@@ -20,7 +20,8 @@ test.describe('site status', () => {
     by: 'Exile is a cool Amiga game'
   }
 
-  test.beforeEach(({ browserName }) => {
+  test.beforeEach(({ page, browserName }) => {
+    page.setDefaultTimeout(15 * 1000) // increase default timeout
     test.skip(browserName === 'firefox', 'bypassing flaky tests on Firefox')
   })
 


### PR DESCRIPTION
Attempts to fix the flaky playwright Status tests by **increasing playwright timeout for Status from 5s to 15s**

Over [~10~ **_20_** test runs on CI](https://github.com/ietf-tools/datatracker/actions/runs/11984306165?pr=8267) it passed every time. Did I just get lucky or does this fix it? :shrug: 

Increasing the timeout doesn't seem to affect the overall playwright test running time in any noticable way in this statistically insignificant sample:
![Screenshot from 2024-11-24 17-38-36](https://github.com/user-attachments/assets/007a385d-48aa-4bcb-93b5-f5bda50082db)
([spreadsheet](https://docs.google.com/spreadsheets/d/1iBKH9ZqDEj20ijuQJlI2cJjOtlDhz6CxuFd1mlyVYTg/edit?gid=977665448#gid=977665448))
