### PR TITLE
feat: monitoring API

### DIFF
--- a/ietf/api/serializers.py
+++ b/ietf/api/serializers.py
@@ -1,0 +1,10 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+"""Serializers for django-rest-framework"""
+from rest_framework import serializers
+
+
+class MonitoringResultSerializer(serializers.Serializer):
+    """Serialize a MonitoringResult"""
+
+    result_type = serializers.CharField()
+    result_value = serializers.IntegerField()

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -10,18 +10,21 @@ from ietf.meeting import views as meeting_views
 from ietf.submit import views as submit_views
 from ietf.utils.urls import url
 
+from . import autodiscover as api_autodiscover
 from . import views as api_views
+from .views_api import MonitoringViewSet
 
 # DRF API routing - disabled until we plan to use it
 # from drf_spectacular.views import SpectacularAPIView
-# from django.urls import path
+from django.urls import path
 # from ietf.person import api as person_api
-# from .routers import PrefixedSimpleRouter 
-# core_router = PrefixedSimpleRouter(name_prefix="ietf.api.core_api")  # core api router
+from .routers import PrefixedSimpleRouter 
+core_router = PrefixedSimpleRouter(name_prefix="ietf.api.core_api")  # core api router
+core_router.register("monitoring", MonitoringViewSet, basename="monitoring"),
 # core_router.register("email", person_api.EmailViewSet)
 # core_router.register("person", person_api.PersonViewSet)
 
-api.autodiscover()
+api_autodiscover()
 
 urlpatterns = [
     # General API help page
@@ -31,7 +34,7 @@ urlpatterns = [
     # For mailarchive use, requires secretariat role
     url(r'^v2/person/person', api_views.ApiV2PersonExportView.as_view()),
     # --- DRF API ---
-    # path("core/", include(core_router.urls)),
+    path("core/", include(core_router.urls)),
     # path("schema/", SpectacularAPIView.as_view()),
     #
     # --- Custom API endpoints, sorted alphabetically ---

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -1,7 +1,7 @@
 # Copyright The IETF Trust 2017-2024, All Rights Reserved
 
 from django.conf import settings
-from django.urls import include
+from django.urls import include, path
 from django.views.generic import TemplateView
 
 from ietf import api
@@ -12,15 +12,13 @@ from ietf.utils.urls import url
 
 from . import autodiscover as api_autodiscover
 from . import views as api_views
-from .views_api import MonitoringViewSet
+from .views_api import MonitoringView
 
 # DRF API routing - disabled until we plan to use it
 # from drf_spectacular.views import SpectacularAPIView
-from django.urls import path
 # from ietf.person import api as person_api
-from .routers import PrefixedSimpleRouter 
-core_router = PrefixedSimpleRouter(name_prefix="ietf.api.core_api")  # core api router
-core_router.register("monitoring", MonitoringViewSet, basename="monitoring"),
+# from .routers import PrefixedSimpleRouter 
+# core_router = PrefixedSimpleRouter(name_prefix="ietf.api.core_api")  # core api router
 # core_router.register("email", person_api.EmailViewSet)
 # core_router.register("person", person_api.PersonViewSet)
 
@@ -34,7 +32,8 @@ urlpatterns = [
     # For mailarchive use, requires secretariat role
     url(r'^v2/person/person', api_views.ApiV2PersonExportView.as_view()),
     # --- DRF API ---
-    path("core/", include(core_router.urls)),
+    # path("core/", include(core_router.urls)),
+    path("core/monitoring/<str:flavor>", MonitoringView.as_view()),
     # path("schema/", SpectacularAPIView.as_view()),
     #
     # --- Custom API endpoints, sorted alphabetically ---

--- a/ietf/api/views_api.py
+++ b/ietf/api/views_api.py
@@ -26,9 +26,7 @@ class MonitoringResult:
 class MonitoringView(APIView):
     """Monitoring / status check DRF API view"""
 
-    authentication_classes = []
-    permission_classes = []  # allow any for testing
-    # api_key_endpoint = "ietf.api.core_api.monitoring"
+    api_key_endpoint = "ietf.api.core_api.monitoring"
 
     @extend_schema(
         responses=MonitoringResultSerializer(many=True),

--- a/ietf/api/views_api.py
+++ b/ietf/api/views_api.py
@@ -7,13 +7,12 @@ and viewsets should be put in api.py.
 """
 from dataclasses import dataclass
 
+from django.http import Http404
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from .serializers import MonitoringResultSerializer
-
-import debug
 
 
 @dataclass
@@ -24,19 +23,20 @@ class MonitoringResult:
     result_value: int
 
 
-class MonitoringViewSet(viewsets.ViewSet):
-    """Monitoring / status check DRF API views"""
+class MonitoringView(APIView):
+    """Monitoring / status check DRF API view"""
 
+    authentication_classes = []
     permission_classes = []  # allow any for testing
     # api_key_endpoint = "ietf.api.core_api.monitoring"
 
     @extend_schema(
         responses=MonitoringResultSerializer(many=True),
     )
-    def retrieve(self, request, pk):
-        """Report status for service monitoring"""
-        
-        debug.show("pk")
+    def get(self, request, flavor, format=None):
+        """Report monitoring status"""
+        if flavor != "nfs":
+            raise Http404()
 
         # ersatz status to report
         result = [
@@ -49,6 +49,6 @@ class MonitoringViewSet(viewsets.ViewSet):
                 result_value=17,  # milliseconds? minutes? Use your imagination
             ),
         ]
-        return Response(
-            MonitoringResultSerializer(result, many=True).data,
-        )
+
+        serializer = MonitoringResultSerializer(result, many=True)
+        return Response(serializer.data)

--- a/ietf/api/views_api.py
+++ b/ietf/api/views_api.py
@@ -1,0 +1,54 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+"""API views for django-rest-framework
+
+This would normally be named api.py, but TastyPie creates an Api instance at
+ietf.api that makes that awkward. For other apps, django-rest-framework API views
+and viewsets should be put in api.py.
+"""
+from dataclasses import dataclass
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from .serializers import MonitoringResultSerializer
+
+import debug
+
+
+@dataclass
+class MonitoringResult:
+    """Data class for a single monitoring result"""
+
+    result_type: str
+    result_value: int
+
+
+class MonitoringViewSet(viewsets.ViewSet):
+    """Monitoring / status check DRF API views"""
+
+    permission_classes = []  # allow any for testing
+    # api_key_endpoint = "ietf.api.core_api.monitoring"
+
+    @extend_schema(
+        responses=MonitoringResultSerializer(many=True),
+    )
+    def retrieve(self, request, pk):
+        """Report status for service monitoring"""
+        
+        debug.show("pk")
+
+        # ersatz status to report
+        result = [
+            MonitoringResult(
+                result_type="online",
+                result_value=1,  # 0 = false, 1 = true
+            ),
+            MonitoringResult(
+                result_type="latency",
+                result_value=17,  # milliseconds? minutes? Use your imagination
+            ),
+        ]
+        return Response(
+            MonitoringResultSerializer(result, many=True).data,
+        )


### PR DESCRIPTION
Adds a set of endpoints at `/api/core/monitoring/<flavor>/` to allow various types of monitoring to be served.

Considered using a viewset but since this is really not a resource-oriented endpoint, it was cleaner to implement it as a standalone `APIView`. I've put it in the same URL prefix-space that the (commented-out) `core_Router` uses because it's part of the same API. This means collisions between the router and the explicit route are possible, but I don't think this will be a big issue.

Draft PR for a monitoring API using django-rest-framework. This is as much for discussion as actual merging.