### PR TITLE
chore: lint, lint everywhere

### DIFF
--- a/ietf/settings_test.py
+++ b/ietf/settings_test.py
@@ -50,7 +50,7 @@ DATABASES = {
 
 # test with a single DB - do not use a DB router
 BLOBDB_DATABASE = "default"
-DATABASE_ROUTERS: list[str] = []
+DATABASE_ROUTERS = []  # type: ignore
 
 if TEST_CODE_COVERAGE_CHECKER and not TEST_CODE_COVERAGE_CHECKER._started: # pyflakes:ignore
     TEST_CODE_COVERAGE_CHECKER.start()                          # pyflakes:ignore


### PR DESCRIPTION
Prevents mypy from complaining about a type annotation in environments (like dev) where `DATABASE_ROUTERS` is already defined (even when it's the same type...)