### PR TITLE
fix: serve materials w/mixed-case exts

### DIFF
--- a/ietf/meeting/urls.py
+++ b/ietf/meeting/urls.py
@@ -64,7 +64,7 @@ type_ietf_only_patterns = [
 type_interim_patterns = [
     url(r'^agenda/(?P<acronym>[A-Za-z0-9-]+)-drafts.pdf$', views.session_draft_pdf),
     url(r'^agenda/(?P<acronym>[A-Za-z0-9-]+)-drafts.tgz$', views.session_draft_tarfile),
-    url(r'^materials/%(document)s(?P<ext>\.[a-z0-9]+)$' % settings.URL_REGEXPS, views.materials_document),
+    url(r'^materials/%(document)s(?P<ext>\.[a-zA-Z0-9]+)$' % settings.URL_REGEXPS, views.materials_document),
     url(r'^materials/%(document)s/?$' % settings.URL_REGEXPS, views.materials_document),
     url(r'^agenda.json$', views.agenda_json)
 ]

--- a/ietf/meeting/urls.py
+++ b/ietf/meeting/urls.py
@@ -64,7 +64,7 @@ type_ietf_only_patterns = [
 type_interim_patterns = [
     url(r'^agenda/(?P<acronym>[A-Za-z0-9-]+)-drafts.pdf$', views.session_draft_pdf),
     url(r'^agenda/(?P<acronym>[A-Za-z0-9-]+)-drafts.tgz$', views.session_draft_tarfile),
-    url(r'^materials/%(document)s(?P<ext>\.[a-zA-Z0-9]+)$' % settings.URL_REGEXPS, views.materials_document),
+    url(r'^materials/%(document)s(?P<ext>\.[A-Za-z0-9]+)$' % settings.URL_REGEXPS, views.materials_document),
     url(r'^materials/%(document)s/?$' % settings.URL_REGEXPS, views.materials_document),
     url(r'^agenda.json$', views.agenda_json)
 ]
@@ -85,7 +85,7 @@ type_ietf_only_patterns_id_optional = [
     url(r'^week-view(?:.html)?/?$', AgendaRedirectView.as_view(pattern_name='agenda', permanent=True)),
     url(r'^materials(?:.html)?/?$', views.materials),
     url(r'^request_minutes/?$', views.request_minutes),
-    url(r'^materials/%(document)s(?P<ext>\.[a-z0-9]+)?/?$' % settings.URL_REGEXPS, views.materials_document),
+    url(r'^materials/%(document)s(?P<ext>\.[A-Za-z0-9]+)?/?$' % settings.URL_REGEXPS, views.materials_document),
     url(r'^session/?$', views.materials_editable_groups),
     url(r'^proceedings(?:.html)?/?$', views.proceedings),
     url(r'^proceedings(?:.html)?/finalize/?$', views.finalize_proceedings),


### PR DESCRIPTION
We have about 50 meeting materials documents with `.PDF` extensions rather than `.pdf`, and perhaps other case combinations for other extensions. This PR allows these to be served rather than 404ing.