### PR TITLE
feat: summarize all documents in iesg processing

### DIFF
--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -422,7 +422,7 @@ class SearchTests(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(r, draft.name)
         self.assertContains(r, escape(draft.action_holders.first().name))
-        self.assertContains(r, rfc.name)
+        self.assertNotContains(r, rfc.name)
         self.assertContains(r, conflrev.name)
         self.assertContains(r, statchg.name)
         self.assertContains(r, charter.name)

--- a/ietf/doc/tests.py
+++ b/ietf/doc/tests.py
@@ -403,6 +403,30 @@ class SearchTests(TestCase):
         self.assertContains(r, discuss_other.doc.name)
         self.assertContains(r, block_other.doc.name)
 
+    def test_docs_for_iesg(self):
+        ad1 = RoleFactory(name_id='ad',group__type_id='area',group__state_id='active').person
+        ad2 = RoleFactory(name_id='ad',group__type_id='area',group__state_id='active').person
+
+        draft = IndividualDraftFactory(ad=ad1)
+        draft.action_holders.set([PersonFactory()])
+        draft.set_state(State.objects.get(type='draft-iesg', slug='lc'))
+        rfc = IndividualRfcFactory(ad=ad2)
+        conflrev = DocumentFactory(type_id='conflrev',ad=ad1)
+        conflrev.set_state(State.objects.get(type='conflrev', slug='iesgeval'))
+        statchg = DocumentFactory(type_id='statchg',ad=ad2)
+        statchg.set_state(State.objects.get(type='statchg', slug='iesgeval'))
+        charter = CharterFactory(name='charter-ietf-ames',ad=ad1)
+        charter.set_state(State.objects.get(type='charter', slug='iesgrev'))
+
+        r = self.client.get(urlreverse('ietf.doc.views_search.docs_for_iesg'))
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, draft.name)
+        self.assertContains(r, escape(draft.action_holders.first().name))
+        self.assertContains(r, rfc.name)
+        self.assertContains(r, conflrev.name)
+        self.assertContains(r, statchg.name)
+        self.assertContains(r, charter.name)
+
     def test_auth48_doc_for_ad(self):
         """Docs in AUTH48 state should have a decoration"""
         ad = RoleFactory(name_id='ad', group__type_id='area', group__state_id='active').person

--- a/ietf/doc/urls.py
+++ b/ietf/doc/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     url(r'^ad/?$', views_search.ad_workload),
     url(r'^ad/(?P<name>[^/]+)/?$', views_search.docs_for_ad),
     url(r'^ad2/(?P<name>[\w.-]+)/$', RedirectView.as_view(url='/doc/ad/%(name)s/', permanent=True)),
+    url(r'^for_iesg/?$', views_search.docs_for_iesg),
     url(r'^rfc-status-changes/?$', views_status_change.rfc_status_changes),
     url(r'^start-rfc-status-change/(?:%(name)s/)?$' % settings.URL_REGEXPS, views_status_change.start_rfc_status_change),
     url(r'^bof-requests/?$', views_bofreq.bof_requests),

--- a/ietf/doc/utils_search.py
+++ b/ietf/doc/utils_search.py
@@ -299,10 +299,10 @@ AD_WORKLOAD = {
         "ad-eval",
         "lc-req",
         "lc",
+        "goaheadw",
         "writeupw",
         # "defer",  # probably not a useful state to show, since it's rare
         "iesg-eva",
-        "goaheadw",
         "approved",
         "ann",
     ],

--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -770,6 +770,28 @@ def docs_for_iesg(request):
                     role__group__state="active",
                 )
             )
+        ).exclude(
+            type_id="rfc",
+        ).exclude(
+            type_id="draft",
+            states__type="draft", 
+            states__slug__in=["repl", "rfc"],
+        ).exclude(
+            type_id="draft",
+            states__type="draft-iesg",
+            states__slug__in=["idexists", "rfcqueue"],
+        ).exclude(
+            type_id="conflrev",
+            states__type="conflrev",
+            states__slug__in=["appr-noprob-sent", "appr-reqnopub-sent", "withdraw", "dead"],
+        ).exclude(
+            type_id="statchg",
+            states__type="statchg",
+            states__slug__in=["appr-sent", "dead"],
+        ).exclude(
+            type_id="charter",
+            states__type="charter",
+            states__slug__in=["notrev", "infrev", "approved", "replaced"],
         ),
         max_results=1000,
         show_ad_and_shepherd=True,

--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -752,6 +752,68 @@ def docs_for_ad(request, name):
     )
 
 
