### PR TITLE
feat: htmlize to a blob on draft submission

### DIFF
--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -7,7 +7,6 @@ import logging
 import os
 
 import django.db
-import rfc2html
 
 from io import BufferedReader
 from pathlib import Path
@@ -44,6 +43,7 @@ from ietf.person.models import Email, Person
 from ietf.person.utils import get_active_balloters
 from ietf.utils import log
 from ietf.utils.decorators import memoize
+from ietf.utils.htmlize import make_htmlized_fragment
 from ietf.utils.validators import validate_no_control_chars
 from ietf.utils.mail import formataddr
 from ietf.utils.models import ForeignKey
@@ -634,10 +634,7 @@ class DocumentInfo(models.Model):
             except EOFError:
                 html = None
             if not html:
-                # The path here has to match the urlpattern for htmlized
-                # documents in order to produce correct intra-document links
-                html = rfc2html.markup(text, path=settings.HTMLIZER_URL_PREFIX)
-                html = f'<div class="rfcmarkup">{html}</div>'
+                html = make_htmlized_fragment(text)
                 if html:
                     cache.set(cache_key, html, settings.HTMLIZER_CACHE_TIME)
         return html

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -933,6 +933,7 @@ IDSUBMIT_EXPIRATION_AGE = datetime.timedelta(days=14)
 IDSUBMIT_FILE_TYPES = (
     'txt',
     'html',
+    'htmlized',
     'xml',
     'pdf',
     'ps',

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -933,7 +933,6 @@ IDSUBMIT_EXPIRATION_AGE = datetime.timedelta(days=14)
 IDSUBMIT_FILE_TYPES = (
     'txt',
     'html',
-    'htmlized',
     'xml',
     'pdf',
     'ps',

--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -55,6 +55,7 @@ from ietf.submit.models import ( Submission, SubmissionEvent, Preapproval, Draft
 from ietf.utils import log
 from ietf.utils.accesstoken import generate_random_key
 from ietf.utils.draft import PlaintextDraft
+from ietf.utils.htmlize import make_htmlized_fragment
 from ietf.utils.mail import is_valid_email
 from ietf.utils.text import parse_unicode, normalize_text
 from ietf.utils.timezone import date_today
@@ -1322,6 +1323,17 @@ def process_and_validate_submission(submission):
                     f">> stderr:\n{err.xml2rfc_stderr}"
                 )
                 raise
+
+        try:
+            html = make_htmlized_fragment(
+                staging_path(submission.name, submission.rev, ".txt").read_text()
+            )
+            store_str("staging", f"{submission.name}-{submission.rev}.htmlized", html)
+        except Exception as err:
+            log.log(
+                f"make_htmlized_fragment failure for {submission.name}-{submission.rev}: {repr(err)}"
+            )
+
         # Parse text, whether uploaded or generated from XML
         text_metadata = process_submission_text(submission.name, submission.rev)
 

--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -649,7 +649,8 @@ def cancel_submission(submission):
 
 
 def rename_submission_files(submission, prev_rev, new_rev):
-    for ext in settings.IDSUBMIT_FILE_TYPES:
+    # TODO-BLOBSTORE decide what to do about the .htmlized submitted files
+    for ext in settings.IDSUBMIT_FILE_TYPES + ["htmlized"]:
         staging_path = Path(settings.IDSUBMIT_STAGING_PATH) 
         source = staging_path / f"{submission.name}-{prev_rev}.{ext}"
         dest = staging_path / f"{submission.name}-{new_rev}.{ext}"
@@ -686,7 +687,8 @@ def remove_staging_files(name, rev, exts=None):
     exts is a list of extensions to be removed. If None, defaults to settings.IDSUBMIT_FILE_TYPES.
     """
     if exts is None:
-        exts = [f'.{ext}' for ext in settings.IDSUBMIT_FILE_TYPES]
+        # TODO-BLOBSTORE decide what to do about the .htmlized submitted files
+        exts = [f'.{ext}' for ext in settings.IDSUBMIT_FILE_TYPES + ["htmlized"]]
     basename = pathlib.Path(settings.IDSUBMIT_STAGING_PATH) / f'{name}-{rev}' 
     for ext in exts:
         basename.with_suffix(ext).unlink(missing_ok=True)

--- a/ietf/templates/doc/document_html.html
+++ b/ietf/templates/doc/document_html.html
@@ -171,7 +171,7 @@
                     <div class="rfcmarkup">
                         <br class="noprint">
                         <!-- [html-validate-disable-block attr-quotes, void-style, element-permitted-content, heading-level -- FIXME: rfcmarkup/rfc2html generates HTML with issues] -->
-                        {{ doc.htmlized|default:"Generation of htmlized text failed"|safe }}
+                        {{ doc.htmlized|default:"Generation of htmlized text failed" }}
                     </div>
                 {% endif %}
             </div>

--- a/ietf/utils/htmlize.py
+++ b/ietf/utils/htmlize.py
@@ -1,0 +1,18 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+import rfc2html
+
+from django.conf import settings
+from django.utils.safestring import SafeString, mark_safe
+from django.utils.html import format_html
+
+
+def make_htmlized_fragment(text: str) -> SafeString:
+    """Generate an htmlized HTML fragment from document text"""
+    # The path here has to match the urlpattern for htmlized
+    # documents in order to produce correct intra-document links
+    html = mark_safe(rfc2html.markup(text, path=settings.HTMLIZER_URL_PREFIX))
+    html = format_html(
+        '<div class="rfcmarkup">{}</div>', 
+        html,
+    )
+    return html


### PR DESCRIPTION
Refactors the htmlize code for reuse, then uses it to write to an `.htmlized` staging file.

Also, drops use of `|safe` in favor of generating a `SafeString` at the source. This is a better practice for avoiding exploitable bugs.

Adds a special case to remove / rename the `.htmlized` files when canceling or editing submissions. (The latter actually won't do anything now - I think it needs to be updated to move the blobs, though, so I'm leaving the code in.)