### PR TITLE
fix: remove stale "contains" docs on rfc-index sync

### DIFF
--- a/ietf/sync/rfceditor.py
+++ b/ietf/sync/rfceditor.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2012-2020, All Rights Reserved
+# Copyright The IETF Trust 2012-2025, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 
@@ -711,10 +711,22 @@ def update_docs_from_rfc_index(
         # have been dropped from the index
         for maybe_stale_subseries_doc in doc.related_that("contains"):
             if maybe_stale_subseries_doc.name not in also:
-                assert(not first_sync_creating_subseries)
-                maybe_stale_subseries_doc.relateddocument_set.filter(target=doc).delete()
-                rfc_events.append(doc.docevent_set.create(type="sync_from_rfc_editor", by=system, desc=f"Removed {doc.name} from {maybe_stale_subseries_doc.name}"))
-                maybe_stale_subseries_doc.docevent_set.create(type="sync_from_rfc_editor", by=system, desc=f"Removed {doc.name} from {maybe_stale_subseries_doc.name}")
+                assert not first_sync_creating_subseries
+                maybe_stale_subseries_doc.relateddocument_set.filter(
+                    target=doc
+                ).delete()
+                rfc_events.append(
+                    doc.docevent_set.create(
+                        type="sync_from_rfc_editor",
+                        by=system,
+                        desc=f"Removed {doc.name} from {maybe_stale_subseries_doc.name}",
+                    )
+                )
+                maybe_stale_subseries_doc.docevent_set.create(
+                    type="sync_from_rfc_editor",
+                    by=system,
+                    desc=f"Removed {doc.name} from {maybe_stale_subseries_doc.name}",
+                )
 
         doc_errata = errata.get(f"RFC{rfc_number}", [])
         all_rejected = doc_errata and all(


### PR DESCRIPTION
Due to a typo / variable naming issue, a document no longer contained by a subseries doc was removed from the wrong `subseries_doc`.

Fixes #7244 