### PR TITLE
fix: paginate search results correctly

### DIFF
--- a/ietf/person/views.py
+++ b/ietf/person/views.py
@@ -62,8 +62,8 @@ def ajax_select2_search(request, model_name):
         page = int(request.GET.get("p", 1)) - 1
     except ValueError:
         page = 0
-
-    objs = objs.distinct()[page:page + 10]
+    first_item = page * 10
+    objs = objs.distinct()[first_item:first_item + 10]
 
     return HttpResponse(select2_id_name_json(objs), content_type='application/json')
 

--- a/ietf/person/views.py
+++ b/ietf/person/views.py
@@ -62,8 +62,9 @@ def ajax_select2_search(request, model_name):
         page = int(request.GET.get("p", 1)) - 1
     except ValueError:
         page = 0
-    first_item = page * 10
-    objs = objs.distinct()[first_item:first_item + 10]
+    PAGE_SIZE = 10
+    first_item = page * PAGE_SIZE
+    objs = objs.distinct()[first_item:first_item + PAGE_SIZE]
 
     return HttpResponse(select2_id_name_json(objs), content_type='application/json')
 


### PR DESCRIPTION
Previously, pages overlapped with page 1 = elements 0-9, page 2 = elements 1-10, page 3 = elements 2-11. This explains anecdotal observations that the ajax search URL was often hit with surprisingly large flurries of activity...