### PR TITLE
feat: improve template coverage cfg

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -716,12 +716,13 @@ TEST_CODE_COVERAGE_EXCLUDE_LINES = [
 ]
 
 # These are filename globs.  They are used by test_parse_templates() and
-# get_template_paths()
+# get_template_paths(). Globs are applied via pathlib.Path().match, using
+# the path to the template from settings.BASE_DIR.
 TEST_TEMPLATE_IGNORE = [
-    ".*",                             # dot-files
-    "*~",                             # tilde temp-files
-    "#*",                             # files beginning with a hashmark
-    "500.html"                        # isn't loaded by regular loader, but checked by test_500_page()
+    ".*",  # dot-files
+    "*~",  # tilde temp-files
+    "#*",  # files beginning with a hashmark
+    "500.html",  # isn't loaded by regular loader, but checked by test_500_page()
 ]
 
 TEST_COVERAGE_MAIN_FILE = os.path.join(BASE_DIR, "../release-coverage.json")

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -31,6 +31,10 @@ warnings.filterwarnings("ignore", message="HTTPResponse.getheader\\(\\) is depre
 base_path = pathlib.Path(__file__).resolve().parent
 BASE_DIR = str(base_path)
 
+project_path = base_path.parent
+PROJECT_DIR = str(project_path)  
+sys.path.append(PROJECT_DIR)
+
 from ietf import __version__
 import debug
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2007-2024, All Rights Reserved
+# Copyright The IETF Trust 2007-2025, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -9,6 +9,7 @@
 import os
 import sys
 import datetime
+import pathlib
 import warnings
 from hashlib import sha384
 from typing import Any, Dict, List, Tuple # pyflakes:ignore
@@ -27,8 +28,8 @@ warnings.filterwarnings("ignore", message="Report.file_reporters will no longer 
 warnings.filterwarnings("ignore", message="Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated", module="bleach")
 warnings.filterwarnings("ignore", message="HTTPResponse.getheader\\(\\) is deprecated", module='selenium.webdriver')
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.abspath(BASE_DIR + "/.."))
+base_path = pathlib.Path(__file__).resolve().parent
+BASE_DIR = str(base_path)
 
 from ietf import __version__
 import debug
@@ -717,7 +718,7 @@ TEST_CODE_COVERAGE_EXCLUDE_LINES = [
 
 # These are filename globs.  They are used by test_parse_templates() and
 # get_template_paths(). Globs are applied via pathlib.Path().match, using
-# the path to the template from settings.BASE_DIR.
+# the path to the template from the project root.
 TEST_TEMPLATE_IGNORE = [
     ".*",  # dot-files
     "*~",  # tilde temp-files

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -414,35 +414,6 @@ def get_url_patterns(module, apps=None):
     return res
 
 
-def old_get_template_paths(apps=None):
-    from fnmatch import fnmatch
-    _all_templates = None
-    if not _all_templates:
-        # TODO: Add app templates to the full list, if we are using
-        # django.template.loaders.app_directories.Loader
-        templates = set()
-        templatepaths = settings.TEMPLATES[0]['DIRS']
-        for templatepath in templatepaths:
-            for dirpath, dirs, files in os.walk(templatepath):
-                if ".svn" in dirs:
-                    dirs.remove(".svn")
-                relative_path = dirpath[len(templatepath)+1:]
-                for file in files:
-                    ignore = False
-                    for pattern in settings.TEST_TEMPLATE_IGNORE:
-                        if fnmatch(file, pattern):
-                            ignore = True
-                            break
-                    if ignore:
-                        continue
-                    if relative_path != "":
-                        file = os.path.join(relative_path, file)
-                    templates.add(file)
-        if apps:
-            templates = [ t for t in templates if t.split(os.path.sep)[0] in apps ]
-        _all_templates = templates
-    return _all_templates
-
 _all_templates = None
 def get_template_paths(apps=None) -> list[str]:
     global _all_templates
@@ -471,6 +442,7 @@ def get_template_paths(apps=None) -> list[str]:
                         templates.add(relative_path / filename)
         _all_templates = [str(t) for t in templates]
     return _all_templates
+
 
 def save_test_results(failures, test_labels):
     # Record the test result in a file, in order to be able to check the

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2009-2020, All Rights Reserved
+# Copyright The IETF Trust 2009-2025, All Rights Reserved
 # -*- coding: utf-8 -*-
 #
 # Portion Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -19,7 +19,6 @@ from email.message import Message
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from fnmatch import fnmatch
 from importlib import import_module
 from textwrap import dedent
 from tempfile import mkdtemp
@@ -320,7 +319,7 @@ class TemplateChecksTestCase(TestCase):
     def setUp(self):
         super().setUp()
         set_coverage_checking(False)
-        self.paths = list(get_template_paths())
+        self.paths = get_template_paths()  # already filtered ignores
         self.paths.sort()
         for path in self.paths:
             try:
@@ -335,11 +334,7 @@ class TemplateChecksTestCase(TestCase):
     def test_parse_templates(self):
         errors = []
         for path in self.paths:
-            for pattern in settings.TEST_TEMPLATE_IGNORE:
-                if fnmatch(path, pattern):
-                    continue
-            if not path in self.templates:
-
+            if path not in self.templates:
                 try:
                     get_template(path)
                 except Exception as e:


### PR DESCRIPTION
Allows full file path exclusions, not just filename-only globs

```
>>> from ietf.utils.test_runner import *
>>> old_templates = old_get_template_paths()  # removed, just for reference
>>> new_templates = set(get_template_paths())
>>> old_templates - new_templates
set()
```