### PR TITLE
refactor: update to coverage 7.9.2 + cleanup

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -55,7 +55,7 @@ from ietf.meeting.views import session_draft_list, parse_agenda_filter_params, s
 from ietf.meeting.views import get_summary_by_area, get_summary_by_type, get_summary_by_purpose, generate_agenda_data
 from ietf.name.models import SessionStatusName, ImportantDateName, RoleName, ProceedingsMaterialTypeName
 from ietf.utils.mail import outbox, empty_outbox, get_payload_text
-from ietf.utils.test_runner import TestBlobstoreManager
+from ietf.utils.test_runner import TestBlobstoreManager, disable_coverage
 from ietf.utils.test_utils import TestCase, login_testing_unauthorized, unicontent
 from ietf.utils.timezone import date_today, time_now
 
@@ -1167,6 +1167,7 @@ class MeetingTests(BaseMeetingTestCase):
                 os.unlink(filename)
 
     @skipIf(skip_pdf_tests, skip_message)
+    @disable_coverage()
     def test_session_draft_pdf(self):  # pragma: no cover
         session, filenames = self.build_session_setup()
         try:

--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -54,7 +54,6 @@ from ietf.meeting.utils import create_recording, delete_recording, get_next_sequ
 from ietf.meeting.views import session_draft_list, parse_agenda_filter_params, sessions_post_save, agenda_extract_schedule
 from ietf.meeting.views import get_summary_by_area, get_summary_by_type, get_summary_by_purpose, generate_agenda_data
 from ietf.name.models import SessionStatusName, ImportantDateName, RoleName, ProceedingsMaterialTypeName
-from ietf.utils.decorators import skip_coverage
 from ietf.utils.mail import outbox, empty_outbox, get_payload_text
 from ietf.utils.test_runner import TestBlobstoreManager
 from ietf.utils.test_utils import TestCase, login_testing_unauthorized, unicontent
@@ -1168,8 +1167,7 @@ class MeetingTests(BaseMeetingTestCase):
                 os.unlink(filename)
 
     @skipIf(skip_pdf_tests, skip_message)
