### PR TITLE
fix: AD dashboard shows undead documents returned to the WG

### DIFF
--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -644,7 +644,7 @@ def docs_for_ad(request, name):
         raise Http404
 
     results, meta = prepare_document_table(
-        request, Document.objects.filter(ad=ad), max_results=500, show_ad_and_shepherd=False
+        request, Document.objects.filter(ad=ad), max_results=500 # EVY show_ad_and_shepherd=False
     )
     results.sort(key=lambda d: sort_key(d))
 
@@ -665,6 +665,7 @@ def docs_for_ad(request, name):
                 r.get_state_slug("draft-iesg") == "dead"
                 or r.get_state_slug("draft") == "repl"
                 or r.get_state_slug("draft") == "rfc"
+                or (r.get_state_slug("draft") == "expired" and r.get_state_slug("draft-iesg") == "idexists")
             )
         )
     ]

--- a/ietf/doc/views_search.py
+++ b/ietf/doc/views_search.py
@@ -644,7 +644,7 @@ def docs_for_ad(request, name):
         raise Http404
 
     results, meta = prepare_document_table(
-        request, Document.objects.filter(ad=ad), max_results=500 # EVY show_ad_and_shepherd=False
+        request, Document.objects.filter(ad=ad), max_results=500, show_ad_and_shepherd=False
     )
     results.sort(key=lambda d: sort_key(d))
 


### PR DESCRIPTION
Addresses (?) #8427 

Do not display expired I-D while in IESG state of 'idexists', normally I-Ds never expire when in "publication requested" or "IESG evaluation" states.

So, there is no need to display I-Ds:
1) were declared "IESG dead" and moved back to the WG while keeping the AD value[1]
2) later expired and WG state moved back 'expired' and IESG state to 'idexists'

[1] the AD value for a document is what makes a document appears on the "Document for AD" page. I.e., the AD value could also be set to undefined when expiring an IESG-dead I-D.