### PR TITLE
chore(dev): use redis for dev sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,12 @@ services:
             - .:/workspace
             - app-assets:/assets
 
+    redis:
+        image: redis:8
+        command: ['redis-server', '--save', '10', '1', '--loglevel', 'warning']
+        volumes:
+            - redis:/data
+
     replicator:
         build:
             context: .
@@ -150,3 +156,4 @@ volumes:
     app-assets:
     minio-data:
     blobdb-data:
+    redis:

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1410,7 +1410,8 @@ if "CACHES" not in locals():
                 "KEY_PREFIX": "ietf:dt",
             },
             "sessions": {
-                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "BACKEND": "django.core.cache.backends.redis.RedisCache",
+                "LOCATION": "redis://redis:6379",
             },
             "htmlized": {
                 "BACKEND": "django.core.cache.backends.dummy.DummyCache",
@@ -1456,7 +1457,6 @@ if SERVER_MODE != 'production':
     loaders = TEMPLATES[0]['OPTIONS']['loaders']
     loaders = tuple(l for e in loaders for l in (e[1] if isinstance(e, tuple) and "cached.Loader" in e[0] else (e,)))
     TEMPLATES[0]['OPTIONS']['loaders'] = loaders
-    SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
     if 'SECRET_KEY' not in locals():
         SECRET_KEY = 'PDwXboUq!=hPjnrtG2=ge#N$Dwy+wn@uivrugwpic8mxyPfHka'


### PR DESCRIPTION
Adds a redis container with a persistent volume and uses this for sessions instead of the database. Results in the same general behavior as before - logins should be persistent until the docker compose stack is torn down.