### PR TITLE
fix: Include text to set/update photo

### DIFF
--- a/ietf/templates/registration/edit_profile.html
+++ b/ietf/templates/registration/edit_profile.html
@@ -41,7 +41,7 @@
                     {% include "person/photo.html" with person=person %}
                     {% endif %}
                     <p>Email <a href="support@ietf.org">support@ietf.org</a>
-                    to udpate your picture.</a></div>
+                    to udpate your picture.</p></a></div>
             </div>
         <div class="row mb-3">
             <label class="col-sm-2 col-form-label fw-bold">NomCom eligible</label>

--- a/ietf/templates/registration/edit_profile.html
+++ b/ietf/templates/registration/edit_profile.html
@@ -40,8 +40,10 @@
                     {% if person.photo %}
                     {% include "person/photo.html" with person=person %}
                     {% endif %}
+                    {% if person.role_set.exists %}
                     <p>Email <a href="support@ietf.org">support@ietf.org</a>
-                    to udpate your picture.</p></div>
+                    to update your photo.</p></div>
+                    {% endif %}
             </div>
         <div class="row mb-3">
             <label class="col-sm-2 col-form-label fw-bold">NomCom eligible</label>

--- a/ietf/templates/registration/edit_profile.html
+++ b/ietf/templates/registration/edit_profile.html
@@ -32,14 +32,17 @@
                 <a class="btn btn-primary" href="{% url 'ietf.ietfauth.views.change_password' %}">Change password</a>
             </div>
         </div>
-        {% if person.photo %}
             <div class="row mb-3">
                 <label class="col-sm-2 col-form-label fw-bold">
                     Photo
                 </label>
-                <div class="col-sm-10">{% include "person/photo.html" with person=person %}</div>
+                <div class="col-sm-10">
+                    {% if person.photo %}
+                    {% include "person/photo.html" with person=person %}
+                    {% endif %}
+                    <p>Email <a href="support@ietf.org">support@ietf.org</a>
+                    to udpate your picture.</a></div>
             </div>
-        {% endif %}
         <div class="row mb-3">
             <label class="col-sm-2 col-form-label fw-bold">NomCom eligible</label>
             <div class="col-sm-10">

--- a/ietf/templates/registration/edit_profile.html
+++ b/ietf/templates/registration/edit_profile.html
@@ -32,6 +32,7 @@
                 <a class="btn btn-primary" href="{% url 'ietf.ietfauth.views.change_password' %}">Change password</a>
             </div>
         </div>
+        {% if person.photo or person.role_set.exists %}
             <div class="row mb-3">
                 <label class="col-sm-2 col-form-label fw-bold">
                     Photo
@@ -45,6 +46,7 @@
                     to update your photo.</p></div>
                     {% endif %}
             </div>
+        {% endif %}
         <div class="row mb-3">
             <label class="col-sm-2 col-form-label fw-bold">NomCom eligible</label>
             <div class="col-sm-10">

--- a/ietf/templates/registration/edit_profile.html
+++ b/ietf/templates/registration/edit_profile.html
@@ -41,7 +41,7 @@
                     {% include "person/photo.html" with person=person %}
                     {% endif %}
                     <p>Email <a href="support@ietf.org">support@ietf.org</a>
-                    to udpate your picture.</p></a></div>
+                    to udpate your picture.</p></div>
             </div>
         <div class="row mb-3">
             <label class="col-sm-2 col-form-label fw-bold">NomCom eligible</label>


### PR DESCRIPTION
This could be the only fix that #2209 (created 2017) is going to get, but I didn't mark it as fixes it.

This PR adds "Email support@ietf.org to update your picture", whether or not there is a photo available.