### PR TITLE
chore: bump rabbitmq to 3.13

### DIFF
--- a/.github/workflows/build-mq-broker.yml
+++ b/.github/workflows/build-mq-broker.yml
@@ -51,4 +51,4 @@ jobs:
         build-args: RABBITMQ_VERSION=${{ inputs.rabbitmq_version }}
         tags: |
           ghcr.io/ietf-tools/datatracker-mq:${{ inputs.rabbitmq_version }}
-
+          ghcr.io/ietf-tools/datatracker-mq:latest

--- a/.github/workflows/build-mq-broker.yml
+++ b/.github/workflows/build-mq-broker.yml
@@ -51,4 +51,4 @@ jobs:
         build-args: RABBITMQ_VERSION=${{ inputs.rabbitmq_version }}
         tags: |
           ghcr.io/ietf-tools/datatracker-mq:${{ inputs.rabbitmq_version }}
-          ghcr.io/ietf-tools/datatracker-mq:latest
+

--- a/.github/workflows/build-mq-broker.yml
+++ b/.github/workflows/build-mq-broker.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       rabbitmq_version:
         description: 'RabbitMQ Version'
-        default: '3.12-alpine'
+        default: '3.13-alpine'
         required: true
         type: string
 

--- a/.github/workflows/build-mq-broker.yml
+++ b/.github/workflows/build-mq-broker.yml
@@ -8,10 +8,13 @@ on:
       - 'dev/mq/**'
       - '.github/workflows/build-mq-broker.yml'
 
-  workflow_dispatch: 
-
-env:
-  RABBITMQ_VERSION: 3.12-alpine
+  workflow_dispatch:
+    inputs:
+      rabbitmq_version:
+        description: 'RabbitMQ Version'
+        default: '3.12-alpine'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -45,7 +48,7 @@ jobs:
         file: dev/mq/Dockerfile
         platforms: linux/amd64,linux/arm64
         push: true
-        build-args: RABBITMQ_VERSION=${{ env.RABBITMQ_VERSION }}
+        build-args: RABBITMQ_VERSION=${{ inputs.rabbitmq_version }}
         tags: |
-          ghcr.io/ietf-tools/datatracker-mq:${{ env.RABBITMQ_VERSION }}
+          ghcr.io/ietf-tools/datatracker-mq:${{ inputs.rabbitmq_version }}
           ghcr.io/ietf-tools/datatracker-mq:latest

--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -29,7 +29,7 @@ spec:
         # -----------------------------------------------------
         # RabbitMQ Container
         # -----------------------------------------------------
-        - image: "ghcr.io/ietf-tools/datatracker-mq:3.12-alpine"
+        - image: "ghcr.io/ietf-tools/datatracker-mq:3.13-alpine"
           imagePullPolicy: Always
           name: rabbitmq
           ports:


### PR DESCRIPTION
After merging, need to build the 3.13 datatracker-mq image before deploying.