### PR TITLE
chore: Vite sourcemap

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,8 @@ export default defineConfig(({ command, mode }) => {
           main: 'client/main.js',
           embedded: 'client/embedded.js'
         }
-      }
+      },
+      sourcemap: true
     },
     cacheDir: '.vite',
     plugins: [


### PR DESCRIPTION
Adds [sourcemaps](https://web.dev/articles/source-maps) to our vite build,

BEFORE
```
ietf/static/dist-neue/manifest.json                                4.12 kB │ gzip:   0.69 kB
ietf/static/dist-neue/assets/main-d9620845.css                     0.39 kB │ gzip:   0.20 kB
ietf/static/dist-neue/assets/ChatLog-15828f3c.css                  0.91 kB │ gzip:   0.30 kB
ietf/static/dist-neue/assets/agenda-1700d7f7.css                   1.20 kB │ gzip:   0.51 kB
ietf/static/dist-neue/assets/FloorPlan-a9b298ac.css                1.61 kB │ gzip:   0.62 kB
ietf/static/dist-neue/assets/Agenda-216fc048.css                  43.09 kB │ gzip:   7.04 kB
ietf/static/dist-neue/assets/_baseFindIndex-15a8234c.js            0.11 kB │ gzip:   0.12 kB
ietf/static/dist-neue/assets/_setToArray-7e958abf.js               1.22 kB │ gzip:   0.66 kB
ietf/static/dist-neue/assets/Status-8aa9949a.js                    1.66 kB │ gzip:   0.84 kB
ietf/static/dist-neue/assets/FloorPlan-8b8c8d21.js                 4.41 kB │ gzip:   1.90 kB
ietf/static/dist-neue/assets/embedded-9ef8fc6b.js                 16.03 kB │ gzip:   4.84 kB
ietf/static/dist-neue/assets/Scrollbar-3b156a06.js                25.38 kB │ gzip:   8.62 kB
ietf/static/dist-neue/assets/main-57067b9f.js                     25.63 kB │ gzip:  10.44 kB
ietf/static/dist-neue/assets/agenda-67f8f375.js                   34.87 kB │ gzip:  14.90 kB
ietf/static/dist-neue/assets/ChatLog-9927ab70.js                  41.28 kB │ gzip:  18.26 kB
ietf/static/dist-neue/assets/datetime-78deadb9.js                 68.03 kB │ gzip:  21.10 kB
ietf/static/dist-neue/assets/Polls-1264a1bc.js                   108.48 kB │ gzip:  32.15 kB
ietf/static/dist-neue/assets/Dropdown-10c600e2.js                211.66 kB │ gzip:  59.93 kB
ietf/static/dist-neue/assets/create-pinia-singleton-f2322392.js  212.76 kB │ gzip:  67.07 kB
ietf/static/dist-neue/assets/Agenda-d7fc5337.js                  695.03 kB │ gzip: 192.39 kB
```
AFTER with `sourcemap: true` the filesizes are only slightly larger. There are additional source map files created as part of the build named `*.js.map`...
```
ietf/static/dist-neue/manifest.json                                4.12 kB │ gzip:   0.69 kB
ietf/static/dist-neue/assets/main-d9620845.css                     0.39 kB │ gzip:   0.20 kB
ietf/static/dist-neue/assets/ChatLog-15828f3c.css                  0.91 kB │ gzip:   0.30 kB
ietf/static/dist-neue/assets/agenda-1700d7f7.css                   1.20 kB │ gzip:   0.51 kB
ietf/static/dist-neue/assets/FloorPlan-a9b298ac.css                1.61 kB │ gzip:   0.62 kB
ietf/static/dist-neue/assets/Agenda-216fc048.css                  43.09 kB │ gzip:   7.04 kB
ietf/static/dist-neue/assets/_baseFindIndex-15a8234c.js            0.17 kB │ gzip:   0.17 kB │ map:     1.25 kB
ietf/static/dist-neue/assets/_setToArray-7e958abf.js               1.27 kB │ gzip:   0.70 kB │ map:     7.32 kB
ietf/static/dist-neue/assets/Status-8aa9949a.js                    1.71 kB │ gzip:   0.88 kB │ map:     7.38 kB
ietf/static/dist-neue/assets/FloorPlan-8b8c8d21.js                 4.46 kB │ gzip:   1.94 kB │ map:    12.25 kB
ietf/static/dist-neue/assets/embedded-9ef8fc6b.js                 16.07 kB │ gzip:   4.87 kB │ map:    43.40 kB
ietf/static/dist-neue/assets/Scrollbar-3b156a06.js                25.43 kB │ gzip:   8.66 kB │ map:   110.01 kB
ietf/static/dist-neue/assets/main-57067b9f.js                     25.67 kB │ gzip:  10.47 kB │ map:   200.65 kB
ietf/static/dist-neue/assets/agenda-67f8f375.js                   34.92 kB │ gzip:  14.94 kB │ map:   181.92 kB
ietf/static/dist-neue/assets/ChatLog-9927ab70.js                  41.32 kB │ gzip:  18.29 kB │ map:   119.18 kB
ietf/static/dist-neue/assets/datetime-78deadb9.js                 68.07 kB │ gzip:  21.13 kB │ map:   369.03 kB
ietf/static/dist-neue/assets/Polls-1264a1bc.js                   108.52 kB │ gzip:  32.18 kB │ map:   398.69 kB
ietf/static/dist-neue/assets/Dropdown-10c600e2.js                211.71 kB │ gzip:  59.97 kB │ map:   776.39 kB
ietf/static/dist-neue/assets/create-pinia-singleton-f2322392.js  212.82 kB │ gzip:  67.12 kB │ map: 1,125.16 kB
ietf/static/dist-neue/assets/Agenda-d7fc5337.js                  695.07 kB │ gzip: 192.42 kB │ map: 2,734.04 kB
```