### PR TITLE
feat: CSS other-session-selected.

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -695,8 +695,8 @@ td.position-empty {
 }
 
 .edit-meeting-schedule .session.other-session-selected {
-    outline: var(--bs-info) solid 0.2em;
-    /* width matches margin on .session */
+    outline: 0.3em solid var(--bs-info);
+    box-shadow: 0 0 1em var(--bs-info);
     z-index: 2;
     /* render above timeslot outlines */
 }


### PR DESCRIPTION
Makes other selected sessions stand out more with CSS tweak.

Note that the following screenshot has the middle truncated... CSS change is the border of the right 'lamps' box.

![Screenshot_2025-02-13_09-58-39](https://github.com/user-attachments/assets/6674b533-a9f8-4ca1-b0a6-160f0985726e)

fixes #8525