### PR TITLE
fix: more submission date feedback; refactor xml2rfc log capture

### DIFF
--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -23,6 +23,7 @@ from fnmatch import fnmatch
 from importlib import import_module
 from textwrap import dedent
 from tempfile import mkdtemp
+from xml2rfc import log as xml2rfc_log
 
 from django.apps import apps
 from django.contrib.auth.models import User
@@ -509,6 +510,18 @@ class PlaintextDraftTests(TestCase):
 
 
 class XMLDraftTests(TestCase):
+    def setUp(self):
+        # suppress xml2rfc output
+        self._orig_write_out = xml2rfc_log.write_out
+        self._orig_write_err = xml2rfc_log.write_err
+        xml2rfc_log.write_out = io.StringIO()
+        xml2rfc_log.write_err = io.StringIO()
+    
+    def tearDown(self):
+        # restore xml2rfc log streams
+        xml2rfc_log.write_out = self._orig_write_out
+        xml2rfc_log.write_err = self._orig_write_err
+
     def test_get_refs_v3(self):
         draft = XMLDraft('ietf/utils/test_draft_with_references_v3.xml')
         self.assertEqual(

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -57,7 +57,7 @@ from ietf.utils.test_runner import get_template_paths, set_coverage_checking
 from ietf.utils.test_utils import TestCase, unicontent
 from ietf.utils.text import parse_unicode
 from ietf.utils.timezone import timezone_not_near_midnight
-from ietf.utils.xmldraft import XMLDraft
+from ietf.utils.xmldraft import XMLDraft, InvalidMetadataError
 
 class SendingMail(TestCase):
 
@@ -590,6 +590,74 @@ class XMLDraftTests(TestCase):
                 ),
                 datetime.date(today.year, 1 if today.month != 1 else 2, 15),
             )
+            # Some exeception-inducing conditions
+            with self.assertRaises(
+                InvalidMetadataError,
+                msg="raise an InvalidMetadataError if a year-only date is not current",
+            ):
+                XMLDraft.parse_creation_date(
+                    {
+                        "year": str(today.year - 1),
+                        "month": "",
+                        "day": "",
+                    }
+                )
+            with self.assertRaises(
+                InvalidMetadataError,
+                msg="raise an InvalidMetadataError for a non-numeric year"
+            ):
+                XMLDraft.parse_creation_date(
+                    {
+                        "year": "two thousand twenty-five",
+                        "month": "2",
+                        "day": "28",
+                    }
+                )
+            with self.assertRaises(
+                InvalidMetadataError,
+                msg="raise an InvalidMetadataError for an invalid month"
+            ):
+                XMLDraft.parse_creation_date(
+                    {
+                        "year": "2024",
+                        "month": "13",
+                        "day": "28",
+                    }
+                )
+            with self.assertRaises(
+                InvalidMetadataError,
+                msg="raise an InvalidMetadataError for a misspelled month"
+            ):
+                XMLDraft.parse_creation_date(
+                    {
+                        "year": "2024",
+                        "month": "Oktobur",
+                        "day": "28",
+                    }
+                )
+            with self.assertRaises(
+                InvalidMetadataError,
+                msg="raise an InvalidMetadataError for an invalid day"
+            ):
+                XMLDraft.parse_creation_date(
+                    {
+                        "year": "2024",
+                        "month": "feb",
+                        "day": "31",
+                    }
+                )
+            with self.assertRaises(
+                InvalidMetadataError,
+                msg="raise an InvalidMetadataError for a non-numeric day"
+            ):
+                XMLDraft.parse_creation_date(
+                    {
+                        "year": "2024",
+                        "month": "feb",
+                        "day": "twenty-four",
+                    }
+                )
+
 
     def test_parse_docname(self):
         with self.assertRaises(ValueError) as cm:

--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -160,11 +160,11 @@ class XMLDraft(Draft):
                     day = today.day
                 else:
                     day = 15
-        except:
+        except Exception as err:
             # Give a generic error if anything goes wrong so far...
             raise InvalidMetadataError(
                 "Unable to parse the <date> element in the <front> section."
-            )
+            ) from err
         try:
             creation_date = datetime.date(year, month, day)
         except Exception:

--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -23,9 +23,11 @@ def capture_xml2rfc_output():
     parser_err = io.StringIO()
     xml2rfc.log.write_out = parser_out
     xml2rfc.log.write_err = parser_err
-    yield {"stdout": parser_out, "stderr": parser_err}
-    xml2rfc.log.write_out = orig_write_out
-    xml2rfc.log.write_err = orig_write_err
+    try:
+        yield {"stdout": parser_out, "stderr": parser_err}
+    finally:
+        xml2rfc.log.write_out = orig_write_out
+        xml2rfc.log.write_err = orig_write_err
 
 
 class XMLDraft(Draft):

--- a/ietf/utils/xmldraft.py
+++ b/ietf/utils/xmldraft.py
@@ -171,7 +171,11 @@ class XMLDraft(Draft):
         return creation_date
 
     def get_creation_date(self):
-        return self.parse_creation_date(self.xmlroot.find("front/date"))
+        try:
+            creation_date = self.parse_creation_date(self.xmlroot.find("front/date"))
+        except InvalidMetadataError:
+            raise  # leave this alone
+        raise InvalidMetadataError("Unable to parse the <date> element in the <front> section.")
 
     # todo fix the implementation of XMLDraft.get_abstract()
     #


### PR DESCRIPTION
Main goal: log helpful feedback on more (hopefully now all!) paths where a `<date>` fails parsing or interpretation.

Throws in some refactoring to centralize capture of the xml2rfc log output. This is done with the `capture_xml2rfc_output` context manager. A known side effect of the refactoring in 3529f14ae548fbffc25ea565a2084d5a5980f394 is that `xml2rfc.log.write_out` and `xml2rfc.log.write_err` will be restored to their original streams after each call to `render_missing_formats()` instead of being left pointing at otherwise abandoned `StringIO` instances. I think that's a win, but wanted to call it out as a possibly non-obvious change.