### PR TITLE
feat: Sort IESG and IAB Statements Pages with Active Statements at the Top

### DIFF
--- a/ietf/group/views.py
+++ b/ietf/group/views.py
@@ -2187,7 +2187,7 @@ def statements(request, acronym, group_type=None):
                 ).values_list("state__slug", flat=True)[:1]
             )
         )
-        .order_by("-published")
+        .order_by("status", "-published")
     )
     return render(
         request,

--- a/ietf/templates/group/statements.html
+++ b/ietf/templates/group/statements.html
@@ -1,51 +1,51 @@
-    {% extends "group/group_base.html" %}
-    {# Copyright The IETF Trust 2023, All Rights Reserved #}
-    {% load origin %}
-    {% load ietf_filters person_filters textfilters %}
-    {% load static %}
-    {% block pagehead %}
-        <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
-    {% endblock %}
-    {% block group_content %}
-        {% origin %}
-        <h2 class="my-3">{{group.acronym|upper}} Statements</h2>
-        {% if request.user|has_role:"Secretariat" %}
-        <div class="buttonlist">
-            <a id="start_button"
-            class="btn btn-primary"
-            href="{% url 'ietf.doc.views_statement.new_statement' %}">
-                Start New Statement
-            </a>
-        </div>
-        {% endif %}
-        <table class="my-3 table table-sm table-striped tablesorter">
-            <thead>
-                <tr>
-                    <th class="col-1" scope="col" data-sort="date">Date</th>
-                    <th scope="col" data-sort="statement">Statement</th>
-                </tr>
-            </thead>
-    {% regroup statements by status as grouped_statements %}
-    {% for statement_group in grouped_statements %}
-            <tbody>
-                <tr class="table-info">
-                    <th scope="col" colspan="2">
-                    {{ statement_group.grouper|title }} {{"Statement"|plural:statement_group.list }} ({{ statement_group.list|length }} {{"hit"|plural:statement_group.list }})
-                    </th>
-                </tr>
-            </tbody>
-            <tbody>
-            {% for statement in statement_group.list %}
-                <tr>
-                    <td title="{{ statement.published|date:'Y-m-d H:i:s O' }}">{{ statement.published|date:"Y-m-d" }}</td>
-                    <td><a href="{#% url 'ietf.doc.views_doc.document_main' name=statement.name %#}">{{statement.title}}</a>
-                    </td>
-                </tr>
-            {% endfor %}   
-            </tbody>
-    {% endfor %}
-        </table>
-    {% endblock %}
-    {% block js %}
-        <script src="{% static "ietf/js/list.js" %}"></script>
-    {% endblock %}
+{% extends "group/group_base.html" %}
+{# Copyright The IETF Trust 2023, All Rights Reserved #}
+{% load origin %}
+{% load ietf_filters person_filters textfilters %}
+{% load static %}
+{% block pagehead %}
+    <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
+{% endblock %}
+{% block group_content %}
+    {% origin %}
+    <h2 class="my-3">{{group.acronym|upper}} Statements</h2>
+    {% if request.user|has_role:"Secretariat" %}
+    <div class="buttonlist">
+        <a id="start_button"
+        class="btn btn-primary"
+        href="{% url 'ietf.doc.views_statement.new_statement' %}">
+            Start New Statement
+        </a>
+    </div>
+    {% endif %}
+    <table class="my-3 table table-sm table-striped tablesorter">
+        <thead>
+            <tr>
+                <th class="col-1" scope="col" data-sort="date">Date</th>
+                <th scope="col" data-sort="statement">Statement</th>
+            </tr>
+        </thead>
+{% regroup statements by status as grouped_statements %}
+{% for statement_group in grouped_statements %}
+        <tbody>
+            <tr class="table-info">
+                <th scope="col" colspan="2">
+                {{ statement_group.grouper|title }} {{"Statement"|plural:statement_group.list }} ({{ statement_group.list|length }} {{"hit"|plural:statement_group.list }})
+                </th>
+            </tr>
+        </tbody>
+        <tbody>
+        {% for statement in statement_group.list %}
+            <tr>
+                <td title="{{ statement.published|date:'Y-m-d H:i:s O' }}">{{ statement.published|date:"Y-m-d" }}</td>
+                <td><a href="{#% url 'ietf.doc.views_doc.document_main' name=statement.name %#}">{{statement.title}}</a>
+                </td>
+            </tr>
+        {% endfor %}   
+        </tbody>
+{% endfor %}
+    </table>
+{% endblock %}
+{% block js %}
+    <script src="{% static "ietf/js/list.js" %}"></script>
+{% endblock %}

--- a/ietf/templates/group/statements.html
+++ b/ietf/templates/group/statements.html
@@ -1,42 +1,51 @@
-{% extends "group/group_base.html" %}
-{# Copyright The IETF Trust 2023, All Rights Reserved #}
-{% load origin %}
-{% load ietf_filters person_filters textfilters %}
-{% load static %}
-{% block pagehead %}
-    <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
-{% endblock %}
-{% block group_content %}
-    {% origin %}
-    <h2 class="my-3">{{group.acronym|upper}} Statements</h2>
-    {% if request.user|has_role:"Secretariat" %}
-    <div class="buttonlist">
-        <a id="start_button"
-           class="btn btn-primary"
-           href="{% url 'ietf.doc.views_statement.new_statement' %}">
-            Start New Statement
-        </a>
-    </div>
-    {% endif %}
-    <table class="my-3 table table-sm table-striped tablesorter">
-        <thead>
-            <tr>
-                <th class="col-1" scope="col" data-sort="date">Date</th>
-                <th scope="col" data-sort="statement">Statement</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for statement in statements %}
-            <tr>
-                <td title="{{ statement.published|date:'Y-m-d H:i:s O' }}">{{ statement.published|date:"Y-m-d" }}</td>
-                <td><a href="{% url 'ietf.doc.views_doc.document_main' name=statement.name %}">{{statement.title}}</a>
-                    {% if statement.status == "replaced" %}<span class="badge rounded-pill text-bg-warning">Replaced</span>{% endif %}
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-{% endblock %}
-{% block js %}
-    <script src="{% static "ietf/js/list.js" %}"></script>
-{% endblock %}
+    {% extends "group/group_base.html" %}
+    {# Copyright The IETF Trust 2023, All Rights Reserved #}
+    {% load origin %}
+    {% load ietf_filters person_filters textfilters %}
+    {% load static %}
+    {% block pagehead %}
+        <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
+    {% endblock %}
+    {% block group_content %}
+        {% origin %}
+        <h2 class="my-3">{{group.acronym|upper}} Statements</h2>
+        {% if request.user|has_role:"Secretariat" %}
+        <div class="buttonlist">
+            <a id="start_button"
+            class="btn btn-primary"
+            href="{% url 'ietf.doc.views_statement.new_statement' %}">
+                Start New Statement
+            </a>
+        </div>
+        {% endif %}
+        <table class="my-3 table table-sm table-striped tablesorter">
+            <thead>
+                <tr>
+                    <th class="col-1" scope="col" data-sort="date">Date</th>
+                    <th scope="col" data-sort="statement">Statement</th>
+                </tr>
+            </thead>
+    {% regroup statements by status as grouped_statements %}
+    {% for statement_group in grouped_statements %}
+            <tbody>
+                <tr class="table-info">
+                    <th scope="col" colspan="2">
+                    {{ statement_group.grouper|title }} {{"Statement"|plural:statement_group.list }} ({{ statement_group.list|length }} {{"hit"|plural:statement_group.list }})
+                    </th>
+                </tr>
+            </tbody>
+            <tbody>
+            {% for statement in statement_group.list %}
+                <tr>
+                    <td title="{{ statement.published|date:'Y-m-d H:i:s O' }}">{{ statement.published|date:"Y-m-d" }}</td>
+                    <td><a href="{#% url 'ietf.doc.views_doc.document_main' name=statement.name %#}">{{statement.title}}</a>
+                    </td>
+                </tr>
+            {% endfor %}   
+            </tbody>
+    {% endfor %}
+        </table>
+    {% endblock %}
+    {% block js %}
+        <script src="{% static "ietf/js/list.js" %}"></script>
+    {% endblock %}

--- a/ietf/templates/group/statements.html
+++ b/ietf/templates/group/statements.html
@@ -38,7 +38,7 @@
         {% for statement in statement_group.list %}
             <tr>
                 <td title="{{ statement.published|date:'Y-m-d H:i:s O' }}">{{ statement.published|date:"Y-m-d" }}</td>
-                <td><a href="{#% url 'ietf.doc.views_doc.document_main' name=statement.name %#}">{{statement.title}}</a>
+                <td><a href="{% url 'ietf.doc.views_doc.document_main' name=statement.name %}">{{statement.title}}</a>
                 </td>
             </tr>
         {% endfor %}   


### PR DESCRIPTION
Address issue #9058 

Remaining caveat: it is sorted by statement.state but currently only "active" and "replaced" whose alphabetical order matches the requested feature. If other states are introduced (e.g., "historic"), then the order wont't be so perfect.