### PR TITLE
fix: improve pw validation without js

### DIFF
--- a/ietf/ietfauth/forms.py
+++ b/ietf/ietfauth/forms.py
@@ -234,9 +234,18 @@ class ChangePasswordForm(forms.Form):
         conf_password = self.cleaned_data.get("new_password_confirmation")
         if new_password != conf_password:
             raise ValidationError(
-                "The password confirmation is different than the new password"
+                {
+                    # attach error to specific field
+                    "new_password_confirmation": "The password confirmation is "
+                                                 "different than the new password"
+                }
             )
-        password_validation.validate_password(conf_password, self.user)
+        try:
+            password_validation.validate_password(conf_password, self.user)
+        except ValidationError as err:
+            raise ValidationError(
+                {"new_password": err}  # attach error to specific field
+            )
 
 
 class ChangeUsernameForm(forms.Form):

--- a/ietf/ietfauth/forms.py
+++ b/ietf/ietfauth/forms.py
@@ -80,6 +80,7 @@ class PasswordForm(forms.Form):
             password_validation.validate_password(password_confirmation, self.user)
         except ValidationError as err:
             self.add_error("password", err)
+        return password_confirmation
 
 
 def ascii_cleaner(supposedly_ascii):

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -168,18 +168,40 @@ class IetfAuthTests(TestCase):
         self.assertEqual(r.status_code, 200)
 
         # password mismatch
-        r = self.client.post(confirm_url, { 'password': 'secret', 'password_confirmation': 'nosecret' })
+        r = self.client.post(
+            confirm_url, {
+                "password": "secret-and-secure",
+                "password_confirmation": "not-secret-or-secure",
+            }
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(User.objects.filter(username=email).count(), 0)
+
+        # weak password
+        r = self.client.post(
+            confirm_url, {
+                "password": "password1234",
+                "password_confirmation": "password1234",
+            }
+        )
         self.assertEqual(r.status_code, 200)
         self.assertEqual(User.objects.filter(username=email).count(), 0)
 
         # confirm
-        r = self.client.post(confirm_url, { 'name': 'User Name', 'ascii': 'User Name', 'password': 'secret', 'password_confirmation': 'secret' })
+        r = self.client.post(
+            confirm_url,
+            {
+                "name": "User Name",
+                "ascii": "User Name",
+                "password": "secret-and-secure",
+                "password_confirmation": "secret-and-secure",
+            },
+        )
         self.assertEqual(r.status_code, 200)
         self.assertEqual(User.objects.filter(username=email).count(), 1)
         self.assertEqual(Person.objects.filter(user__username=email).count(), 1)
         self.assertEqual(Email.objects.filter(person__user__username=email).count(), 1)
 
-        
     # This also tests new account creation.
     def test_create_existing_account(self):
         # create account once

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -655,7 +655,7 @@ class IetfAuthTests(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertFormError(
             r.context["form"],
-            None,
+            "password_confirmation",
             "The password confirmation is different than the new password",
         )
 
@@ -671,7 +671,7 @@ class IetfAuthTests(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertFormError(
             r.context["form"],
-            None,
+            "password",
             "This password is too short. It must contain at least "
             f"{settings.PASSWORD_POLICY_MIN_LENGTH} characters."
         )
@@ -688,7 +688,7 @@ class IetfAuthTests(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertFormError(
             r.context["form"],
-            None,
+            "password",
             "This password does not meet complexity requirements "
             "and is easily guessable."
         )

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -636,8 +636,8 @@ class IetfAuthTests(TestCase):
             chpw_url,
             {
                 "current_password": "fiddlesticks",
-                "new_password": ANOTHER_VALID_PASSWORD,
-                "new_password_confirmation": ANOTHER_VALID_PASSWORD,
+                "password": ANOTHER_VALID_PASSWORD,
+                "password_confirmation": ANOTHER_VALID_PASSWORD,
             },
         )
         self.assertEqual(r.status_code, 200)
@@ -648,8 +648,8 @@ class IetfAuthTests(TestCase):
             chpw_url,
             {
                 "current_password": VALID_PASSWORD,
-                "new_password": ANOTHER_VALID_PASSWORD,
-                "new_password_confirmation": ANOTHER_VALID_PASSWORD[::-1],
+                "password": ANOTHER_VALID_PASSWORD,
+                "password_confirmation": ANOTHER_VALID_PASSWORD[::-1],
             },
         )
         self.assertEqual(r.status_code, 200)
@@ -664,8 +664,8 @@ class IetfAuthTests(TestCase):
             chpw_url,
             {
                 "current_password": VALID_PASSWORD,
-                "new_password": "sh0rtpw0rd",
-                "new_password_confirmation": "sh0rtpw0rd",
+                "password": "sh0rtpw0rd",
+                "password_confirmation": "sh0rtpw0rd",
             }
         )
         self.assertEqual(r.status_code, 200)
@@ -681,8 +681,8 @@ class IetfAuthTests(TestCase):
             chpw_url,
             {
                 "current_password": VALID_PASSWORD,
-                "new_password": "passwordpassword",
-                "new_password_confirmation": "passwordpassword",
+                "password": "passwordpassword",
+                "password_confirmation": "passwordpassword",
             }
         )
         self.assertEqual(r.status_code, 200)
