### PR TITLE
feat: API for RFC metadata fetch/filtering

### DIFF
--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -1,25 +1,29 @@
 # Copyright The IETF Trust 2017-2024, All Rights Reserved
 
+from drf_spectacular.views import SpectacularAPIView
+
 from django.conf import settings
-from django.urls import include
+from django.urls import include, path
 from django.views.generic import TemplateView
 
 from ietf import api
-from ietf.doc import views_ballot
+from ietf.doc import views_ballot, api as doc_api
 from ietf.meeting import views as meeting_views
 from ietf.submit import views as submit_views
 from ietf.utils.urls import url
 
 from . import views as api_views
+from .routers import PrefixedSimpleRouter 
 
 # DRF API routing - disabled until we plan to use it
-# from drf_spectacular.views import SpectacularAPIView
-# from django.urls import path
 # from ietf.person import api as person_api
-# from .routers import PrefixedSimpleRouter 
 # core_router = PrefixedSimpleRouter(name_prefix="ietf.api.core_api")  # core api router
 # core_router.register("email", person_api.EmailViewSet)
 # core_router.register("person", person_api.PersonViewSet)
+
+# todo more general name for this API?
+red_router = PrefixedSimpleRouter(name_prefix="ietf.api.red_api")  # red api router
+red_router.register("doc", doc_api.RfcViewSet)
 
 api.autodiscover()
 
@@ -32,7 +36,8 @@ urlpatterns = [
     url(r'^v2/person/person', api_views.ApiV2PersonExportView.as_view()),
     # --- DRF API ---
     # path("core/", include(core_router.urls)),
-    # path("schema/", SpectacularAPIView.as_view()),
+    path("red/", include(red_router.urls)),
+    path("schema/", SpectacularAPIView.as_view()),
     #
     # --- Custom API endpoints, sorted alphabetically ---
     # Email alias information for drafts

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -3,6 +3,7 @@
 from django.db.models import OuterRef, Subquery
 from django.db.models.functions import TruncDate
 from django_filters import rest_framework as filters
+from rest_framework import filters as drf_filters
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.viewsets import GenericViewSet
@@ -58,5 +59,6 @@ class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
 
     serializer_class = RfcMetadataSerializer
     pagination_class = RfcLimitOffsetPagination
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, drf_filters.SearchFilter]
     filterset_class = RfcFilter
+    search_fields = ["title", "abstract"]

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -34,7 +34,12 @@ class RfcFilter(filters.FilterSet):
         field_name="group__parent__acronym",
         to_field_name="acronym",
     )
-
+    sort = filters.OrderingFilter(
+        fields = (
+            ("rfc_number", "number"),  # ?sort=number / ?sort=-number
+            ("published", "published"),  # ?sort=published / ?sort=-published
+        ),
+    )
 
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes = []
@@ -49,7 +54,7 @@ class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         ),
     ).annotate(
         published=TruncDate("published_datetime", tzinfo=RPC_TZINFO)
-    ).order_by("-rfc_number")
+    ).order_by("-rfc_number")  # default ordering - RfcFilter may override
 
     serializer_class = RfcMetadataSerializer
     pagination_class = RfcLimitOffsetPagination

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -1,0 +1,13 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+"""Doc API implementations"""
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from .models import Document
+from .serializers import RfcMetadataSerializer
+
+
+class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    permission_classes = []
+    queryset = Document.objects.filter(type_id="rfc")
+    serializer_class = RfcMetadataSerializer

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -1,10 +1,14 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 """Doc API implementations"""
+from django.db.models import OuterRef, Subquery
+from django.db.models.functions import TruncDate
+from django_filters import rest_framework as filters
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.viewsets import GenericViewSet
 
-from .models import Document
+from ietf.utils.timezone import RPC_TZINFO
+from .models import Document, DocEvent
 from .serializers import RfcMetadataSerializer
 
 
@@ -13,8 +17,26 @@ class RfcLimitOffsetPagination(LimitOffsetPagination):
     max_limit = 500
 
 
+class RfcFilter(filters.FilterSet):
+    published = filters.DateFromToRangeFilter()
+
+
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes = []
-    pagination_class = RfcLimitOffsetPagination
-    queryset = Document.objects.filter(type_id="rfc").order_by("-rfc_number")
+    queryset = Document.objects.filter(
+        type_id="rfc"
+    ).annotate(
+        published_datetime=Subquery(
+            DocEvent.objects.filter(
+                doc_id=OuterRef("pk"),
+                type="published_rfc",
+            ).order_by("-time").values("time")[:1]
+        ),
+    ).annotate(
+        published=TruncDate("published_datetime", tzinfo=RPC_TZINFO)
+    ).order_by("-rfc_number")
+
     serializer_class = RfcMetadataSerializer
