### PR TITLE
feat: subseries api for red

### DIFF
--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -24,6 +24,7 @@ from .routers import PrefixedSimpleRouter
 # todo more general name for this API?
 red_router = PrefixedSimpleRouter(name_prefix="ietf.api.red_api")  # red api router
 red_router.register("doc", doc_api.RfcViewSet)
+red_router.register("subseries", doc_api.SubseriesViewSet, basename="subseries")
 
 api.autodiscover()
 

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -25,7 +25,7 @@ from .serializers import (
 
 class RfcLimitOffsetPagination(LimitOffsetPagination):
     default_limit = 10
-    max_limit = 50000
+    max_limit = 500
 
 
 class RfcFilter(filters.FilterSet):

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -172,19 +172,3 @@ class SubseriesViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     queryset = Document.objects.subseries_docs().prefetch_related(
         PrefetchSubseriesContents(to_attr="contents")
     )
-
-    def list(self, request, *args, **kwargs):
-        from django.db import connection, reset_queries
-        reset_queries()
-        result = super().list(request, *args, **kwargs)
-        print("\n\n".join(q["sql"] for q in connection.queries))
-        print(f"\n\nTotal: {len(connection.queries)} queries")
-        return result
-
-    def retrieve(self, request, *args, **kwargs):
-        from django.db import connection, reset_queries
-        reset_queries()
-        result = super().retrieve(request, *args, **kwargs)
-        print("\n\n".join(q["sql"] for q in connection.queries))
-        print(f"\n\nTotal: {len(connection.queries)} queries")
-        return result

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -158,7 +158,6 @@ class PrefetchSubseriesContents(Prefetch):
                 Prefetch(
                     "target",
                     queryset=augment_rfc_queryset(Document.objects.all()),
-                    to_attr="document",
                 )
             ),
             to_attr=to_attr,

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -937,7 +937,18 @@ validate_docname = RegexValidator(
     'invalid'
 )
 
+
+SUBSERIES_DOC_TYPE_IDS = ("bcp", "fyi", "std")
+
+
+class DocumentQuerySet(models.QuerySet):
+    def subseries_docs(self):
+        return self.filter(type_id__in=SUBSERIES_DOC_TYPE_IDS)
+
+
 class Document(StorableMixin, DocumentInfo):
+    objects = DocumentQuerySet.as_manager()
+
     name = models.CharField(max_length=255, validators=[validate_docname,], unique=True)           # immutable
     
     action_holders = models.ManyToManyField(Person, through=DocumentActionHolder, blank=True)

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -145,7 +145,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     area = GroupSerializer(source="group.area", required=False)
     stream = StreamNameSerializer()
     identifiers = fields.SerializerMethodField()
-    draft = RelatedDraftSerializer(source="drafts.first", read_only=True)
+    draft = serializers.SerializerMethodField()
     obsoletes = RelatedRfcSerializer(many=True, read_only=True)
     obsoleted_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
     updates = RelatedRfcSerializer(many=True, read_only=True)
@@ -190,6 +190,14 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
                 DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}")
             )
         return DocIdentifierSerializer(instance=identifiers, many=True).data
+
+    @extend_schema_field(RelatedDraftSerializer)
+    def get_draft(self, object):
+        try:
+            related_doc = object.drafts[0]
+        except IndexError:
+            return None
+        return RelatedDraftSerializer(related_doc.source).data
 
 
 class RfcSerializer(RfcMetadataSerializer):

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -145,7 +145,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     area = GroupSerializer(source="group.area", required=False)
     stream = StreamNameSerializer()
     identifiers = fields.SerializerMethodField()
-    draft = RelatedDraftSerializer(source="came_from_draft", read_only=True)  # todo prefetch this
+    draft = RelatedDraftSerializer(source="drafts.first", read_only=True)
     obsoletes = RelatedRfcSerializer(many=True, read_only=True)
     obsoleted_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
     updates = RelatedRfcSerializer(many=True, read_only=True)
@@ -221,7 +221,29 @@ class SubseriesContentListSerializer(serializers.ListSerializer):
 class SubseriesContentSerializer(RfcMetadataSerializer):
     class Meta(RfcMetadataSerializer.Meta):
         list_serializer_class = SubseriesContentListSerializer
-    
+        fields = [
+            "number",
+            "title",
+            "published",
+            "status",
+            "pages",
+            "authors",
+            "group",
+            "area",
+            "stream",
+            "identifiers",
+            "obsoletes",
+            "obsoleted_by",
+            "updates",
+            "updated_by",
+            "is_also",
+            "see_also",
+            "draft",
+            "abstract",
+            "formats",
+            "keywords",
+            "errata",
+        ]
 
 class SubseriesDocSerializer(serializers.ModelSerializer):
     """Serialize a subseries document (e.g., a BCP or STD)"""


### PR DESCRIPTION
Adds API calls `subseriesList` and `subseriesRetrieve`. The former retrieves all subseries docs, optionally filtering by type (bcp, std, and fyi are the allowed values). The latter retrieves a single subseries doc.

This PR does not yet add the links from RFC documents to the subseries they belong to. The `is_also` value for each document is still faked and always an empty list. That will be a separate PR.

The subseries doc schema for a subseries document looks like this, with the List returning a list of these records. The `contents` value is a list of the RFCs contained in the document. The schema of the entries in contents is the same as the `docList` endpoint that retrieves a list of RFCs. This is still incomplete the same way that was incomplete - e.g., the formats lists are faked. I'm planning to straighten that out in the shared code separately also.

```json
{
  "name": "bcp243",
  "type": "bcp",
  "contents": [
    {
      "number": 9813,
      "title": "Operational Considerations for Using TLS Pre-Shared Keys (TLS-PSKs) with RADIUS",
      "published": "2025-07-11",
      "status": {
        "slug": "bcp",
        "name": "best current practice"
      },
      "pages": 20,
      "authors": [
        {
          "person": 108624,
          "name": "Alan DeKok",
          "email": "alan.dekok@inkbridge.io",
          "affiliation": "InkBridge Networks",
          "country": ""
        }
      ],
      "group": {
        "acronym": "radext",
        "name": "RADIUS EXTensions"
      },
      "area": {
        "acronym": "sec",
        "name": "Security Area"
      },
      "stream": {
        "slug": "ietf",
        "name": "IETF",
        "desc": "Internet Engineering Task Force (IETF)"
      },
      "identifiers": [
        {
          "type": "doi",
          "value": "10.17487/RFC9813"
        }
      ],
      "obsoletes": [],
      "obsoleted_by": [],
      "updates": [],
      "updated_by": [],
      "is_also": [],
      "see_also": [],
      "draft": {
        "id": 119429,
        "name": "draft-ietf-radext-tls-psk",
        "title": "Operational Considerations for RADIUS and TLS-PSK"
      },
      "abstract": "This document provides implementation and operational considerations for using TLS Pre-Shared Keys (TLS-PSKs) with RADIUS/TLS (RFC 6614) and RADIUS/DTLS (RFC 7360).  The purpose of the document is to help smooth the operational transition from the use of RADIUS/UDP to RADIUS/TLS.",
      "formats": [
        "txt",
        "xml"
      ],
      "keywords": [
        "keyword"
      ],
      "errata": []
    }
  ]
}
```