### PR TITLE
chore: increase timeout for rabbitmq probe

### DIFF
--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -52,17 +52,17 @@ spec:
                   key: CELERY_PASSWORD
           livenessProbe:
             exec:
-              command: ["rabbitmq-diagnostics", "-q", "ping"]
+              command: ["rabbitmq-diagnostics", "-q", "ping", "-t", "30"]
             periodSeconds: 30
-            timeoutSeconds: 5
+            timeoutSeconds: 35  # slightly longer than ping "-t" option
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 35  # slightly longer than ping "-t" option
             successThreshold: 1
             failureThreshold: 60
             exec:
-              command: ["rabbitmq-diagnostics", "-q", "ping"]
+              command: ["rabbitmq-diagnostics", "-q", "ping", "-t", "30"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Liveness probes for the RabbitMQ pod are failing occasionally in production, sometimes leading to the pod being terminated and replaced. Other than interruptions caused by the roll-over, there are no signs of problems with the service. Notably, the celery worker is processing jobs without apparent interruption, which indicates that the message queue is operating. RabbitMQ itself does not report any errors, and its memory / CPU usage are not remarkable. There are some indications that the k8s node might be busy at the time of the mq pod restart (synthetics checks had slow responses at around the same time).

My suspicion is that once in a while, perhaps during heavy load, the `rabbitmq-diagnostics ping` command we use is taking too long to execute. We're using a short (5s) timeout on the liveness probe. This bumps the timeout to 30 seconds on the `ping` command, which was using its default infinite timeout. The k8s livenessProbe config timeout is set to 35 seconds to allow time for the command to start / exit.