### PR TITLE
feat: Add "IESG" group at top of Groups menu

### DIFF
--- a/ietf/templates/base/menu.html
+++ b/ietf/templates/base/menu.html
@@ -19,7 +19,10 @@
             <span class="fw-bolder">Groups</span>
         </li>
     {% endif %}
-    {% if flavor == 'top' %}<li class="dropdown-header">By area/parent</li>{% endif %}
+    {% if flavor == 'top' %}
+        <li><a class="dropdown-item" href="https://datatracker.ietf.org/group/iesg/about/">IESG</a></li>
+        <li class="dropdown-header">By area/parent</li>
+    {% endif %}
     {% wg_menu flavor %}
     <li class="dropend">
         <a class="dropdown-item dropdown-toggle {% if flavor != 'top' %}text-wrap{% endif %}"

--- a/ietf/templates/base/menu.html
+++ b/ietf/templates/base/menu.html
@@ -19,10 +19,8 @@
             <span class="fw-bolder">Groups</span>
         </li>
     {% endif %}
-    {% if flavor == 'top' %}
-        <li><a class="dropdown-item" href="https://datatracker.ietf.org/group/iesg/about/">IESG</a></li>
-        <li class="dropdown-header">By area/parent</li>
-    {% endif %}
+    <li><a class="dropdown-item" href="{% url "ietf.group.views.group_about" acronym="iesg" %}">IESG</a></li>
+    {% if flavor == 'top' %}<li class="dropdown-header">By area/parent</li>{% endif %}
     {% wg_menu flavor %}
     <li class="dropend">
         <a class="dropdown-item dropdown-toggle {% if flavor != 'top' %}text-wrap{% endif %}"


### PR DESCRIPTION
Creates an IESG group at the top of the Group dropdown menu that points at https://datatracker.ietf.org/group/iesg/about/. Maybe that value shouldn't be hardcoded into menu.html. (Holler if that's the case.) This feature is in response to issue #9018.