-    @skip_coverage
-    def test_session_draft_pdf(self):
+    def test_session_draft_pdf(self):  # pragma: no cover
         session, filenames = self.build_session_setup()
         try:
             url = urlreverse('ietf.meeting.views.session_draft_pdf', kwargs={'num':session.meeting.number,'acronym':session.group.acronym})

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -711,6 +711,7 @@ TEST_CODE_COVERAGE_EXCLUDE_FILES = [
     "ietf/utils/patch.py",
     "ietf/utils/test_data.py",
     "ietf/utils/jstest.py",
+    "ietf/utils/coverage.py",
 ]
 
 # These are code line regex patterns

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -735,7 +735,10 @@ TEST_TEMPLATE_IGNORE = [
 TEST_COVERAGE_MAIN_FILE = os.path.join(BASE_DIR, "../release-coverage.json")
 TEST_COVERAGE_LATEST_FILE = os.path.join(BASE_DIR, "../latest-coverage.json")
 
-TEST_CODE_COVERAGE_ENABLED = False
+TEST_CODE_COVERAGE_CHECKER = None
+if SERVER_MODE != 'production':
+    from ietf.utils.coverage import CoverageManager
+    TEST_CODE_COVERAGE_CHECKER = CoverageManager()
 
 TEST_CODE_COVERAGE_REPORT_PATH = "coverage/"
 TEST_CODE_COVERAGE_REPORT_URL = os.path.join(STATIC_URL, TEST_CODE_COVERAGE_REPORT_PATH, "index.html")

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -735,16 +735,7 @@ TEST_TEMPLATE_IGNORE = [
 TEST_COVERAGE_MAIN_FILE = os.path.join(BASE_DIR, "../release-coverage.json")
 TEST_COVERAGE_LATEST_FILE = os.path.join(BASE_DIR, "../latest-coverage.json")
 
-TEST_CODE_COVERAGE_CHECKER = None
-# TODO-PY312: figure out how to run coverage
-# Context: the old version of coverage that we use (4.5.4, ca 2019) is falling back from its
-# fast CTracer module to its very slow PyTracer when used on Python 3.12. It's not clear exactly
-# why, but it's almost 3x slower. The situation may be better if we can update to a current
-# version of coverage, but see https://github.com/nedbat/coveragepy/issues/1665 for more info.
-# For now at least, disabling the checker completely.
-# if SERVER_MODE != 'production':
-#     import coverage
-#     TEST_CODE_COVERAGE_CHECKER = coverage.Coverage(source=[ BASE_DIR ], cover_pylib=False, omit=TEST_CODE_COVERAGE_EXCLUDE_FILES)
+TEST_CODE_COVERAGE_ENABLED = False
 
 TEST_CODE_COVERAGE_REPORT_PATH = "coverage/"
 TEST_CODE_COVERAGE_REPORT_URL = os.path.join(STATIC_URL, TEST_CODE_COVERAGE_REPORT_PATH, "index.html")

--- a/ietf/settings_test.py
+++ b/ietf/settings_test.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import tempfile
 from ietf.settings import *                                          # pyflakes:ignore
-from ietf.settings import TEST_CODE_COVERAGE_CHECKER, ORIG_AUTH_PASSWORD_VALIDATORS
+from ietf.settings import ORIG_AUTH_PASSWORD_VALIDATORS
 import debug                            # pyflakes:ignore
 debug.debug = True
 
@@ -52,9 +52,7 @@ DATABASES = {
 BLOBDB_DATABASE = "default"
 DATABASE_ROUTERS = []  # type: ignore
 
-if TEST_CODE_COVERAGE_CHECKER and not TEST_CODE_COVERAGE_CHECKER._started: # pyflakes:ignore
-    TEST_CODE_COVERAGE_CHECKER.start()                          # pyflakes:ignore
-
+TEST_CODE_COVERAGE_ENABLED = True
 
 def tempdir_with_cleanup(**kwargs):
     """Utility to create a temporary dir and arrange cleanup"""

--- a/ietf/settings_test.py
+++ b/ietf/settings_test.py
@@ -52,7 +52,8 @@ DATABASES = {
 BLOBDB_DATABASE = "default"
 DATABASE_ROUTERS = []  # type: ignore
 
-TEST_CODE_COVERAGE_ENABLED = True
+if TEST_CODE_COVERAGE_CHECKER: # pyflakes:ignore
+    TEST_CODE_COVERAGE_CHECKER.start()                          # pyflakes:ignore
 
 def tempdir_with_cleanup(**kwargs):
     """Utility to create a temporary dir and arrange cleanup"""

--- a/ietf/utils/coverage.py
+++ b/ietf/utils/coverage.py
@@ -46,7 +46,7 @@ class CoverageManager:
             return reporter.report(self.checker)
 
 
-class CustomDictReporter:
+class CustomDictReporter:  # pragma: no cover
     total = Numbers()
 
     def report(self, coverage):

--- a/ietf/utils/coverage.py
+++ b/ietf/utils/coverage.py
@@ -38,7 +38,7 @@ class CoverageManager:
     def report(self, include: list[str] | None = None):
         if self.checker is None:
             return None
-        reporter = CustomJsonReporter()
+        reporter = CustomDictReporter()
         with override_coverage_config(
             self.checker,
             report_include=include,
@@ -46,7 +46,7 @@ class CoverageManager:
             return reporter.report(self.checker)
 
 
-class CustomJsonReporter:
+class CustomDictReporter:
     total = Numbers()
 
     def report(self, coverage):

--- a/ietf/utils/coverage.py
+++ b/ietf/utils/coverage.py
@@ -1,0 +1,90 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+from coverage import Coverage, CoverageData, FileReporter
+from coverage.control import override_config as override_coverage_config
+from coverage.results import Numbers
+from coverage.report_core import get_analysis_to_report
+from coverage.results import Analysis
+from django.conf import settings
+
+
+class CoverageManager:
+    checker: Coverage | None = None
+    started = False
+
+    def start(self):
+        if settings.SERVER_MODE != "production" and not self.started:
+            self.checker = Coverage(
+                source=[settings.BASE_DIR],
+                cover_pylib=False,
+                omit=settings.TEST_CODE_COVERAGE_EXCLUDE_FILES,
+            )
+            for exclude_regex in getattr(
+                settings,
+                "TEST_CODE_COVERAGE_EXCLUDE_LINES",
+                [],
+            ):
+                self.checker.exclude(exclude_regex)
+            self.checker.start()
+            self.started = True
+
+    def stop(self):
+        if self.checker is not None:
+            self.checker.stop()
+
+    def save(self):
+        if self.checker is not None:
+            self.checker.save()
+
+    def report(self, include: list[str] | None = None):
+        if self.checker is None:
+            return None
+        reporter = CustomJsonReporter()
+        with override_coverage_config(
+            self.checker,
+            report_include=include,
+        ):
+            return reporter.report(self.checker)
+
+
+class CustomJsonReporter:
+    total = Numbers()
+
+    def report(self, coverage):
+        coverage_data = coverage.get_data()
+        coverage_data.set_query_contexts(None)
+        measured_files = {}
+        for file_reporter, analysis in get_analysis_to_report(coverage, None):
+            measured_files[file_reporter.relative_filename()] = self.report_one_file(
+                coverage_data,
+                analysis,
+                file_reporter,
+            )
+        tot_numer, tot_denom = self.total.ratio_covered
+        return {
+            "coverage": 1 if tot_denom == 0 else tot_numer / tot_denom,
+            "covered": measured_files,
+            "format": 5,
+        }
+
+    def report_one_file(
+        self,
+        coverage_data: CoverageData,
+        analysis: Analysis,
+        file_reporter: FileReporter,
+    ):
+        """Extract the relevant report data for a single file."""
+        nums = analysis.numbers
+        self.total += nums
+        n_statements = nums.n_statements
+        numer, denom = nums.ratio_covered
+        fraction_covered = 1 if denom == 0 else numer / denom
+        missing_line_nums = sorted(analysis.missing)
+        # Extract missing lines from source files
+        source_lines = file_reporter.source().splitlines()
+        missing_lines = [source_lines[num - 1] for num in missing_line_nums]
+        return (
+            n_statements,
+            fraction_covered,
+            missing_line_nums,
+            missing_lines,
+        )

--- a/ietf/utils/decorators.py
+++ b/ietf/utils/decorators.py
@@ -19,17 +19,6 @@ from ietf.utils.test_runner import set_coverage_checking
 from ietf.person.models import Person, PersonalApiKey, PersonApiKeyEvent
 from ietf.utils import log
 
-def skip_coverage(f):
-    @wraps(f)
-    def _wrapper(*args, **kwargs):
-        if settings.TEST_CODE_COVERAGE_CHECKER:
-            set_coverage_checking(False)
-            result = f(*args, **kwargs)
-            set_coverage_checking(True)
-            return result
-        else:
-            return  f(*args, **kwargs)
-    return _wrapper
 
 def person_required(f):
     @wraps(f)

--- a/ietf/utils/decorators.py
+++ b/ietf/utils/decorators.py
@@ -15,7 +15,6 @@ from django.utils.encoding import force_bytes
 
 import debug                            # pyflakes:ignore
 
-from ietf.utils.test_runner import set_coverage_checking
 from ietf.person.models import Person, PersonalApiKey, PersonApiKeyEvent
 from ietf.utils import log
 

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -1217,37 +1217,6 @@ class IetfTestRunner(DiscoverRunner):
 
         return failures
 
-class IetfLiveServerTestCase(StaticLiveServerTestCase):
-    @classmethod
-    def setUpClass(cls):
-        set_coverage_checking(False)
-        super(IetfLiveServerTestCase, cls).setUpClass()
-
-    def setUp(self):
-        super(IetfLiveServerTestCase, self).setUp()
-        # LiveServerTestCase uses TransactionTestCase which seems to
-        # somehow interfere with the fixture loading process in
-        # IetfTestRunner when running multiple tests (the first test
-        # is fine, in the next ones the fixtures have been wiped) -
-        # this is no doubt solvable somehow, but until then we simply
-        # recreate them here
-        from ietf.person.models import Person
-        if not Person.objects.exists():
-            load_and_run_fixtures(verbosity=0)
-        self.replaced_settings = dict()
-        if hasattr(settings, 'IDTRACKER_BASE_URL'):
-            self.replaced_settings['IDTRACKER_BASE_URL'] = settings.IDTRACKER_BASE_URL
-            settings.IDTRACKER_BASE_URL = self.live_server_url
-
-    @classmethod
-    def tearDownClass(cls):
-        super(IetfLiveServerTestCase, cls).tearDownClass()
-        set_coverage_checking(True)
-
-    def tearDown(self):
-        for k, v in self.replaced_settings.items():
-            setattr(settings, k, v)
-        super().tearDown()
 
 class TestBlobstoreManager():
     # N.B. buckets and blobstore are intentional Class-level attributes

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -797,10 +797,6 @@ class IetfTestRunner(DiscoverRunner):
                     "covered": {},
                     "format": 1,
                 },
-                "migration": {
-                    "present": {},
-                    "format": 3,
-                }
             }
 
             settings.TEMPLATES[0]['OPTIONS']['loaders'] = ('ietf.utils.test_runner.TemplateCoverageLoader',) + settings.TEMPLATES[0]['OPTIONS']['loaders']

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -48,6 +48,8 @@ import pathlib
 import subprocess
 import tempfile
 import copy
+from contextlib import contextmanager
+
 import boto3
 import botocore.config
 import factory.random
@@ -471,9 +473,6 @@ def set_url_coverage(flag):
     url_coverage_collection = flag
     return orig
 
-class CoverageReporter(Reporter):
-    def report(self):
-        self.find_file_reporters(None)
 
         total = Numbers()
         result = {"coverage": 0.0, "covered": {}, "format": 5, }
@@ -499,6 +498,14 @@ class CoverageReporter(Reporter):
                     raise
         result["coverage"] = total.pc_covered/100.0
         return result
+@contextmanager
+def disable_coverage():
+    """Context manager/decorator that disables template/url coverage"""
+    orig_template = set_template_coverage(False)
+    orig_url = set_url_coverage(False)
+    yield
+    set_template_coverage(orig_template)
+    set_url_coverage(orig_url)
 
 
 class CoverageTest(unittest.TestCase):

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -97,8 +97,8 @@ test_database_name: Optional[str] = None
 old_destroy: Optional[Callable] = None
 old_create: Optional[Callable] = None
 
-template_coverage_collection = None
-url_coverage_collection = None
+template_coverage_collection = False
+url_coverage_collection = False
 validation_settings = {"validate_html": None, "validate_html_harder": None, "show_logging": False}
 
 def start_vnu_server(port=8888):
@@ -457,18 +457,19 @@ def save_test_results(failures, test_labels):
             tfile.write("%s OK\n" % (timestr, ))
     tfile.close()
 
-def set_coverage_checking(flag=True):
+
+def set_template_coverage(flag):
     global template_coverage_collection
+    orig = template_coverage_collection
+    template_coverage_collection = flag
+    return orig
+
+
+def set_url_coverage(flag):
     global url_coverage_collection
-    if settings.SERVER_MODE == 'test' and settings.TEST_CODE_COVERAGE_CHECKER is not None:
-        if flag:
-            settings.TEST_CODE_COVERAGE_CHECKER.collector.resume()
-            template_coverage_collection = True
-            url_coverage_collection = True
-        else:
-            settings.TEST_CODE_COVERAGE_CHECKER.collector.pause()
-            template_coverage_collection = False
-            url_coverage_collection = False
+    orig = url_coverage_collection
+    url_coverage_collection = flag
+    return orig
 
 class CoverageReporter(Reporter):
     def report(self):

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -98,7 +98,6 @@ old_destroy: Optional[Callable] = None
 old_create: Optional[Callable] = None
 
 template_coverage_collection = None
-code_coverage_collection = None
 url_coverage_collection = None
 validation_settings = {"validate_html": None, "validate_html_harder": None, "show_logging": False}
 
@@ -460,18 +459,15 @@ def save_test_results(failures, test_labels):
 
 def set_coverage_checking(flag=True):
     global template_coverage_collection
-    global code_coverage_collection
     global url_coverage_collection
     if settings.SERVER_MODE == 'test' and settings.TEST_CODE_COVERAGE_CHECKER is not None:
         if flag:
             settings.TEST_CODE_COVERAGE_CHECKER.collector.resume()
             template_coverage_collection = True
-            code_coverage_collection = True
             url_coverage_collection = True
         else:
             settings.TEST_CODE_COVERAGE_CHECKER.collector.pause()
             template_coverage_collection = False
-            code_coverage_collection = False
             url_coverage_collection = False
 
 class CoverageReporter(Reporter):
@@ -1135,9 +1131,8 @@ class IetfTestRunner(DiscoverRunner):
                 ),
             ]
         if self.check_coverage:
-            global template_coverage_collection, code_coverage_collection, url_coverage_collection
+            global template_coverage_collection, url_coverage_collection
             template_coverage_collection = True
-            code_coverage_collection = True
             url_coverage_collection = True
             tests += [
                 PyFlakesTestCase(test_runner=self, methodName='pyflakes_test'),

--- a/ietf/utils/tests.py
+++ b/ietf/utils/tests.py
@@ -55,7 +55,11 @@ from ietf.utils.mail import (
     decode_header_value,
     show_that_mail_was_sent,
 )
-from ietf.utils.test_runner import get_template_paths, set_coverage_checking
+from ietf.utils.test_runner import (
+    get_template_paths,
+    set_template_coverage,
+    set_url_coverage,
+)
 from ietf.utils.test_utils import TestCase, unicontent
 from ietf.utils.text import parse_unicode
 from ietf.utils.timezone import timezone_not_near_midnight
@@ -312,14 +316,15 @@ def get_callbacks(urllist, namespace=None):
 
     return list(callbacks)
 
-class TemplateChecksTestCase(TestCase):
+class TemplateChecksTestCase(TestCase):  # pragma: no cover
 
     paths = []                          # type: List[str]
     templates = {}                      # type: Dict[str, Template]
 
     def setUp(self):
         super().setUp()
-        set_coverage_checking(False)
+        set_template_coverage(False)
+        set_url_coverage(False)
         self.paths = list(get_template_paths())
         self.paths.sort()
         for path in self.paths:
@@ -329,7 +334,8 @@ class TemplateChecksTestCase(TestCase):
                 pass
 
     def tearDown(self):
-        set_coverage_checking(True)
+        set_template_coverage(True)
+        set_url_coverage(True)
         super().tearDown()
 
     def test_parse_templates(self):

--- a/ietf/utils/tests_coverage.py
+++ b/ietf/utils/tests_coverage.py
@@ -1,0 +1,56 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+"""Tests of the coverage.py module"""
+
+from unittest import mock
+
+from django.test import override_settings
+
+from .coverage import CoverageManager
+from .test_utils import TestCase
+
+
+class CoverageManagerTests(TestCase):
+    @override_settings(
+        BASE_DIR="/path/to/project/ietf",
+        TEST_CODE_COVERAGE_EXCLUDE_FILES=["a.py"],
+        TEST_CODE_COVERAGE_EXCLUDE_LINES=["some-regex"],
+    )
+    @mock.patch("ietf.utils.coverage.Coverage")
+    def test_coverage_manager(self, mock_coverage):
+        """CoverageManager managed coverage correctly in non-production mode
+
+        Presumes we're not running tests in production mode.
+        """
+        cm = CoverageManager()
+        self.assertFalse(cm.started)
+
+        cm.start()
+        self.assertTrue(cm.started)
+        self.assertEqual(cm.checker, mock_coverage.return_value)
+        self.assertTrue(mock_coverage.called)
+        coverage_kwargs = mock_coverage.call_args.kwargs
+        self.assertEqual(coverage_kwargs["source"], ["/path/to/project/ietf"])
+        self.assertEqual(coverage_kwargs["omit"], ["a.py"])
+        self.assertTrue(isinstance(cm.checker.exclude, mock.Mock))
+        assert isinstance(cm.checker.exclude, mock.Mock)  # for type checker
+        self.assertEqual(cm.checker.exclude.call_count, 1)
+        cm.checker.exclude.assert_called_with("some-regex")
+
+    @mock.patch("ietf.utils.coverage.Coverage")
+    def test_coverage_manager_is_defanged_in_production(self, mock_coverage):
+        """CoverageManager is a no-op in production mode"""
+        # Be careful faking settings.SERVER_MODE, but there's really no other way to
+        # test this.
+        with override_settings(SERVER_MODE="production"):
+            cm = CoverageManager()
+            cm.start()
+
+        # Check that nothing actually happened
+        self.assertFalse(mock_coverage.called)
+        self.assertIsNone(cm.checker)
+        self.assertFalse(cm.started)
+
+        # Check that other methods are guarded appropriately
+        cm.stop()
+        cm.save()
+        self.assertIsNone(cm.report())

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ boto3>=1.35,<1.36
 boto3-stubs[s3]>=1.35,<1.36
 botocore>=1.35,<1.36
 celery>=5.2.6
-coverage>=4.5.4,<5.0    # Coverage 5.x moves from a json database to SQLite.  Moving to 5.x will require substantial rewrites in ietf.utils.test_runner and ietf.release.views
+coverage>=7.9.2
 defusedxml>=0.7.1    # for TastyPie when using xml; not a declared dependency
 Django>4.2,<5
 django-admin-rangefilter>=0.13.2


### PR DESCRIPTION
Upgrades to the current version of coverage 7.9.2. Refactors the code organization to separate the parts that wrangle coverage from the rest of the test_runner. Removes some unused / unneeded bits of code.

A major difference in the new (5.0+) coverage is that its internal data are stored as an sqlite database instead of json. As far as I can see, this is not significant for our purposes. We work with what coverage calls a "report" rather than with its own internal data. This PR refactors the old code with the fairly small set of changes needed to adapt to some reorganization in the coverage project and produces the same JSON coverage data that datatracker has been using in recent years.

Excluding lines / blocks from coverage checking is now done with the `# pragma: no cover` magic comment. The old method, using a context manager, was nice but is not easily translated into what the modern coverage package makes possible. A context manager to disable template and url coverage is still used, now called `disable_coverage()`. This needs to be used together with the pragma to turn off all types of coverage checks. 

I've added tests to ensure that the new `CoverageManager` class orchestrates things correctly and, as a safeguard, turns into a no-op if it is somehow called in production mode. I did not add tests for the stats reporting module because errors in it are likely to cause test failures, coverage drops, or other problems that we'll notice through other means. Testing it will require pretty involved mocking that didn't seem worth it.

Comparing the coverage stats generated by this refactor against the 12.43.1 release coverage finds very good but not exact agreement. There are many trivial format changes ("0" and "1" become "0.0" and "1.0"; rounding of floats is different in the 10^-9 decimal place or so), a few real but insignificant changes that I believe have to do with which lines coverage treats as coverable, and some changes to do with minor configuration changes between dev and GHA testing. None of these affects more than a few lines in any file and the overwhelming majority of files have exactly the same coverage stats.

Regarding speed, according to `time` the full test suite takes a total of 14:53.50 (871 seconds reported by the test runner) on my laptop. The current main branch using py39 and coverage 4.5.4 takes a total of 14:26.69 (855 seconds reported by the test runner). That's a negligible difference.
