### PR TITLE
chore(deps): remove pydyf pin, update weasyprint req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ oic>=1.3    # Used only by tests
 Pillow>=9.1.0
 psycopg2>=2.9.6
 pyang>=2.5.3
-pydyf>0.8.0,<0.10.0 # until weasyprint adjusts for 0.10.0 and later
+pydyf>0.8.0
 pyflakes>=2.4.0
 pyopenssl>=22.0.0    # Used by urllib3.contrib, which is used by PyQuery but not marked as a dependency
 pyquery>=1.4.3
@@ -80,6 +80,6 @@ tlds>=2022042700    # Used to teach bleach about which TLDs currently exist
 tqdm>=4.64.0
 Unidecode>=1.3.4
 urllib3>=1.26,<2
-weasyprint>=59
+weasyprint>=64.1
 xml2rfc[pdf]>=3.23.0
 xym>=0.6,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,5 +81,5 @@ tqdm>=4.64.0
 Unidecode>=1.3.4
 urllib3>=1.26,<2
 weasyprint>=64.1
-xml2rfc[pdf]>=3.23.0
+xml2rfc>=3.23.0
 xym>=0.6,<1.0


### PR DESCRIPTION
Drops the `[pdf]` extra from the `xml2rfc` requirement. That is ok for now because we don't use `xml2rfc` to generate PDFs. When we do that, we should bring the extra back.

(If we want to keep that, we could just wait until https://github.com/ietf-tools/xml2rfc/pull/1215 merges, but I think it's better not to tightly couple the releases.)