### PR TITLE
fix: approve slides link for all pending submissions

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -4659,13 +4659,15 @@ class SessionDetailsTests(TestCase):
         # This test overlaps somewhat with MaterialsTests of proposed slides handling. The focus
         # here is on the display of slides, not the approval action.
         group = GroupFactory()
-        meeting = MeetingFactory(type_id="ietf", date=date_today() + datetime.timedelta(days=10))
+        meeting = MeetingFactory(
+            type_id="ietf", date=date_today() + datetime.timedelta(days=10)
+        )
         sessions = SessionFactory.create_batch(
             2,
             group=group,
             meeting=meeting,
         )
-
+    
         # slides submission _not_ in the `pending` state
         do_not_show = [
             SlideSubmissionFactory(
@@ -4679,21 +4681,26 @@ class SessionDetailsTests(TestCase):
                 status_id="rejected",
             ),
         ]
-
+    
         # pending submissions
-        first_session_pending = SlideSubmissionFactory(session=sessions[0], title="first session title") 
-        second_session_pending = SlideSubmissionFactory(session=sessions[1], title="second session title")
-        
+        first_session_pending = SlideSubmissionFactory(
+            session=sessions[0], title="first session title"
+        )
+        second_session_pending = SlideSubmissionFactory(
+            session=sessions[1], title="second session title"
+        )
+    
         # and their approval URLs
         def _approval_url(slidesub):
             return urlreverse(
-            "ietf.meeting.views.approve_proposed_slides",
-            kwargs={"slidesubmission_id": slidesub.pk, "num": meeting.number},
-        )
+                "ietf.meeting.views.approve_proposed_slides",
+                kwargs={"slidesubmission_id": slidesub.pk, "num": meeting.number},
+            )
+    
         first_approval_url = _approval_url(first_session_pending)
         second_approval_url = _approval_url(second_session_pending)
         do_not_show_urls = [_approval_url(ss) for ss in do_not_show]
-
+    
         # Retrieve the URL as a group chair
         url = urlreverse(
             "ietf.meeting.views.session_details",
@@ -4703,24 +4710,26 @@ class SessionDetailsTests(TestCase):
             },
         )
         chair = RoleFactory(group=group, name_id="chair").person
-        self.client.login(username=chair.user.username, password=f"{chair.user.username}+password")
+        self.client.login(
+            username=chair.user.username, password=f"{chair.user.username}+password"
+        )
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         pq = PyQuery(r.content)
         self.assertEqual(
-            len(pq(f'a[href="{first_approval_url}"]')), 
-            1, 
+            len(pq(f'a[href="{first_approval_url}"]')),
+            1,
             "first session proposed slides should be linked for approval",
         )
         self.assertEqual(
             len(pq(f'a[href="{second_approval_url}"]')),
-            1, 
+            1,
             "second session proposed slides should be linked for approval",
         )
         for no_show_url in do_not_show_urls:
             self.assertEqual(
                 len(pq(f'a[href="{no_show_url}"]')),
-                0, 
+                0,
                 "second session proposed slides should be linked for approval",
             )
         

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -4656,6 +4656,8 @@ class SessionDetailsTests(TestCase):
         self.assertEqual(1,len(q(".alert-warning:contains('may affect published proceedings')")))
 
     def test_proposed_slides_for_approval(self):
