### PR TITLE
chore: configure gunicorn secure_scheme_headers

### DIFF
--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -1,5 +1,11 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 
+# Configure security scheme headers for forwarded requets. Cloudflare sets X-Forwarded-Proto 
+# for us. Don't trust any of the other similar headers. Only trust the header if it's coming
+# from localhost, as all legitimate traffic will reach gunicorn via co-located nginx.
+secure_scheme_headers = {"X-FORWARDED-PROTO": "https"}
+forwarded_allow_ips = "127.0.0.1, ::1"  # this is the default 
+
 # Log as JSON on stdout (to distinguish from Django's logs on stderr)
 #
 # This is applied as an update to gunicorn's glogging.CONFIG_DEFAULTS.

--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -1,6 +1,6 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 
-# Configure security scheme headers for forwarded requets. Cloudflare sets X-Forwarded-Proto 
+# Configure security scheme headers for forwarded requests. Cloudflare sets X-Forwarded-Proto 
 # for us. Don't trust any of the other similar headers. Only trust the header if it's coming
 # from localhost, as all legitimate traffic will reach gunicorn via co-located nginx.
 secure_scheme_headers = {"X-FORWARDED-PROTO": "https"}

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -19,13 +19,6 @@ def _multiline_to_list(s):
 # Default to "development". Production _must_ set DATATRACKER_SERVER_MODE="production" in the env!
 SERVER_MODE = os.environ.get("DATATRACKER_SERVER_MODE", "development")
 
-# Use X-Forwarded-Proto to determine request.is_secure(). This relies on CloudFlare overwriting the
-# value of the header if an incoming request sets it, which it does:
-# https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#x-forwarded-proto
-# See also, especially the warnings:
-# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
 # Secrets
 _SECRET_KEY = os.environ.get("DATATRACKER_DJANGO_SECRET_KEY", None)
 if _SECRET_KEY is not None:


### PR DESCRIPTION
Instead of training Django to look at the request headers, this configures gunicorn only to respect `X-Forwarded-Proto`. It sets `wsgi.url_scheme`, which is used by Django's `request.is_secure()` to decide whether a forwarded request is actually secure.

Draft while I look back to make sure there wasn't some other corner where we needed the `SECURE_PROXY_SSL_HEADER` setting.