+    pagination_class = RfcLimitOffsetPagination
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_class = RfcFilter

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -7,10 +7,11 @@ from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.viewsets import GenericViewSet
 
+from ietf.group.models import Group
+from ietf.name.models import StreamName
 from ietf.utils.timezone import RPC_TZINFO
 from .models import Document, DocEvent
 from .serializers import RfcMetadataSerializer
-from ..name.models import StreamName
 
 
 class RfcLimitOffsetPagination(LimitOffsetPagination):
@@ -20,7 +21,19 @@ class RfcLimitOffsetPagination(LimitOffsetPagination):
 
 class RfcFilter(filters.FilterSet):
     published = filters.DateFromToRangeFilter()
-    stream = filters.ModelMultipleChoiceFilter(queryset=StreamName.objects.filter(used=True))
+    stream = filters.ModelMultipleChoiceFilter(
+        queryset=StreamName.objects.filter(used=True)
+    )
+    group = filters.ModelMultipleChoiceFilter(
+        queryset=Group.objects.wgs(),
+        field_name="group__acronym",
+        to_field_name="acronym",
+    )
+    area = filters.ModelMultipleChoiceFilter(
+        queryset=Group.objects.areas(),
+        field_name="group__parent__acronym",
+        to_field_name="acronym",
+    )
 
 
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -10,6 +10,7 @@ from rest_framework.viewsets import GenericViewSet
 from ietf.utils.timezone import RPC_TZINFO
 from .models import Document, DocEvent
 from .serializers import RfcMetadataSerializer
+from ..name.models import StreamName
 
 
 class RfcLimitOffsetPagination(LimitOffsetPagination):
@@ -19,6 +20,7 @@ class RfcLimitOffsetPagination(LimitOffsetPagination):
 
 class RfcFilter(filters.FilterSet):
     published = filters.DateFromToRangeFilter()
+    stream = filters.ModelMultipleChoiceFilter(queryset=StreamName.objects.filter(used=True))
 
 
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -1,13 +1,20 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 """Doc API implementations"""
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.viewsets import GenericViewSet
 
 from .models import Document
 from .serializers import RfcMetadataSerializer
 
 
+class RfcLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 10
+    max_limit = 500
+
+
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes = []
-    queryset = Document.objects.filter(type_id="rfc")
+    pagination_class = RfcLimitOffsetPagination
+    queryset = Document.objects.filter(type_id="rfc").order_by("-rfc_number")
     serializer_class = RfcMetadataSerializer

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -12,7 +12,7 @@ from ietf.group.models import Group
 from ietf.name.models import StreamName
 from ietf.utils.timezone import RPC_TZINFO
 from .models import Document, DocEvent
-from .serializers import RfcMetadataSerializer
+from .serializers import RfcMetadataSerializer, RfcStatus
 
 
 class RfcLimitOffsetPagination(LimitOffsetPagination):
@@ -34,6 +34,10 @@ class RfcFilter(filters.FilterSet):
         queryset=Group.objects.areas(),
         field_name="group__parent__acronym",
         to_field_name="acronym",