+        # This test overlaps somewhat with MaterialsTests of proposed slides handling. The focus
+        # here is on the display of slides, not the approval action.
         group = GroupFactory()
         meeting = MeetingFactory(type_id="ietf", date=date_today() + datetime.timedelta(days=10))
         sessions = SessionFactory.create_batch(

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -4523,6 +4523,7 @@ class EditTests(TestCase):
 
 
 class SessionDetailsTests(TestCase):
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['SLIDE_STAGING_PATH']
 
     def test_session_details(self):
 

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2509,19 +2509,14 @@ def session_details(request, num, acronym):
     scheduled_sessions = [s for s in sessions if s.current_status == 'sched']
     unscheduled_sessions = [s for s in sessions if s.current_status != 'sched']
 
-    pending_suggestions = None
-    if request.user.is_authenticated:
-        if can_manage:
-            pending_suggestions = SlideSubmission.objects.filter(
-                session__in=sessions,
-                status__slug='pending',
-            )
-        else:
-            pending_suggestions = SlideSubmission.objects.filter(
-                session__in=sessions,
-                status__slug='pending',
-                submitter=request.user.person,
-            )
+    # Start with all the pending suggestions for all the group's sessions
+    pending_suggestions = SlideSubmission.objects.filter(session__in=sessions, status__slug='pending')
+    if can_manage:
+        pass  # keep the full set
+    elif hasattr(request.user, "person"):
+        pending_suggestions = pending_suggestions.filter(submitter=request.user.person)
+    else:
+        pending_suggestions = SlideSubmission.objects.none()
 
     return render(request, "meeting/session_details.html",
                   { 'scheduled_sessions':scheduled_sessions ,

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2512,9 +2512,16 @@ def session_details(request, num, acronym):
     pending_suggestions = None
     if request.user.is_authenticated:
         if can_manage:
-            pending_suggestions = session.slidesubmission_set.filter(status__slug='pending')
+            pending_suggestions = SlideSubmission.objects.filter(
+                session__in=sessions,
+                status__slug='pending',
+            )
         else:
-            pending_suggestions = session.slidesubmission_set.filter(status__slug='pending', submitter=request.user.person)
+            pending_suggestions = SlideSubmission.objects.filter(
+                session__in=sessions,
+                status__slug='pending',
+                submitter=request.user.person,
+            )
 
     return render(request, "meeting/session_details.html",
                   { 'scheduled_sessions':scheduled_sessions ,

--- a/ietf/templates/meeting/session_details.html
+++ b/ietf/templates/meeting/session_details.html
@@ -31,30 +31,28 @@
     {% include 'meeting/session_details_panel.html' with sessions=scheduled_sessions %}
     <h2 class="mt-3">Unscheduled Sessions</h2>
     {% include 'meeting/session_details_panel.html' with sessions=unscheduled_sessions %}
-    {% if pending_suggestions.exists %}
-        <h2 class="mt-3">
+    {% for s in pending_suggestions %}
+        {% if forloop.first %}<h2 class="mt-3">
             {% if can_manage_materials %}
                 Proposed slides awaiting your approval
             {% else %}
                 Your proposed slides awaiting chair approval
             {% endif %}
         </h2>
-        <div class="proposedslidelist">
-            {% for s in pending_suggestions %}
-                {% if can_manage_materials %}
-                    <p>
-                        <a href="{% url "ietf.meeting.views.approve_proposed_slides" slidesubmission_id=s.pk num=s.session.meeting.number %}">
-                            {{ s.submitter }} - {{ s.title }} ({{ s.time }})
-                        </a>
-                    </p>
-                {% else %}
-                    <p>
-                        {{ s.title }} ({{ s.time }})
-                    </p>
-                {% endif %}
-            {% endfor %}
-        </div>
-    {% endif %}
+        <div class="proposedslidelist">{% endif %}
+            {% if can_manage_materials %}
+                <p>
+                    <a href="{% url "ietf.meeting.views.approve_proposed_slides" slidesubmission_id=s.pk num=s.session.meeting.number %}">
+                        {{ s.submitter }} - {{ s.title }} ({{ s.time }})
+                    </a>
+                </p>
+            {% else %}
+                <p>
+                    {{ s.title }} ({{ s.time }})
+                </p>
+            {% endif %}
+        {% if forloop.last %}</div>{% endif %}
+    {% endfor %}
 {% endblock %}
 {% block js %}
     <script src="{% static 'ietf/js/list.js' %}"></script>

--- a/ietf/templates/meeting/session_details.html
+++ b/ietf/templates/meeting/session_details.html
@@ -31,7 +31,7 @@
     {% include 'meeting/session_details_panel.html' with sessions=scheduled_sessions %}
     <h2 class="mt-3">Unscheduled Sessions</h2>
     {% include 'meeting/session_details_panel.html' with sessions=unscheduled_sessions %}
-    {% if pending_suggestions %}
+    {% if pending_suggestions.exists %}
         <h2 class="mt-3">
             {% if can_manage_materials %}
                 Proposed slides awaiting your approval


### PR DESCRIPTION
Fixes issue where only slides attached to the first session at a meeting were shown for chair approval. Refactors the view a bit to flatten some redundant authentication checks and simplify typing.

Fixes #6045