### PR TITLE
feat: On the doc page display id-nits3 for the IESG (for testing)

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -658,6 +658,7 @@ DRF_STANDARDIZED_ERRORS = {
 IDTRACKER_BASE_URL = "https://datatracker.ietf.org"
 RFCDIFF_BASE_URL = "https://author-tools.ietf.org/iddiff"
 IDNITS_BASE_URL = "https://author-tools.ietf.org/api/idnits"
+IDNITS3_BASE_URL = "https://author-tools.ietf.org/idnits3/results"
 IDNITS_SERVICE_URL = "https://author-tools.ietf.org/idnits"
 
 # Content security policy configuration (django-csp)

--- a/ietf/templates/doc/document_draft.html
+++ b/ietf/templates/doc/document_draft.html
@@ -661,6 +661,17 @@
                 </i>
                 Nits
             </a>
+            {% if user|has_role:"Area Director" %}
+            {# IDNITS3 is an experimental service, so only show it to Area Directors #}
+             <a class="btn btn-primary btn-sm"
+               href="{{ settings.IDNITS3_BASE_URL }}?url=https://www.ietf.org/archive/id/{{ doc.filename_with_rev }}"
+               rel="nofollow"
+               target="_blank">
+                <i class="bi bi-exclamation-diamond">
+                </i>
+                Nits-v3 (Experimental)
+            </a>           
+            {% endif %}
             <a class="btn btn-primary btn-sm"
                href="https://mailarchive.ietf.org/arch/search/?q=%22{{ doc.name }}%22"
                rel="nofollow"


### PR DESCRIPTION
Addressing #9167 

Add a idnits-v3 button displayed only to IESG members (test phase only, to be removed once idnits-v3 is stable and in production)