### PR TITLE
fix: prevent navigation on doc search header sort click

### DIFF
--- a/ietf/static/js/list.js
+++ b/ietf/static/js/list.js
@@ -247,7 +247,8 @@ $(document)
 
                 $(table)
                     .find(".sort")
-                    .on("click", function () {
+                    .on("click", function (ev) {
+                        ev.preventDefault()
                         var order = $(this)
                             .hasClass("asc") ? "desc" : "asc";
                         $.each(list_instance, (_, e) => {


### PR DESCRIPTION
Fix #9136