### PR TITLE
feat: toggle all areas in agenda editor

### DIFF
--- a/ietf/static/js/edit-meeting-schedule.js
+++ b/ietf/static/js/edit-meeting-schedule.js
@@ -50,6 +50,7 @@ $(function () {
     let sessionPurposeInputs = schedEditor.find('.session-purpose-toggles input');
     let timeSlotGroupInputs = schedEditor.find("#timeslot-group-toggles-modal .modal-body .individual-timeslots input");
     let sessionParentInputs = schedEditor.find(".session-parent-toggles input");
+    let sessionParentToggleAll = schedEditor.find(".session-parent-toggles .session-parent-toggle-all")
     const classes_to_hide = '.hidden-timeslot-group,.hidden-timeslot-type';
 
     // hack to work around lack of position sticky support in old browsers, see https://caniuse.com/#feat=css-sticky
@@ -768,6 +769,17 @@ $(function () {
 
     sessionParentInputs.on("click", updateSessionParentToggling);
     updateSessionParentToggling();
+
+    // Toggle _all_ session parents
+    function toggleAllSessionParents() {
+        if (sessionParentInputs.filter(":checked").length < sessionParentInputs.length) {
+            sessionParentInputs.prop("checked", true);
+        } else {
+            sessionParentInputs.prop("checked", false);
+        }
+        updateSessionParentToggling();
+    }
+    sessionParentToggleAll.on("click", toggleAllSessionParents);
 
     // Toggling timeslot types
     function updateTimeSlotTypeToggling() {

--- a/ietf/templates/meeting/edit_meeting_schedule.html
+++ b/ietf/templates/meeting/edit_meeting_schedule.html
@@ -223,6 +223,11 @@
                                     {{ p.acronym }}
                                 </label>
                             {% endfor %}
+                            <button type="button"
+                                    class="btn btn-outline-primary btn-sm session-parent-toggle-all">
+                                Toggle All
+                            </button>
+                                    
                         </div>
                         <div class="my-3">
                         {% if session_purposes|length > 1 %}


### PR DESCRIPTION
Adds a "Toggle All" button to enable/disable all areas on the agenda editor

<img width="928" alt="image" src="https://github.com/user-attachments/assets/6b2f504b-89db-497a-904b-f821255e8ffe" />