### PR TITLE
chore: finish dropping smtpd 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -108,7 +108,7 @@
                 "aiosmtpd",
                 "-n",
                 "-c",
-                "aiosmtpd.handlers.Debugging",
+                "ietf.utils.aiosmtpd.DevDebuggingHandler",
                 "-l",
                 "localhost:2025"
             ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -105,10 +105,11 @@
             "command": "/usr/local/bin/python",
             "args": [
                 "-m",
-                "smtpd",
+                "aiosmtpd",
                 "-n",
                 "-c",
-                "DebuggingServer",
+                "aiosmtpd.handlers.Debugging",
+                "-l",
                 "localhost:2025"
             ],
             "presentation": {

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -108,7 +108,7 @@ echo "Running initial checks..."
 
 if [ -z "$EDITOR_VSCODE" ]; then
     CODE=0
-    python -m smtpd -n -c DebuggingServer localhost:2025 &
+    python -m aiosmtpd -n -c aiosmtpd.handlers.Debugging -l localhost:2025 &
     if [ -z "$*" ]; then
         echo "-----------------------------------------------------------------"
         echo "Ready!"

--- a/docker/scripts/app-init.sh
+++ b/docker/scripts/app-init.sh
@@ -108,7 +108,7 @@ echo "Running initial checks..."
 
 if [ -z "$EDITOR_VSCODE" ]; then
     CODE=0
-    python -m aiosmtpd -n -c aiosmtpd.handlers.Debugging -l localhost:2025 &
+    python -m aiosmtpd -n -c ietf.utils.aiosmtpd.DevDebuggingHandler -l localhost:2025 &
     if [ -z "$*" ]; then
         echo "-----------------------------------------------------------------"
         echo "Ready!"

--- a/ietf/utils/aiosmtpd.py
+++ b/ietf/utils/aiosmtpd.py
@@ -1,10 +1,14 @@
 # Copyright The IETF Trust 2014-2025, All Rights Reserved
-# -*- coding: utf-8 -*-
+"""aiosmtpd-related utilities
 
+These are for testing / dev use. If you're using this for production code, think very
+hard about the choices you're making...
+"""
+from aiosmtpd import handlers
 from aiosmtpd.controller import Controller
 from aiosmtpd.smtp import SMTP
 from email.utils import parseaddr
-from typing import Optional
+from typing import Optional, TextIO
 
 
 class SMTPTestHandler:
@@ -54,3 +58,16 @@ class SMTPTestServerDriver:
 
     def stop(self):
         self.controller.stop()
+
+
+class DevDebuggingHandler(handlers.Debugging):
+    """Debugging handler for use in dev ONLY"""
+    def __init__(self, stream: Optional[TextIO] = None):
+        # Allow longer lines than the 1001 that RFC 5321 requires. As of 2025-04-16 the
+        # datatracker emits some non-compliant messages.
+        # See https://aiosmtpd.aio-libs.org/en/latest/smtp.html
+        # Doing this in a handler class is a huge hack. Tests all pass with this set
+        # to 4000, but make the limit longer for dev just in case.
+        SMTP.line_length_limit = 10000
+        super().__init__(stream)
+        

--- a/ietf/utils/test_runner.py
+++ b/ietf/utils/test_runner.py
@@ -82,7 +82,7 @@ debug.debug = True
 import ietf
 import ietf.utils.mail
 from ietf.utils.management.commands import pyflakes
-from ietf.utils.test_smtpserver import SMTPTestServerDriver
+from ietf.utils.aiosmtpd import SMTPTestServerDriver
 from ietf.utils.test_utils import TestCase
 
 from mypy_boto3_s3.service_resource import Bucket


### PR DESCRIPTION
This gets rid of the last uses of the deprecated smtpd library, which was providing the debugging server that echoed messages to the dev console. The supported aiosmtpd library has an equivalent command-line debug mode. Because of #8806, a custom handler is added just to set the line length limit to something that works. (Without this, e.g., a password reset email is rejected by the debug server.)

Also renames the `test_smtpserver.py` module to something that makes more sense to me and is less likely to be confused for a set of test cases.