+    )
+    status = filters.MultipleChoiceFilter(
+        choices=[(slug, slug) for slug in RfcStatus.status_slugs],
+        method=RfcStatus.filter,
     )
     sort = filters.OrderingFilter(
         fields=(

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -38,7 +38,7 @@ class DocIdentifierSerializer(serializers.Serializer):
 class RfcMetadataSerializer(serializers.ModelSerializer):
     # all fields are stand-ins
     # updates = serializers.CharField()
-    # date = serializers.CharField()
+    published = serializers.DateField()
     authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
     # identifiers = fields.SerializerMethodField()
 
@@ -48,7 +48,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "title",
-            # "date",
+            "published",
             "pages",
             "authors",
             "group",

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -8,6 +8,7 @@ from rest_framework import serializers, fields
 
 from ietf.name.serializers import StreamNameSerializer
 from .models import Document, DocumentAuthor
+from ..group.serializers import GroupSerializer
 
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
@@ -36,6 +37,8 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     # updates = serializers.CharField()
     published = serializers.DateField()
     authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
+    group = GroupSerializer()
+    area = GroupSerializer(source="group.area", required=False)
     stream = StreamNameSerializer()
     identifiers = fields.SerializerMethodField()
 
@@ -49,7 +52,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "pages",
             "authors",
             "group",
-            # "area",
+            "area",
             "stream",
             "identifiers",
         ]

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -13,6 +13,7 @@ from ..group.serializers import GroupSerializer
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
     """Serializer for a DocumentAuthor in a response"""
+
     name = fields.CharField(source="person.plain_name")
     email = fields.EmailField(source="email.address", required=False)
 
@@ -62,5 +63,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     def get_identifiers(self, doc: Document):
         identifiers = []
         if doc.rfc_number:
-            identifiers.append(DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}"))
+            identifiers.append(
+                DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}")
+            )
         return DocIdentifierSerializer(instance=identifiers, many=True).data

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -35,6 +35,7 @@ class DocIdentifierSerializer(serializers.Serializer):
 class RfcMetadataSerializer(serializers.ModelSerializer):
     # all fields are stand-ins
     # updates = serializers.CharField()
+    number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()
     authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
     group = GroupSerializer()
@@ -46,7 +47,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
         model = Document
         fields = [
             "id",
-            "name",
+            "number",
             "title",
             "published",
             "pages",

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -8,7 +8,7 @@ from rest_framework import serializers, fields
 
 from ietf.group.serializers import GroupSerializer
 from ietf.name.serializers import StreamNameSerializer
-from .models import Document, DocumentAuthor
+from .models import Document, DocumentAuthor, RelatedDocument
 
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
@@ -107,9 +107,13 @@ class RfcStatusSerializer(serializers.Serializer):
         return super().to_representation(instance=RfcStatus.from_document(instance))
 
 
+class RelatedRfcSerializer(serializers.Serializer):
+    id = serializers.IntegerField(source="source.id")
+    number = serializers.IntegerField(source="source.rfc_number")
+    title = serializers.CharField(source="source.title")
+
+
 class RfcMetadataSerializer(serializers.ModelSerializer):
-    # all fields are stand-ins
-    # updates = serializers.CharField()
     number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()
     status = RfcStatusSerializer(source="*")
@@ -118,6 +122,8 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     area = GroupSerializer(source="group.area", required=False)
     stream = StreamNameSerializer()
     identifiers = fields.SerializerMethodField()
+    obsoleted_by = RelatedRfcSerializer(many=True, read_only=True)
+    updated_by = RelatedRfcSerializer(many=True, read_only=True)
 
     class Meta:
         model = Document
@@ -133,6 +139,8 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "area",
             "stream",
             "identifiers",
+            "obsoleted_by",
+            "updated_by",
         ]
 
     @extend_schema_field(DocIdentifierSerializer)

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -1,14 +1,14 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 """django-rest-framework serializers"""
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, ClassVar
 
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers, fields
 
+from ietf.group.serializers import GroupSerializer
 from ietf.name.serializers import StreamNameSerializer
 from .models import Document, DocumentAuthor
-from ..group.serializers import GroupSerializer
 
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
@@ -33,11 +33,65 @@ class DocIdentifierSerializer(serializers.Serializer):
     value = serializers.CharField()
 
 
+# This should become "type RfcStatusSlugT ..." when we drop pre-py3.12 support
+# It should be "RfcStatusSlugT: TypeAlias ..." when we drop py3.9 support
+RfcStatusSlugT = Literal[
+    "standard", "bcp", "informational", "experimental", "historic", "unknown"
+]
+
+
+@dataclass
+class RfcStatus:
+    """Helper to extract the 'Status' from an RFC document for serialization"""
+
+    slug: RfcStatusSlugT
+
+    # Names that aren't just the slug itself. ClassVar annotation prevents dataclass from treating this as a field.
+    fancy_names: ClassVar[dict[RfcStatusSlugT, str]] = {
+        "standard": "standards track",
+        "bcp": "best current practice",
+    }
+
+    # ClassVar annotation prevents dataclass from treating this as a field
+    stdlevelname_slug_map: ClassVar[dict[str, RfcStatusSlugT]] = {
+        "bcp": "bcp",
+        "ds": "standard",  # ds is obsolete
+        "exp": "experimental",
+        "hist": "historic",
+        "inf": "informational",
+        "std": "standard",
+        "ps": "standard",
+        "unkn": "unknown",
+    }
+
+    @property
+    def name(self):
+        return RfcStatus.fancy_names.get(self.slug, self.slug)
+
+    @classmethod
+    def from_document(cls, doc: Document):
+        """Decide the status that applies to a document"""
+        return cls(
+            slug=(cls.stdlevelname_slug_map.get(doc.std_level.slug, "unknown")),
+        )
+
+
+class RfcStatusSerializer(serializers.Serializer):
+    """Status serializer for a Document instance"""
+
+    slug = serializers.ChoiceField(choices=list(RfcStatus.stdlevelname_slug_map.keys()))
+    name = serializers.CharField()
+
+    def to_representation(self, instance: Document):
+        return super().to_representation(instance=(RfcStatus.from_document(instance)))
+
+
 class RfcMetadataSerializer(serializers.ModelSerializer):
     # all fields are stand-ins
     # updates = serializers.CharField()
     number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()
