### PR TITLE
refactor: smtpd->aiosmtpd

### DIFF
--- a/ietf/utils/management/tests.py
+++ b/ietf/utils/management/tests.py
@@ -12,7 +12,7 @@ from ietf.utils.management.base import EmailOnFailureCommand
 from ietf.utils.test_utils import TestCase
 
 
-@mock.patch.object(EmailOnFailureCommand, 'handle')
+@mock.patch.object(EmailOnFailureCommand, 'handle', return_value=None)
 class EmailOnFailureCommandTests(TestCase):
     def test_calls_handle(self, handle_method):
         call_command(EmailOnFailureCommand())

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -863,7 +863,7 @@ class IetfTestRunner(DiscoverRunner):
             try:
                 # remember the value so ietf.utils.mail.send_smtp() will use the same
                 ietf.utils.mail.SMTP_ADDR['port'] = base + offset
-                self.smtpd_driver = SMTPTestServerDriver((ietf.utils.mail.SMTP_ADDR['ip4'],ietf.utils.mail.SMTP_ADDR['port']),None)
+                self.smtpd_driver = SMTPTestServerDriver(ietf.utils.mail.SMTP_ADDR['ip4'],ietf.utils.mail.SMTP_ADDR['port'], None)
                 self.smtpd_driver.start()
                 print(("     Running an SMTP test server on %(ip4)s:%(port)s to catch outgoing email." % ietf.utils.mail.SMTP_ADDR))
                 break

--- a/ietf/utils/test_smtpserver.py
+++ b/ietf/utils/test_smtpserver.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from aiosmtpd.controller import Controller
+from aiosmtpd.smtp import SMTP
 from email.utils import parseaddr
 from typing import Optional
 
@@ -38,6 +39,10 @@ class SMTPTestHandler:
 class SMTPTestServerDriver:
 
     def __init__(self, address: str, port: int, inbox: Optional[list] = None):
