### PR TITLE
fix: guard against KeyError in telechat_page_count

### DIFF
--- a/ietf/iesg/utils.py
+++ b/ietf/iesg/utils.py
@@ -33,7 +33,7 @@ def telechat_page_count(date=None, docs=None, ad=None):
             ballot = draft.active_ballot()
             if ballot:
                 positions = ballot.active_balloter_positions()
-                ad_position = positions[ad]
+                ad_position = positions.get(ad, None)
                 if ad_position is None or ad_position.pos_id == "norecord":
                     ad_pages_left_to_ballot_on += draft.pages or 0
 


### PR DESCRIPTION
Fixes server errors when a pre-AD views the `agenda_documents` view. 

The root cause of the issue is including pre-AD roles here: https://github.com/ietf-tools/datatracker/blob/cb25831a2a33a97d0b5cf0ee2a0ba29af51c887b/ietf/iesg/views.py#L363

The `ad` value set in that view is only used to compute the pages left to ballot, where it's assumed that the `ad` will be an active balloter. The bug being fixed comes from that assumption being violated.