### PR TITLE
feat: set BEAT_CRON_STARTING_DEADLINE

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1268,6 +1268,7 @@ CELERY_TIMEZONE = 'UTC'
 CELERY_BROKER_URL = 'amqp://mq/'
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 CELERY_BEAT_SYNC_EVERY = 1  # update DB after every event
+CELERY_BEAT_CRON_STARTING_DEADLINE = 1800  # seconds after a missed deadline before abandoning a cron task
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True  # the default, but setting it squelches a warning
 # Use a result backend so we can chain tasks. This uses the rpc backend, see
 # https://docs.celeryq.dev/en/stable/userguide/tasks.html#rpc-result-backend-rabbitmq-qpid


### PR DESCRIPTION
This configures beat to look back at most 30 minutes (1800 seconds) when deciding if a PeriodicTask scheduled via a crontab schedule is due. The value was chosen to be long enough that tasks missed by a moderately problematic production deployment will still run, but that we won't be surprised by a task running at entirely the wrong time.

This will not impact newly created tasks, only ones that have a "last run" time that's too long ago.

https://docs.celeryq.dev/en/main/userguide/configuration.html#beat-cron-starting-deadline