### PR TITLE
chore(deps): revert "bump to fixed django-celery-beat"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Django>4.2,<5
 django-admin-rangefilter>=0.13.2
 django-analytical>=3.1.0
 django-bootstrap5>=21.3
-django-celery-beat>=2.8.1
+django-celery-beat>=2.3.0,<2.8.0  # pin until https://github.com/celery/django-celery-beat/issues/875 is resolved, then revisit
 django-celery-results>=2.5.1
 django-csp>=3.7
 django-cors-headers>=3.11.0


### PR DESCRIPTION
This reverts commit 5b77ba6b716d5da0ef8ea60de365e75952d0e1d0. There are still reports of trouble with django-celery-beat 2.8.1.