### PR TITLE
test: tolerate APP_API_TOKENS existing in settings

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1582,7 +1582,7 @@ class DirectAuthApiTests(TestCase):
             data = self.response_data(r)
             self.assertEqual(data["result"], "failure")
             self.assertEqual(data["reason"], "invalid post")
-        
+
         bad = dict(authtoken=self.valid_token, username=self.valid_person.user.username, password=self.valid_password)
         r = self.client.post(self.url, bad)
         self.assertEqual(r.status_code, 200)
@@ -1590,8 +1590,9 @@ class DirectAuthApiTests(TestCase):
         self.assertEqual(data["result"], "failure")
         self.assertEqual(data["reason"], "invalid post")       
 
+    @override_settings()
     def test_notokenstore(self):
-        self.assertFalse(hasattr(settings, "APP_API_TOKENS"))
+        del settings.APP_API_TOKENS  # only affects overridden copy of settings!
         r = self.client.post(self.url,self.valid_body_with_good_password)
         self.assertEqual(r.status_code, 200)
         data = self.response_data(r)


### PR DESCRIPTION
This test used to help ensure we did not accidentally deploy dev API tokens, but our CI/CD practices have changed enough that it's no longer an effective check.