### PR TITLE
fix(agenda): Agenda 'now' fallback to next event if there is no current event

### DIFF
--- a/client/agenda/AgendaMobileBar.vue
+++ b/client/agenda/AgendaMobileBar.vue
@@ -124,11 +124,11 @@ const downloadIcsOptions = [
 
 function jumpToDay (dayId) {
   if (dayId === 'now') {
-    const lastEventId = agendaStore.findCurrentEventId()
-    if (lastEventId) {
-      document.getElementById(`agenda-rowid-${lastEventId}`)?.scrollIntoView(true)
+    const nowEventId = agendaStore.findNowEventId()
+    if (nowEventId) {
+      document.getElementById(`agenda-rowid-${nowEventId}`)?.scrollIntoView(true)
     } else {
-      message.warning('There is no event happening right now.')
+      message.warning('There is no event happening right now or in the future.')
     }
   } else {
     document.getElementById(dayId)?.scrollIntoView(true)

--- a/client/agenda/AgendaQuickAccess.vue
+++ b/client/agenda/AgendaQuickAccess.vue
@@ -204,10 +204,10 @@ function scrollToDay (daySlug, ev) {
 }
 
 function scrollToNow (ev) {
-  const lastEventId = agendaStore.findCurrentEventId()
+  const nowEventId = agendaStore.findNowEventId()
 
-  if (lastEventId) {
-    document.getElementById(`agenda-rowid-${lastEventId}`)?.scrollIntoView(true)
+  if (nowEventId) {
+    document.getElementById(`agenda-rowid-${nowEventId}`)?.scrollIntoView(true)
   } else {
     message.warning('There is no event happening right now.')
   }

--- a/client/agenda/AgendaQuickAccess.vue
+++ b/client/agenda/AgendaQuickAccess.vue
@@ -209,7 +209,7 @@ function scrollToNow (ev) {
   if (nowEventId) {
     document.getElementById(`agenda-rowid-${nowEventId}`)?.scrollIntoView(true)
   } else {
-    message.warning('There is no event happening right now.')
+    message.warning('There is no event happening right now or in the future.')
   }
 }
 

--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -590,10 +590,10 @@ function renderLinkLabel (opt) {
 
 function recalculateRedLine () {
   state.currentMinute = DateTime.local().minute
-  const lastEventId = agendaStore.findCurrentEventId()
+  const currentEventId = agendaStore.findCurrentEventId()
 
-  if (lastEventId) {
-    state.redhandOffset = document.getElementById(`agenda-rowid-${lastEventId}`)?.offsetTop || 0
+  if (currentEventId) {
+    state.redhandOffset = document.getElementById(`agenda-rowid-${currentEventId}`)?.offsetTop || 0
   } else {
     state.redhandOffset = 0
   }
@@ -614,9 +614,13 @@ function recalculateRedLine () {
       return
     }
     unsubscribe() // we only need to scroll once, so unsubscribe from future updates
-    if(window.location.hash === "#now") {
-      const lastEventId = agendaStore.findCurrentEventId()
-      document.getElementById(`agenda-rowid-${lastEventId}`)?.scrollIntoView(true)
+    if (window.location.hash === "#now") {
+      const nowEventId = agendaStore.findNowEvent()
+      if (nowEventId) {
+        document.getElementById(`agenda-rowid-${nowEventId}`)?.scrollIntoView(true)
+      } else {
+        message.warning('There is no event happening right now or in the future.')
+      }
     } else if(window.location.hash.startsWith(`#${daySlugPrefix}`)) {
       document.getElementById(window.location.hash.substring(1))?.scrollIntoView(true)
     }

--- a/client/agenda/store.js
+++ b/client/agenda/store.js
@@ -242,19 +242,15 @@ export const useAgendaStore = defineStore('agenda', {
       const current = (this.nowDebugDiff ? DateTime.local().minus(this.nowDebugDiff) : DateTime.local()).setZone(this.timezone)
 
       // -> Find next event after current time
-      let nextEvent = {}
+      let nextEventId = undefined
       for(const sh of this.scheduleAdjusted) {
         if (sh.adjustedStart > current) {
-          nextEvent = {
-            id: sh.id,
-            start: sh.adjustedStart.toMillis(),
-            end: sh.adjustedEnd.toMillis()
-          }
+          nextEventId = sh.id
           break
         }
       }
 
-      return nextEvent.id || null
+      return nextEventId || null
     },
     hideLoadingScreen () {
       // -> Hide loading screen

--- a/client/agenda/store.js
+++ b/client/agenda/store.js
@@ -230,6 +230,38 @@ export const useAgendaStore = defineStore('agenda', {
 
       return lastEvent.id || null
     },
+    findNowEventId () {
+      const currentEventId = this.findCurrentEventId()
+      
+      if (currentEventId) return currentEventId
+
+      // if there isn't a current event then instead find the next event
+
+      const current = (this.nowDebugDiff ? DateTime.local().minus(this.nowDebugDiff) : DateTime.local()).setZone(this.timezone)
+
+      // -> Find next event after current time
+      let nextEvent = {}
+      for(const sh of this.scheduleAdjusted) {
+        if (sh.adjustedStart > current) {
+          // -> Use the first event of multiple events having identical times
+          if (nextEvent.start === sh.adjustedStart.toMillis()) {
+            continue
+          } else {
+            nextEvent = {
+              id: sh.id,
+              start: sh.adjustedStart.toMillis(),
+              end: sh.adjustedEnd.toMillis()
+            }
+          }
+        }
+        // -> Skip other future events
+        if (sh.adjustedStart > current) {
+          break
+        }
+      }
+
+      return nextEvent.id || null
+    },
     hideLoadingScreen () {
       // -> Hide loading screen
       const loadingRef = document.querySelector('#app-loading')

--- a/client/agenda/store.js
+++ b/client/agenda/store.js
@@ -245,19 +245,11 @@ export const useAgendaStore = defineStore('agenda', {
       let nextEvent = {}
       for(const sh of this.scheduleAdjusted) {
         if (sh.adjustedStart > current) {
-          // -> Use the first event of multiple events having identical times
-          if (nextEvent.start === sh.adjustedStart.toMillis()) {
-            break
-          } else {
-            nextEvent = {
-              id: sh.id,
-              start: sh.adjustedStart.toMillis(),
-              end: sh.adjustedEnd.toMillis()
-            }
+          nextEvent = {
+            id: sh.id,
+            start: sh.adjustedStart.toMillis(),
+            end: sh.adjustedEnd.toMillis()
           }
-        }
-        // -> Skip other future events
-        if (sh.adjustedStart > current) {
           break
         }
       }

--- a/client/agenda/store.js
+++ b/client/agenda/store.js
@@ -233,7 +233,9 @@ export const useAgendaStore = defineStore('agenda', {
     findNowEventId () {
       const currentEventId = this.findCurrentEventId()
       
-      if (currentEventId) return currentEventId
+      if (currentEventId) {
+        return currentEventId
+      }
 
       // if there isn't a current event then instead find the next event
 
@@ -245,7 +247,7 @@ export const useAgendaStore = defineStore('agenda', {
         if (sh.adjustedStart > current) {
           // -> Use the first event of multiple events having identical times
           if (nextEvent.start === sh.adjustedStart.toMillis()) {
-            continue
+            break
           } else {
             nextEvent = {
               id: sh.id,


### PR DESCRIPTION
The 'now' internal page link would fail if there was no current event. For example, clicking 'now' before  
events start for the day would fail. This PR adds a fallback where it will find the next event even if it hasn't started yet.