### PR TITLE
test: fix apparent typo / tautological test

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1440,7 +1440,7 @@ class TastypieApiTestCase(ResourceTestCaseMixin, TestCase):
         resource_list = r.json()
 
         for name in self.apps:
-            if not name in self.apps:
+            if not name in resource_list:
                 sys.stderr.write("Expected a REST API resource for %s, but didn't find one\n" % name)
 
         for name in self.apps:


### PR DESCRIPTION
This fixes a no-op that's long been in the tastypie test. It's still redundant with the assertions, but I think the idea is to give a complete list of missing resources rather than failing on the first one.