### PR TITLE
chore(deps): bump to fixed django-celery-beat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Django>4.2,<5
 django-admin-rangefilter>=0.13.2
 django-analytical>=3.1.0
 django-bootstrap5>=21.3
-django-celery-beat>=2.3.0,<2.8.0  # pin until https://github.com/celery/django-celery-beat/issues/875 is resolved, then revisit
+django-celery-beat>=2.8.1
 django-celery-results>=2.5.1
 django-csp>=3.7
 django-cors-headers>=3.11.0


### PR DESCRIPTION
django-celery-beat 2.8.1 is out with the fix for the time zone issue. We could fall back to >= 2.3.0 because they've yanked the broken release, but I don't see any reason to allow the old versions.

Should be safe to install this immediately since they're all currently in UTC. We can later test that schedules in non-UTC time zones do in fact run, then convert our schedules back to America/Los_Angeles (if we want to do so).