### PR TITLE
feat: add email/url to purple person API

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -7,7 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from ietf.doc.models import DocumentAuthor, Document, RelatedDocument
+from ietf.doc.models import DocumentAuthor, Document
 from ietf.person.models import Person
 
 
@@ -27,10 +27,9 @@ class PersonSerializer(serializers.ModelSerializer):
     def get_url(self, object: Person):
         return urlreverse(
             "ietf.person.views.profile",
-            kwargs={
-                "email_or_name": object.email_address() or object.name
-            },
+            kwargs={"email_or_name": object.email_address() or object.name},
         )
+
 
 class EmailPersonSerializer(serializers.Serializer):
     email = serializers.EmailField(source="address")

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -12,6 +12,7 @@ from ietf.person.models import Person
 
 
 class PersonSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField(read_only=True)
     picture = serializers.URLField(source="cdn_photo_url", read_only=True)
     url = serializers.SerializerMethodField(
         help_text="relative URL for datatracker person page"
@@ -19,8 +20,8 @@ class PersonSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Person
-        fields = ["id", "plain_name", "picture", "url"]
-        read_only_fields = ["id", "plain_name", "picture"]
+        fields = ["id", "plain_name", "email", "picture", "url"]
+        read_only_fields = ["id", "plain_name", "email", "picture", "url"]
 
     @extend_schema_field(OpenApiTypes.URI)
     def get_url(self, object: Person):


### PR DESCRIPTION
Includes the primary email and a URL for the person's profile. Builds a profile URL using email if possible, but if called for a Person who somehow has no email address, uses name. That may return a page listing more than one person if the name is not unique, but it's the best we can do.

(I guess we could refuse to give a URL, but I think this approach will make it clearer that the name is not unique)