### PR TITLE
feat: Add calendar buttons for future group meetings

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -58,6 +58,7 @@ from django.urls import reverse as urlreverse
 from django.utils import timezone
 from django.utils.html import escape
 from django.views.decorators.cache import cache_page, cache_control
+from django.urls import reverse
 
 import debug                            # pyflakes:ignore
 
@@ -898,6 +899,18 @@ def meetings(request, acronym, group_type=None):
                 far_past.append(s)
         past = recent_past
 
+    # Add calendar actions
+    cal_actions = []
+
+    cal_actions.append(dict(
+        label='Download as .ics',
+        url=reverse('ietf.meeting.views.upcoming_ical')+"?show="+group.acronym)
+    )
+    cal_actions.append(dict(
+        label='Subscribe with webcal',
+        url='webcal://'+request.get_host()+reverse('ietf.meeting.views.upcoming_ical')+"?show="+group.acronym)
+    )
+
     return render(
         request,
         "group/meetings.html",
@@ -915,6 +928,7 @@ def meetings(request, acronym, group_type=None):
                 "far_past": far_past,
                 "can_edit": can_edit,
                 "can_always_edit": can_always_edit,
+                "cal_actions": cal_actions,
             },
         ),
     )

--- a/ietf/templates/group/meetings.html
+++ b/ietf/templates/group/meetings.html
@@ -40,12 +40,12 @@
     {% if future %}
         <h2 class="mt-5" id="futuremeets">
             Future Meetings
-            <a class="ms-2"
-               aria-label="icalendar entry for all scheduled future {{ group.acronym }} meetings"
-               title="icalendar entry for all scheduled future {{ group.acronym }} meetings"
-               href="{% url 'ietf.meeting.views.upcoming_ical' %}?show={{ group.acronym }}">
-                <i class="bi bi-calendar"></i>
-            </a>
+            {% for cal_action in cal_actions %}
+                <a class="btn btn-primary"
+                   href="{{ cal_action.url }}">
+                    {{ cal_action.label }}
+                </a>
+            {% endfor %}
         </h2>
         <table class="table table-sm table-striped tablesorter">
             <thead>


### PR DESCRIPTION
The buttons appear when there are future meetings for a group, on https://datatracker.ietf.org/wg/GROUPNAME/meetings/. The buttons are basically the same two calendar buttons that are on https://datatracker.ietf.org/meeting/upcoming?show=GROUPNAME .This change addresses issue #7524. (Separately, the description of #7526 might need to be updated to refer to the new buttons.)