### PR TITLE
chore: drop unused cf-connecting-ipv6 header

### DIFF
--- a/ietf/utils/jsonlogger.py
+++ b/ietf/utils/jsonlogger.py
@@ -29,7 +29,6 @@ class GunicornRequestJsonFormatter(DatatrackerJsonFormatter):
         log_record.setdefault("x_forwarded_for", record.args["{x-forwarded-for}i"])
         log_record.setdefault("x_forwarded_proto", record.args["{x-forwarded-proto}i"])
         log_record.setdefault("cf_connecting_ip", record.args["{cf-connecting-ip}i"])
-        log_record.setdefault("cf_connecting_ipv6", record.args["{cf-connecting-ipv6}i"])
         log_record.setdefault("cf_ray", record.args["{cf-ray}i"])
         log_record.setdefault("asn", record.args["{x-ip-src-asnum}i"])
         log_record.setdefault("is_authenticated", record.args["{x-datatracker-is-authenticated}o"])

--- a/k8s/nginx-logging.conf
+++ b/k8s/nginx-logging.conf
@@ -17,7 +17,6 @@ log_format  ietfjson  escape=json
     '"x_forwarded_for":"$${keepempty}http_x_forwarded_for",'
     '"x_forwarded_proto":"$${keepempty}http_x_forwarded_proto",'
     '"cf_connecting_ip":"$${keepempty}http_cf_connecting_ip",'
-    '"cf_connecting_ipv6":"$${keepempty}http_cf_connecting_ipv6",'
     '"cf_ray":"$${keepempty}http_cf_ray",'
     '"asn":"$${keepempty}http_x_ip_src_asnum"'
   '}';


### PR DESCRIPTION
Only used in certain configurations of Cloudflare's Pseudo IPv4.