### PR TITLE
fix: handle agenda room slug with single quote + ampersand

### DIFF
--- a/client/shared/xslugify.js
+++ b/client/shared/xslugify.js
@@ -1,5 +1,5 @@
 import slugify from 'slugify'
 
 export default (str) => {
-  return slugify(str.replaceAll('/', '-'), { lower: true })
+  return slugify(str.replaceAll('/', '-').replaceAll(/['&]/g, ''), { lower: true })
 }


### PR DESCRIPTION
Fix rooms with ' or & in name not working when clicking on them from the agenda or floor plan menu.

fix #9041 