### PR TITLE
fix: test file existence using metadata

### DIFF
--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -546,8 +546,12 @@ class DocumentInfo(models.Model):
         path = Path(self._text_path())
         if not path.exists():
             return None
-        with path.open('rb') as file:
-            raw = file.read(size)
+        try:
+            with path.open('rb') as file:
+                raw = file.read(size)
+        except IOError as e:
+            log.log(f"Error reading text for {path}: {e}")
+            return None
         text = None
         try:
             text = raw.decode('utf-8')

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -530,12 +530,20 @@ class DocumentInfo(models.Model):
     def replaced_by(self):
         return set([ r.document for r in self.related_that("replaces") ])
 
-    def text(self, size = -1):
+    def _text_path(self):
         path = self.get_file_name()
         root, ext =  os.path.splitext(path)
         txtpath = root+'.txt'
         if ext != '.txt' and os.path.exists(txtpath):
             path = txtpath
+        return path
+    
+    def text_exists(self):
+        path = Path(self._text_path())
+        return path.exists()
+
+    def text(self, size = -1):
+        path = self._text_path()
         try:
             with io.open(path, 'rb') as file:
                 raw = file.read(size)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -4,7 +4,6 @@
 
 import datetime
 import logging
-import io
 import os
 
 import django.db

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -543,12 +543,11 @@ class DocumentInfo(models.Model):
         return path.exists()
 
     def text(self, size = -1):
-        path = self._text_path()
-        try:
-            with io.open(path, 'rb') as file:
-                raw = file.read(size)
-        except IOError:
+        path = Path(self._text_path())
+        if not path.exists():
             return None
+        with path.open('rb') as file:
+            raw = file.read(size)
         text = None
         try:
             text = raw.decode('utf-8')

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -1081,7 +1081,7 @@ def build_file_urls(doc: Union[Document, DocHistory]):
             label = "plain text" if t == "txt" else t
             file_urls.append((label, base + doc.name + "-" + doc.rev + "." + t))
 
-        if doc.text():
+        if doc.text_exists():
             file_urls.append(("htmlized", urlreverse('ietf.doc.views_doc.document_html', kwargs=dict(name=doc.name, rev=doc.rev))))
             file_urls.append(("pdfized", urlreverse('ietf.doc.views_doc.document_pdfized', kwargs=dict(name=doc.name, rev=doc.rev))))
         file_urls.append(("bibtex", urlreverse('ietf.doc.views_doc.document_bibtex',kwargs=dict(name=doc.name,rev=doc.rev))))


### PR DESCRIPTION
Without something like this, each view of a draft's main page reads the entire file twice.