### PR TITLE
fix: 500->400 for bad /api/v1/ requests

### DIFF
--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -28,7 +28,7 @@ from django.views.generic.detail import DetailView
 from email.message import EmailMessage
 from importlib.metadata import version as metadata_version
 from jwcrypto.jwk import JWK
-from tastypie.exceptions import BadRequest, UnsupportedFormat
+from tastypie.exceptions import BadRequest
 from tastypie.serializers import Serializer
 from tastypie.utils import is_valid_jsonp_callback_value
 from tastypie.utils.mime import determine_format, build_content_type

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -18,7 +18,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.http import HttpResponse, Http404, JsonResponse
+from django.http import HttpResponse, Http404, JsonResponse, HttpResponseBadRequest
 from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -28,7 +28,7 @@ from django.views.generic.detail import DetailView
 from email.message import EmailMessage
 from importlib.metadata import version as metadata_version
 from jwcrypto.jwk import JWK
-from tastypie.exceptions import BadRequest
+from tastypie.exceptions import BadRequest, UnsupportedFormat
 from tastypie.serializers import Serializer
 from tastypie.utils import is_valid_jsonp_callback_value
 from tastypie.utils.mime import determine_format, build_content_type
@@ -68,7 +68,10 @@ def top_level(request):
         }
 
     serializer = Serializer()
-    desired_format = determine_format(request, serializer)
+    try:
+        desired_format = determine_format(request, serializer)
+    except BadRequest as err:
+        return HttpResponseBadRequest(str(err))
 
     options = {}
 
@@ -76,10 +79,12 @@ def top_level(request):
         callback = request.GET.get('callback', 'callback')
 
         if not is_valid_jsonp_callback_value(callback):
-            raise BadRequest('JSONP callback name is invalid.')
+            return HttpResponseBadRequest("JSONP callback name is invalid")
 
         options['callback'] = callback
 
+    # This might raise UnsupportedFormat, but that indicates a real server misconfiguration
+    # so let it bubble up unhandled and trigger a 500 / email to admins.
     serialized = serializer.serialize(available_resources, desired_format, options)
     return HttpResponse(content=serialized, content_type=build_content_type(desired_format))
 


### PR DESCRIPTION
With this change, an invalid or unsupported `Accept` header will trigger a 400 response instead of a 500.

If we wanted to be more precise I suppose we could return a [406 response status](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/406), but that requires some additional effort that I don't think is needed.