### PR TITLE
feat: retrieve single rfc, including text

### DIFF
--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -50,8 +50,9 @@ class RfcFilter(filters.FilterSet):
 
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes: list[BasePermission] = []
+    lookup_field = "rfc_number"
     queryset = (
-        Document.objects.filter(type_id="rfc")
+        Document.objects.filter(type_id="rfc", rfc_number__isnull=False)
         .annotate(
             published_datetime=Subquery(
                 DocEvent.objects.filter(

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -13,7 +13,7 @@ from ietf.group.models import Group
 from ietf.name.models import StreamName
 from ietf.utils.timezone import RPC_TZINFO
 from .models import Document, DocEvent, RelatedDocument
-from .serializers import RfcMetadataSerializer, RfcStatus
+from .serializers import RfcMetadataSerializer, RfcStatus, RfcSerializer
 
 
 class RfcLimitOffsetPagination(LimitOffsetPagination):
@@ -82,9 +82,12 @@ class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
             ),
         )
     )  # default ordering - RfcFilter may override
-
-    serializer_class = RfcMetadataSerializer
     pagination_class = RfcLimitOffsetPagination
     filter_backends = [filters.DjangoFilterBackend, drf_filters.SearchFilter]
     filterset_class = RfcFilter
     search_fields = ["title", "abstract"]
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return RfcSerializer
+        return RfcMetadataSerializer

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -114,6 +114,8 @@ class RelatedRfcSerializer(serializers.Serializer):
 
 
 class RfcMetadataSerializer(serializers.ModelSerializer):
+    """Serialize metadata of an RFC"""
+
     number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()
     status = RfcStatusSerializer(source="*")
@@ -152,3 +154,13 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
                 DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}")
             )
         return DocIdentifierSerializer(instance=identifiers, many=True).data
+
+
+class RfcSerializer(RfcMetadataSerializer):
+    """Serialize an RFC, including its metadata and text content if available"""
+
+    text = serializers.CharField(allow_null=True)
+
+    class Meta:
+        model = RfcMetadataSerializer.Meta.model
+        fields = RfcMetadataSerializer.Meta.fields + ["text"]

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -130,7 +130,6 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     class Meta:
         model = Document
         fields = [
-            "id",
             "number",
             "title",
             "published",


### PR DESCRIPTION
This makes the stub of a retrieve action via GET of `/api/red/doc/<rfc number>/` into a working endpoint. It replaces doc id with RFC number as a lookup attribute and stops exposing the doc ID through this interface.

Adds a `text` field to the retrieve action that includes the plaintext format of the requested document when available. If not available, returns a null value instead.

Per our discussion on Dec 17 about how we'll store / serve document contents, there's a fairly good chance we'll change that last part in the future. This gets data to the front end to serve in the short term though, which will allow progress on the front end while we're working out the storage details.