+        # Allow longer lines than the 1001 that RFC 5321 requires. As of 2025-04-16 the
+        # datatracker emits some non-compliant messages.
+        # See https://aiosmtpd.aio-libs.org/en/latest/smtp.html
+        SMTP.line_length_limit = 4000  # tests start failing between 3000 and 4000
         self.controller = Controller(
             hostname=address,
             port=port,

--- a/ietf/utils/test_smtpserver.py
+++ b/ietf/utils/test_smtpserver.py
@@ -1,92 +1,51 @@
-# Copyright The IETF Trust 2014-2020, All Rights Reserved
+# Copyright The IETF Trust 2014-2025, All Rights Reserved
 # -*- coding: utf-8 -*-
 
-
-import smtpd
-import threading
-import asyncore
-
-import debug                            # pyflakes:ignore
-
-class AsyncCoreLoopThread(object):
-
-    def wrap_loop(self, exit_condition, timeout=1.0, use_poll=False, map=None):
-        if map is None:
-            map = asyncore.socket_map
-            while map and not exit_condition:
-                asyncore.loop(timeout=1.0, use_poll=False, map=map, count=1)
-
-    def start(self):
-        """Start the listening service"""
-        self.exit_condition = []
-        kwargs={'exit_condition':self.exit_condition,'timeout':1.0} 
-        self.thread = threading.Thread(target=self.wrap_loop, kwargs=kwargs)
-        self.thread.daemon = True
-        self.thread.daemon = True
-        self.thread.start()     
-
-    def stop(self):
-        """Stop the listening service"""
-        self.exit_condition.append(True)
-        self.thread.join()
+from aiosmtpd.controller import Controller
+from email.utils import parseaddr
+from typing import Optional
 
 
-class SMTPTestChannel(smtpd.SMTPChannel):
+class SMTPTestHandler:
 
-#    mail_options = ['BODY=8BITMIME', 'SMTPUTF8']
+    def __init__(self, inbox: list):
+        self.inbox = inbox
 
-    def smtp_RCPT(self, arg):
-        if not self.mailfrom:
-            self.push(str('503 Error: need MAIL command'))
-            return
-        arg = self._strip_command_keyword('TO:', arg)
-        address, __ = self._getaddr(arg)
-        if not address:
-            self.push(str('501 Syntax: RCPT TO: <address>'))
-            return
+    async def handle_DATA(self, server, session, envelope):
+        """Handle the DATA command and 'deliver' the message"""
+
+        self.inbox.append(envelope.content)
+        # Per RFC2033: https://datatracker.ietf.org/doc/html/rfc2033.html#section-4.2
+        #     ...after the final ".", the server returns one reply
+        #     for each previously successful RCPT command in the mail transaction,
+        #     in the order that the RCPT commands were issued.  Even if there were
+        #     multiple successful RCPT commands giving the same forward-path, there
+        #     must be one reply for each successful RCPT command.
+        return "\n".join("250 OK" for _ in envelope.rcpt_tos)
+
+    async def handle_RCPT(self, server, session, envelope, address, rcpt_options):
+        """Handle an RCPT command and add the address to the envelope if it is acceptable"""
+        _, address = parseaddr(address)
+        if address == "":
+            return "501 Syntax: RCPT TO: <address>"
         if "poison" in address:
-            self.push(str('550 Error: Not touching that'))
-            return
-        self.rcpt_options = []
-        self.rcpttos.append(address)
-        self.push(str('250 Ok'))
-
-class SMTPTestServer(smtpd.SMTPServer):
-
-    def __init__(self,localaddr,remoteaddr,inbox):
-        if inbox is not None:
-            self.inbox=inbox
-        else:
-            self.inbox = []
-        smtpd.SMTPServer.__init__(self,localaddr,remoteaddr)
-
-    def handle_accept(self):
-        pair = self.accept()
-        if pair is not None:
-            conn, addr = pair
-            #channel = SMTPTestChannel(self, conn, addr)
-            SMTPTestChannel(self, conn, addr)
-
-    def process_message(self, peer, mailfrom, rcpttos, data, mail_options=None, rcpt_options=None):
-        self.inbox.append(data)
+            return "550 Error: Not touching that"
+        # At this point the address is acceptable
+        envelope.rcpt_tos.append(address)
+        return "250 OK"
 
 
-class SMTPTestServerDriver(object):
-    def __init__(self, localaddr, remoteaddr, inbox=None):
-        self.localaddr=localaddr
-        self.remoteaddr=remoteaddr
-        if inbox is not None:
-            self.inbox = inbox
-        else:
-            self.inbox = []
-        self.thread_driver = None
+class SMTPTestServerDriver:
+
+    def __init__(self, address: str, port: int, inbox: Optional[list] = None):
+        self.controller = Controller(
+            hostname=address,
+            port=port,
+            handler=SMTPTestHandler(inbox=[] if inbox is None else inbox),
+        )
 
     def start(self):
-        self.smtpserver = SMTPTestServer(self.localaddr,self.remoteaddr,self.inbox)
-        self.thread_driver = AsyncCoreLoopThread()
-        self.thread_driver.start()
+        self.controller.start()
 
     def stop(self):
-        if self.thread_driver:
-            self.thread_driver.stop()
-
+        self.controller.stop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # -*- conf-mode -*-
 setuptools>=51.1.0    # Require this first, to prevent later errors
 #
+aiosmtpd>=1.4.6
 argon2-cffi>=21.3.0    # For the Argon2 password hasher option
 beautifulsoup4>=4.11.1    # Only used in tests
 bibtexparser>=1.2.0    # Only used in tests


### PR DESCRIPTION
This is a prerequisite for moving to Python 3.12 (see https://github.com/ietf-tools/datatracker/issues/7929#issuecomment-2435388004). Fixes #8077 

The `line_length_limit` increase in commit 5bb3700 is needed because, as indicated in the comment, some of the tests are sending messages that exceed the RFC 5321 line length limit in the DATA section. From what I have found so far, the issue is that datatracker is incorrectly sending `<LF>` instead of `<CRLF>` as line endings when sending SMTP messages. It's just possible that this is a test-only bug, but it's likely affecting production. This is causing failures now because aiosmtpd is strict, both about line endings and about line lengths, whereas our previous test server was extremely lenient.

While that's embarrassing and should be investigated/fixed soon, I think we should do that separately and run with the `line_length_limit` fix for now. That only affects testing code and can only cause new failures, not hide ones we'd have caught before.