+    status = RfcStatusSerializer(source="*")
     authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
     group = GroupSerializer()
     area = GroupSerializer(source="group.area", required=False)
@@ -51,6 +105,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "number",
             "title",
             "published",
+            "status",
             "pages",
             "authors",
             "group",

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -37,7 +37,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     published = serializers.DateField()
     authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
     stream = StreamNameSerializer()
-    # identifiers = fields.SerializerMethodField()
+    identifiers = fields.SerializerMethodField()
 
     class Meta:
         model = Document
@@ -51,7 +51,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "group",
             # "area",
             "stream",
-            # "identifiers",
+            "identifiers",
         ]
 
     @extend_schema_field(DocIdentifierSerializer)
@@ -59,4 +59,4 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
         identifiers = []
         if doc.rfc_number:
             identifiers.append(DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}"))
-        return DocIdentifierSerializer(data=identifiers, many=True)
+        return DocIdentifierSerializer(instance=identifiers, many=True).data

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -1,0 +1,65 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+"""django-rest-framework serializers"""
+from dataclasses import dataclass
+from typing import Literal
+
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers, fields
+
+from .models import Document, DocumentAuthor
+
+
+class RfcAuthorSerializer(serializers.ModelSerializer):
+    """Serializer for a DocumentAuthor in a response"""
+    name = fields.CharField(source="person.plain_name")
+    email = fields.EmailField(source="email.address", required=False)
+
+    class Meta:
+        model = DocumentAuthor
+        fields = ["person", "name", "email", "affiliation", "country"]
+
+    # @extend_schema_field(fields.CharField)
+    # def get_name(self, document_author: DocumentAuthor) -> str:
+    #     """Name that should be shown for the RFC author list"""
+    #     return document_author.person.plain_name()
+
+
+@dataclass
+class DocIdentifier:
+    type: Literal["doi", "issn"]
+    value: str
+
+
+class DocIdentifierSerializer(serializers.Serializer):
+    type = serializers.ChoiceField(choices=["doi", "issn"])
+    value = serializers.CharField()
+
+
+class RfcMetadataSerializer(serializers.ModelSerializer):
+    # all fields are stand-ins
+    # updates = serializers.CharField()
+    # date = serializers.CharField()
+    authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
+    # identifiers = fields.SerializerMethodField()
+
+    class Meta:
+        model = Document
+        fields = [
+            "id",
+            "name",
+            "title",
+            # "date",
+            "pages",
+            "authors",
+            "group",
+            # "area",
+            "stream",
+            # "identifiers",
+        ]
+
+    @extend_schema_field(DocIdentifierSerializer)
+    def get_identifiers(self, doc: Document):
+        identifiers = []
+        if doc.rfc_number:
+            identifiers.append(DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}"))
+        return DocIdentifierSerializer(data=identifiers, many=True)

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -104,7 +104,7 @@ class RfcStatusSerializer(serializers.Serializer):
     name = serializers.CharField()
 
     def to_representation(self, instance: Document):
-        return super().to_representation(instance=(RfcStatus.from_document(instance)))
+        return super().to_representation(instance=RfcStatus.from_document(instance))
 
 
 class RfcMetadataSerializer(serializers.ModelSerializer):

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -6,6 +6,7 @@ from typing import Literal
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers, fields
 
+from ietf.name.serializers import StreamNameSerializer
 from .models import Document, DocumentAuthor
 
 
@@ -17,11 +18,6 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
     class Meta:
         model = DocumentAuthor
         fields = ["person", "name", "email", "affiliation", "country"]
