### PR TITLE
fix: In dark mode, IESG dashboard has unreadable numbers

### DIFF
--- a/ietf/templates/doc/ad_list.html
+++ b/ietf/templates/doc/ad_list.html
@@ -8,15 +8,19 @@
 {% endblock %}
 {% block morecss %}
     table .border-bottom { border-bottom-color: var(--highcharts-neutral-color-80) !important; }
-    .highcharts-container .highcharts-axis-labels { font-size: .7rem; }
+    .highcharts-container .highcharts-axis-labels { 
+        font-size: .7rem; 
+        fill: var(--bs-body-color)
+    }
     .highcharts-container .highcharts-graph { stroke-width: 2.5; }
     .highcharts-container .highcharts-color-0 {
-        fill: var(--bs-primary);
+        fill: var(--bs-body-color);
         stroke: var(--bs-primary);
     }
     .highcharts-container .highcharts-data-label text {
         font-size: 1rem;
         font-weight: inherit;
+        fill: var(--bs-body-color)
     }
 {% endblock %}
 {% block title %}IESG Dashboard{% endblock %}


### PR DESCRIPTION
Addressing #9147 by re-using bootstrap --bs-body-color for labels & co in highCharts.css