### PR TITLE
fix: Update Rev Regex in settings.py

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -774,7 +774,7 @@ URL_REGEXPS = {
     "date": r"(?P<date>\d{4}-\d{2}-\d{2})",
     "name": r"(?P<name>[A-Za-z0-9._+-]+?)",
     "document": r"(?P<document>[a-z][-a-z0-9]+)", # regular document names
-    "rev": r"(?P<rev>[0-9]{1,2}(-[0-9]{2})?)",
+    "rev": r"(?P<rev>[0-9]{2}(-[0-9]{2})?)",
     "owner": r"(?P<owner>[-A-Za-z0-9\'+._]+@[A-Za-z0-9-._]+)",
     "schedule_name": r"(?P<name>[A-Za-z0-9-:_]+)",
 }


### PR DESCRIPTION
Removing single value revision numbers as that is against the naming standard (https://authors.ietf.org/naming-your-internet-draft#version) and causes issues with htmlized documents with -1 in the name (eg draft-ietf-oauth-v2-1)