### PR TITLE
feat: improve apply_to_all handling in upload forms

### DIFF
--- a/ietf/meeting/forms.py
+++ b/ietf/meeting/forms.py
@@ -458,11 +458,10 @@ class UploadBlueSheetForm(FileUploadForm):
 class ApplyToAllFileUploadForm(FileUploadForm):
     """FileUploadField that adds an apply_to_all checkbox
 
-    Checkbox can be disabled by passing show_apply_to_all_checkbox=False to the constructor.
-    This entirely removes the field from the form.
+    Checkbox can be removed from form by passing show_apply_to_all_checkbox=False to the constructor.
     """
     # Note: subclasses must set doc_type for FileUploadForm
-    apply_to_all = forms.BooleanField(label='Apply to all group sessions at this meeting',initial=True,required=False)
+    apply_to_all = forms.BooleanField(label='Post to all sessions for this group at this meeting', initial=True, required=False)
 
     def __init__(self, show_apply_to_all_checkbox, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3221,9 +3221,9 @@ def upload_session_slides(request, session_id, num, name=None):
                     acronym=session.group.acronym,
                 )
     else:
-        initial = {}
+        initial = {"apply_to_all": False}
         if doc is not None:
-            initial = {"title": doc.title}
+            initial["title"] = doc.title
         form = UploadSlidesForm(session, show_apply_to_all_checkbox, can_manage, initial=initial)
 
     return render(

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -4883,7 +4883,7 @@ def request_minutes(request, num=None):
 
 class ApproveSlidesForm(forms.Form):
     title = forms.CharField(max_length=255)
-    apply_to_all = forms.BooleanField(label='Apply to all group sessions at this meeting',initial=False,required=False)
+    apply_to_all = forms.BooleanField(label='Post to all sessions for this group at this meeting',initial=False,required=False)
 
     def __init__(self, show_apply_to_all_checkbox, *args, **kwargs):
         super(ApproveSlidesForm, self).__init__(*args, **kwargs )


### PR DESCRIPTION
- Relabel `apply_to_all` field because old text caused confusion ("what is being applied?")
- Set `apply_to_all=False` by default for uploading slides (as per the apparently common usecase)