### PR TITLE
fix: agenda 'show meeting materials' button theme

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -302,7 +302,7 @@ const meetingEvents = computed(() => {
           icon: 'collection',
           href: undefined,
           click: () => showMaterials(item.id),
-          color: 'black'
+          color: 'darkgray'
         })
         links.push({
           id: `lnk-${item.id}-tar`,
@@ -1155,7 +1155,7 @@ onBeforeUnmount(() => {
       .agenda-table-cell-links-buttons {
         white-space: nowrap;
 
-        > a, > i {
+        > a, > i, > button {
           margin-left: 3px;
           color: #666;
           cursor: pointer;
@@ -1195,6 +1195,18 @@ onBeforeUnmount(() => {
 
             &:hover, &:focus {
               background-color: rgba($orange-500, .3);
+            }
+          }
+          &.text-darkgray {
+            color: $gray-900;
+            background-color: rgba($gray-700, .1);
+
+            @at-root .theme-dark & {
+              color: $gray-100;
+            }
+
+            &:hover, &:focus {
+              background-color: rgba($gray-700, .3);
             }
           }
           &.text-blue {


### PR DESCRIPTION
fixes #9117 

The 'show agenda materials' button wasn't themed correctly. This was because (1) it was a `<button>` not a `<a>` which meant the CSS selectors didn't match, and (2) the current CSS class `text-black` collided with a class already made elsewhere with a `!important` which clobbered the dark mode variation, so I changed the color name to `darkgray` (sic) to avoid the problem.

**screenshots** (light and dark mode)

![Screenshot_2025-07-10_11-12-50](https://github.com/user-attachments/assets/525660b0-6f47-46b9-aef1-51f124f98e99)
![Screenshot_2025-07-10_11-13-37](https://github.com/user-attachments/assets/11d299e8-e57c-4da1-bbfe-3965daffb5f3)