-
-    # @extend_schema_field(fields.CharField)
-    # def get_name(self, document_author: DocumentAuthor) -> str:
-    #     """Name that should be shown for the RFC author list"""
-    #     return document_author.person.plain_name()
 
 
 @dataclass
@@ -40,6 +36,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     # updates = serializers.CharField()
     published = serializers.DateField()
     authors = RfcAuthorSerializer(many=True, source="documentauthor_set")
+    stream = StreamNameSerializer()
     # identifiers = fields.SerializerMethodField()
 
     class Meta:

--- a/ietf/group/models.py
+++ b/ietf/group/models.py
@@ -112,6 +112,9 @@ class GroupManager(models.Manager):
     def closed_wgs(self):
         return self.wgs().exclude(state__in=Group.ACTIVE_STATE_IDS)
 
+    def areas(self):
+        return self.get_queryset().filter(type="area")
+
     def with_meetings(self):
         return self.get_queryset().filter(type__features__has_meetings=True)
 

--- a/ietf/group/serializers.py
+++ b/ietf/group/serializers.py
@@ -1,0 +1,11 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+"""django-rest-framework serializers"""
+from rest_framework import serializers
+
+from .models import Group
+
+
+class GroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Group
+        fields = ["acronym", "name"]

--- a/ietf/name/serializers.py
+++ b/ietf/name/serializers.py
@@ -1,0 +1,11 @@
+# Copyright The IETF Trust 2024, All Rights Reserved
+"""django-rest-framework serializers"""
+from rest_framework import serializers
+
+from .models import StreamName
+
+
+class StreamNameSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StreamName
+        fields = ["slug", "name", "desc"]

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -19,6 +19,7 @@ warnings.filterwarnings("ignore", "Log out via GET requests is deprecated")  # h
 warnings.filterwarnings("ignore", module="tastypie", message="The django.utils.datetime_safe module is deprecated.")
 warnings.filterwarnings("ignore", module="oidc_provider", message="The django.utils.timezone.utc alias is deprecated.")
 warnings.filterwarnings("ignore", message="The USE_DEPRECATED_PYTZ setting,")  # https://github.com/ietf-tools/datatracker/issues/5635
+warnings.filterwarnings("ignore", message="The is_dst argument to make_aware\\(\\)")  # caused by django-filters when USE_DEPRECATED_PYTZ is true 
 warnings.filterwarnings("ignore", message="The USE_L10N setting is deprecated.")  # https://github.com/ietf-tools/datatracker/issues/5648
 warnings.filterwarnings("ignore", message="django.contrib.auth.hashers.CryptPasswordHasher is deprecated.")  # https://github.com/ietf-tools/datatracker/issues/5663
 warnings.filterwarnings("ignore", message="'urllib3\\[secure\\]' extra is deprecated")
@@ -454,6 +455,7 @@ INSTALLED_APPS = [
     'django_celery_beat',
     'corsheaders',
     'django_markup',
+    'django_filters',
     'oidc_provider',
     'drf_spectacular',
     'drf_standardized_errors',

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-celery-beat>=2.3.0
 django-csp>=3.7
 django-cors-headers>=3.11.0
 django-debug-toolbar>=3.2.4
+django-filter>=24.3
 django-markup>=1.5    # Limited use - need to reconcile against direct use of markdown
 django-oidc-provider>=0.8.1    # 0.8 dropped Django 2 support
 django-referrer-policy>=1.0


### PR DESCRIPTION
This starts an API to be used by the RFC editor website (code name: red) to retrieve RFCs. So far, it deals only in metadata and authors. I've put these API endpoints under `/api/red/` at least for now - we can argue about that later.

Allows filtering by several fields (stream, group, area, publication date) using query parameters. The OpenAPI spec will describe the syntax of the filters accurately (`ietf/manage.py spectacular --file datatracker.yml` to generate), but to get all SIP RFCs published between 2011 and 2013, you'd request `http://localhost:8000/api/red/doc/?published_after=2011-01-01&published_before=2013-01-01&group=sip`.  The stream, group, and area filters accept multiple values, combined with "OR". Multiple values are requested by repeating the parameter, like `?group=sip&group=stir`

Results are paginated with a limit of 500 results per request. To paginate, use `?limit=20&offset=20`. The response JSON includes `count`, `next`, and `previous` fields with the total record count and links to previous/next pages of results. The actual results are in `results`.