### PR TITLE
chore: Adding postscript to RFC meta serializer

### DIFF
--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -128,7 +128,7 @@ class ReverseRelatedRfcSerializer(serializers.Serializer):
 
 class RfcMetadataSerializer(serializers.ModelSerializer):
     """Serialize metadata of an RFC"""
-    RFC_FORMATS = ("xml", "txt", "html", "htmlized", "pdf")
+    RFC_FORMATS = ("xml", "txt", "html", "htmlized", "pdf", "ps")
 
     number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()


### PR DESCRIPTION
RFC 12 has postscript as a format so we'll need that format https://www.rfc-editor.org/rfc-index.txt