### PR TITLE
refactor: don't template inside <script>

### DIFF
--- a/ietf/static/js/complete-review.js
+++ b/ietf/static/js/complete-review.js
@@ -24,6 +24,8 @@ $(document)
             .before(mailArchiveSearchTemplate);
 
         var mailArchiveSearch = form.find(".mail-archive-search");
+        const isReviewer = mailArchiveSearch.data('isReviewer');
+        const searchMailArchiveUrl = mailArchiveSearch.data('searchMailArchiveUrl');
 
         var retrievingData = null;
 

--- a/ietf/templates/doc/review/complete_review.html
+++ b/ietf/templates/doc/review/complete_review.html
@@ -94,7 +94,13 @@
         {% endif %}
         <div class="template d-none">
             {% if mail_archive_query_urls %}
-                <div class="mail-archive-search">
+                <div class="mail-archive-search"
+                    {% if assignment %}
+                     data-search-mail-archive-url="{% url "ietf.doc.views_review.search_mail_archive" name=doc.name assignment_id=assignment.pk %}"
+                    {% else %}
+                     data-search-mail-archive-url="{% url "ietf.doc.views_review.search_mail_archive" name=doc.name acronym=team.acronym %}"
+                    {% endif %}
+                     data-is-reviewer="{{ is_reviewer|yesno:"true,false" }}">
                     <div class="offset-md-2 col-md-10">
                         <label for="mail-archive-subjects" class="form-label">Search {{team.list_email}} mail archive subjects for:</label>
                         <div class="input-group mb-3">
@@ -144,13 +150,5 @@
 {% endblock %}
 {% block js %}
     <script src="{% static 'ietf/js/datepicker.js' %}"></script>
-    <script>
-        {% if assignment %}
-            var searchMailArchiveUrl = "{% url "ietf.doc.views_review.search_mail_archive" name=doc.name assignment_id=assignment.pk %}";
-        {% else %}
-            var searchMailArchiveUrl = "{% url "ietf.doc.views_review.search_mail_archive" name=doc.name acronym=team.acronym %}";
-        {% endif %}
-        var isReviewer = {{ is_reviewer|yesno:'true,false' }};
-    </script>
     <script src="{% static 'ietf/js/complete-review.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Addresses the issue described here https://github.com/ietf-tools/datatracker/issues/8475#issuecomment-2621909945

(the quoting issues were non-issues, but it's really not a good practice to use Django templating in javascript)

This does not address the issue in that ticket, just the comment.