### PR TITLE
feat(agenda): keep video client + onsite tool buttons for plenary for rest of day

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -448,6 +448,23 @@ const meetingEvents = computed(() => {
               color: 'purple'
             })
           }
+          // -> Keep showing video client / on-site tool for Plenary until end of day, in case it goes over the planned time range
+          if (item.type === 'plenary' && item.adjustedEnd.day === current.day) {
+            links.push({
+              id: `lnk-${item.id}-video`,
+              label: 'Full Client with Video',
+              icon: 'camera-video',
+              href: item.links.videoStream,
+              color: 'purple'
+            })
+            links.push({
+              id: `lnk-${item.id}-onsitetool`,
+              label: 'Onsite tool',
+              icon: 'telephone-outbound',
+              href: item.links.onsiteTool,
+              color: 'teal'
+            })
+          }
         }
       }
     }

--- a/playwright/helpers/common.js
+++ b/playwright/helpers/common.js
@@ -13,5 +13,29 @@ module.exports = {
 
       return rect.top < bottom && rect.top > 0 - rect.height
     })
+  },
+  /**
+   * Override page DateTime with a new value
+   *
+   * @param {Object} page Page object
+   * @param {Object} dateTimeOverride New DateTime object
+   */
+  overridePageDateTime: async (page, dateTimeOverride) => {
+    await page.addInitScript(`{
+      // Extend Date constructor to default to fixed time
+      Date = class extends Date {
+        constructor(...args) {
+          if (args.length === 0) {
+            super(${dateTimeOverride.toMillis()});
+          } else {
+            super(...args);
+          }
+        }
+      }
+      // Override Date.now() to start from fixed time
+      const __DateNowOffset = ${dateTimeOverride.toMillis()} - Date.now();
+      const __DateNow = Date.now;
+      Date.now = () => __DateNow() + __DateNowOffset;
+    }`)
   }
 }

--- a/playwright/helpers/meeting.js
+++ b/playwright/helpers/meeting.js
@@ -609,6 +609,9 @@ module.exports = {
             startDateTime: curDay.set({ hour: 17, minute: 30 }),
             duration: '2h',
             type: 'plenary',
+            showAgenda: true,
+            hasAgenda: true,
+            hasRecordings: true,
             ...findAreaGroup('ietf-plenary', categories[2])
           }, floors))
         }


### PR DESCRIPTION
"Full Client with Video" + "Onsite tool" buttons for plenary now stay available until the end of day:

![image](https://github.com/user-attachments/assets/98855cfb-5466-43ca-a77f-eb096d244f91)
