### PR TITLE
chore: config gunicorn secure_scheme_headers

### DIFF
--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -1,5 +1,11 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 
+# Configure security scheme headers for forwarded requets. Cloudflare sets X-Forwarded-Proto 
+# for us. Don't trust any of the other similar headers. Only trust the header if it's coming
+# from localhost, as all legitimate traffic will reach gunicorn via co-located nginx.
+secure_scheme_headers = {"X-FORWARDED-PROTO": "https"}
+forwarded_allow_ips = "127.0.0.1, ::1"  # this is the default 
+
 # Log as JSON on stdout (to distinguish from Django's logs on stderr)
 #
 # This is applied as an update to gunicorn's glogging.CONFIG_DEFAULTS.

--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -1,6 +1,6 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 
-# Configure security scheme headers for forwarded requets. Cloudflare sets X-Forwarded-Proto 
+# Configure security scheme headers for forwarded requests. Cloudflare sets X-Forwarded-Proto 
 # for us. Don't trust any of the other similar headers. Only trust the header if it's coming
 # from localhost, as all legitimate traffic will reach gunicorn via co-located nginx.
 secure_scheme_headers = {"X-FORWARDED-PROTO": "https"}


### PR DESCRIPTION
Ignore `X-FORWARDED-PROTOCOL` and `X-FORWARDED-SSL` headers, which we do not use and which cause warnings in our logs.

These being set was causing gunicorn to reject the requests with 400 status codes - instead, they'll go through but the headers will be ignored. If we want to reject traffic with those headers set as obviously garbage, we should do so elsewhere.