@@ -698,8 +698,8 @@ class IetfAuthTests(TestCase):
             chpw_url,
             {
                 "current_password": VALID_PASSWORD,
-                "new_password": ANOTHER_VALID_PASSWORD,
-                "new_password_confirmation": ANOTHER_VALID_PASSWORD,
+                "password": ANOTHER_VALID_PASSWORD,
+                "password_confirmation": ANOTHER_VALID_PASSWORD,
             },
         )
         self.assertRedirects(r, prof_url)

--- a/ietf/ietfauth/tests.py
+++ b/ietf/ietfauth/tests.py
@@ -415,6 +415,7 @@ class IetfAuthTests(TestCase):
         self.assertTrue(q('#volunteered'))
 
     def test_reset_password(self):
+        WEAK_PASSWORD="password1234"
         VALID_PASSWORD = "complex-and-long-valid-password"
         ANOTHER_VALID_PASSWORD = "very-complicated-and-lengthy-password"
         url = urlreverse("ietf.ietfauth.views.password_reset")
@@ -466,6 +467,18 @@ class IetfAuthTests(TestCase):
             {
                 "password": ANOTHER_VALID_PASSWORD,
                 "password_confirmation": ANOTHER_VALID_PASSWORD[::-1],
+            },
+        )
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+        self.assertTrue(len(q("form .is-invalid")) > 0)
+
+        # weak password
+        r = self.client.post(
+            confirm_url,
+            {
+                "password": WEAK_PASSWORD,
+                "password_confirmation": WEAK_PASSWORD,
             },
         )
         self.assertEqual(r.status_code, 200)

--- a/ietf/ietfauth/views.py
+++ b/ietf/ietfauth/views.py
@@ -529,7 +529,7 @@ def confirm_password_reset(request, auth):
         )
     success = False
     if request.method == 'POST':
-        form = PasswordForm(request.POST)
+        form = PasswordForm(user=user, data=request.POST)
         if form.is_valid():
             password = form.cleaned_data["password"]
 
@@ -538,7 +538,7 @@ def confirm_password_reset(request, auth):
 
             success = True
     else:
-        form = PasswordForm()
+        form = PasswordForm(user=user)
 
     hlibname, hashername = settings.PASSWORD_HASHERS[0].rsplit('.',1)
     hlib = importlib.import_module(hlibname)

--- a/ietf/ietfauth/views.py
+++ b/ietf/ietfauth/views.py
@@ -669,7 +669,7 @@ def change_password(request):
     if request.method == 'POST':
         form = ChangePasswordForm(user, request.POST)
         if form.is_valid():
-            new_password = form.cleaned_data["new_password"]
+            new_password = form.cleaned_data["password"]
             
             user.set_password(new_password)
             user.save()


### PR DESCRIPTION
Fixes issues with poor / absent feedback about rejected passwords when passwords are reset, changed, or initially created in a browser with javascript disabled.

It's tempting to go on a deeper dive refactoring the password forms, but I think this is a sensible stopping point. This will need more serious work when we move to an external auth system and/or migrate to Django 5.