### PR TITLE
fix: escape nulls in XML api responses

### DIFF
--- a/ietf/api/__init__.py
+++ b/ietf/api/__init__.py
@@ -145,5 +145,26 @@ class ToOneField(tastypie.fields.ToOneField):
 
 
 class Serializer(tastypie.serializers.Serializer):
+    OPTION_ESCAPE_NULLS = "datatracker-escape-nulls"
+
     def format_datetime(self, data):
         return data.astimezone(datetime.timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds") + "Z"
+
+    def to_simple(self, data, options):
+        options = options or {}
+        simple_data = super().to_simple(data, options)
+        if (
+            options.get(self.OPTION_ESCAPE_NULLS, False) 
+            and isinstance(simple_data, str)
+        ):
+            # replace nulls with literal "\0"
+            simple_data = simple_data.replace("\x00", r"\0")
+        return simple_data
+
+    def to_etree(self, data, options=None, name=None, depth=0):
+        # lxml does not escape nulls on its own, so ask to_simple() to do it.
+        # This is mostly (only?) an issue when generating errors responses for
+        # fuzzers.
+        options = options or {}
+        options[self.OPTION_ESCAPE_NULLS] = True
+        return super().to_etree(data, options, name, depth)

--- a/ietf/api/__init__.py
+++ b/ietf/api/__init__.py
@@ -157,8 +157,8 @@ class Serializer(tastypie.serializers.Serializer):
             options.get(self.OPTION_ESCAPE_NULLS, False) 
             and isinstance(simple_data, str)
         ):
-            # replace nulls with literal "\0"
-            simple_data = simple_data.replace("\x00", r"\0")
+            # replace nulls with unicode "symbol for null character", \u2400
+            simple_data = simple_data.replace("\x00", "\u2400")
         return simple_data
 
     def to_etree(self, data, options=None, name=None, depth=0):

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -41,6 +41,7 @@ from ietf.utils.mail import empty_outbox, outbox, get_payload_text
 from ietf.utils.models import DumpInfo
 from ietf.utils.test_utils import TestCase, login_testing_unauthorized, reload_db_objects
 
+from . import Serializer
 from .ietf_utils import is_valid_token, requires_api_token
 from .views import EmailIngestionError
 
@@ -1540,6 +1541,21 @@ class TastypieApiTests(ResourceTestCaseMixin, TestCase):
                     #print("There doesn't seem to be any resource for model %s.models.%s"%(app.__name__,model.__name__,))
                     self.assertIn(model._meta.model_name, list(app_resources.keys()),
                         "There doesn't seem to be any API resource for model %s.models.%s"%(app.__name__,model.__name__,))
+
+    def test_serializer_to_etree_handles_nulls(self):
+        """Serializer to_etree() should handle a null character"""
+        serializer = Serializer()
+        try:
+            serializer.to_etree("string with no nulls in it")
+        except ValueError as e:
+            self.fail("serializer.to_etree raised ValueError on an ordinary string")
+        try:
+            serializer.to_etree("string with a \x00 in it")
+        except ValueError as e:
+            self.fail(
+                "serializer.to_etree raised ValueError on a string "
+                "containing a null character"
+            )
 
 
 class RfcdiffSupportTests(TestCase):

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1496,7 +1496,7 @@ class DirectAuthApiTests(TestCase):
         data = self.response_data(r)
         self.assertEqual(data["result"], "success")
 
-class TastypieApiTestCase(ResourceTestCaseMixin, TestCase):
+class TastypieApiTests(ResourceTestCaseMixin, TestCase):
     def __init__(self, *args, **kwargs):
         self.apps = {}
         for app_name in settings.INSTALLED_APPS:
@@ -1506,7 +1506,7 @@ class TastypieApiTestCase(ResourceTestCaseMixin, TestCase):
                 models_path = os.path.join(os.path.dirname(app.__file__), "models.py")
                 if os.path.exists(models_path):
                     self.apps[name] = app_name
-        super(TastypieApiTestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_api_top_level(self):
         client = Client(Accept='application/json')

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1547,11 +1547,11 @@ class TastypieApiTests(ResourceTestCaseMixin, TestCase):
         serializer = Serializer()
         try:
             serializer.to_etree("string with no nulls in it")
-        except ValueError as e:
+        except ValueError:
             self.fail("serializer.to_etree raised ValueError on an ordinary string")
         try:
             serializer.to_etree("string with a \x00 in it")
-        except ValueError as e:
+        except ValueError:
             self.fail(
                 "serializer.to_etree raised ValueError on a string "
                 "containing a null character"


### PR DESCRIPTION
Replaces null characters with `\0` in tastypie XML responses. This should stanch the flow of 500 errors we get when fuzzers hit tastypie endpoints. (Tastypie is correctly rejecting the requests with the garbage, then hitting an exception when it tries to respond with an XML format error that includes the garbage, so these errors are pure noise.)