+def docs_for_iesg(request):
+    def sort_key(doc):
+        dt = doc_type(doc)
+        dt_key = list(AD_WORKLOAD.keys()).index(dt)
+        ds = doc_state(doc)
+        ds_key = AD_WORKLOAD[dt].index(ds) if ds in AD_WORKLOAD[dt] else 99
+        return dt_key * 100 + ds_key
+
+    results, meta = prepare_document_table(
+        request,
+        Document.objects.filter(
+            ad__in=Person.objects.filter(
+                Q(
+                    role__name__in=("pre-ad", "ad"),
+                    role__group__type="area",
+                    role__group__state="active",
+                )
+            )
+        ),
+        max_results=1000,
+        show_ad_and_shepherd=True,
+    )
+    results.sort(key=lambda d: sort_key(d))
+
+    # filter out some results
+    results = [
+        r
+        for r in results
+        if not (
+            r.type_id == "charter"
+            and (
+                r.group.state_id == "abandon"
+                or r.get_state_slug("charter") == "replaced"
+            )
+        )
+        and not (
+            r.type_id == "draft"
+            and (
+                r.get_state_slug("draft-iesg") == "dead"
+                or r.get_state_slug("draft") == "repl"
+                or r.get_state_slug("draft") == "rfc"
+            )
+        )
+    ]
+
+    _calculate_state_name = get_state_name_calculator()
+    for d in results:
+        dt = d.type.slug
+        d.search_heading = _calculate_state_name(dt, doc_state(d))
+        if d.search_heading != "RFC":
+            d.search_heading += f" {doc_type_name(dt)}"
+
+    return render(
+        request,
+        "doc/drafts_for_iesg.html",
+        {
+            "docs": results,
+            "meta": meta,
+        },
+    )
+
+
 def drafts_in_last_call(request):
     lc_state = State.objects.get(type="draft-iesg", slug="lc").pk
     form = SearchForm({'by':'state','state': lc_state, 'rfcs':'on', 'activedrafts':'on'})

--- a/ietf/templates/doc/ad_list.html
+++ b/ietf/templates/doc/ad_list.html
@@ -29,6 +29,7 @@
         are only shown to logged-in Area Directors.
     </div>
     {% endif %}
+    <p><a href="{% url 'ietf.doc.views_search.docs_for_iesg' %}">Documents in IESG Processing</a></p>
     {% for dt in metadata %}
         <h2 class="mt-5" id="{{ dt.type.0 }}">{{ dt.type.1 }} State Counts</h2>
         <table class="table table-sm table-striped table-bordered tablesorter navskip">

--- a/ietf/templates/doc/drafts_for_iesg.html
+++ b/ietf/templates/doc/drafts_for_iesg.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{# Copyright The IETF Trust 2015, All Rights Reserved #}
+{% load origin static %}
+{% load ietf_filters %}
+{% load person_filters %}
+{% block pagehead %}
+    <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
+{% endblock %}
+{% block title %}Documents for the IESG{% endblock %}
+{% block content %}
+    {% cache 300 ietf_doc_drafts_for_iesg using="slowpages" %}
+    {% origin %}
+    <h1 class="mt-4">Documents for the IESG</h1>
+    {% include "doc/search/search_results.html" with start_table=True end_table=True %}
+    {% endcache %}
+{% endblock %}
+{% block js %}
+    <script src="{% static "ietf/js/list.js" %}"></script>
+{% endblock %}

--- a/ietf/templates/doc/drafts_for_iesg.html
+++ b/ietf/templates/doc/drafts_for_iesg.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {# Copyright The IETF Trust 2015, All Rights Reserved #}
 {% load origin static %}
+{% load cache %}
 {% load ietf_filters %}
 {% load person_filters %}
 {% block pagehead %}

--- a/ietf/templates/doc/drafts_in_iesg_process.html
+++ b/ietf/templates/doc/drafts_in_iesg_process.html
@@ -10,6 +10,7 @@
 {% block content %}
     {% origin %}
     <h1>{{ title }}</h1>
+    <h2><i class="bi bi-exclamation-triangle"></i>This view is deprecated, and will soon redirect to a <a href="{% url 'ietf.doc.views_search.docs_for_iesg' %}">different representation</a></h2>
     <table class="table table-sm table-striped tablesorter">
         <thead>
             <tr>


### PR DESCRIPTION
This creates a new path at /doc/for_iesg and adds a link to it from /doc/ad

It provides more information than the older /doc/iesg path (which is not linked from anywhere)

If the new view meets the needs of #7307 we could remove the view at /doc/iesg (which could come after merging this if there's a reason to keep that view for awhile).