### PR TITLE
feat: add subseries+stub titlepage_name to rfc serializer

### DIFF
--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2024, All Rights Reserved
+# Copyright The IETF Trust 2024-2025, All Rights Reserved
 """Doc API implementations"""
 
 from django.db.models import OuterRef, Subquery, Prefetch, Value, JSONField, QuerySet

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -10,7 +10,7 @@ from rest_framework import serializers, fields
 
 from ietf.group.serializers import GroupSerializer
 from ietf.name.serializers import StreamNameSerializer
-from .models import Document, DocumentAuthor, RelatedDocument
+from .models import Document, DocumentAuthor
 
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
@@ -43,9 +43,7 @@ class DocIdentifierSerializer(serializers.Serializer):
     value = serializers.CharField()
 
 
-# This should become "type RfcStatusSlugT ..." when we drop pre-py3.12 support
-# It should be "RfcStatusSlugT: TypeAlias ..." when we drop py3.9 support
-RfcStatusSlugT = Literal[
+type RfcStatusSlugT = Literal[
     "standard",
     "bcp",
     "informational",

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2024, All Rights Reserved
+# Copyright The IETF Trust 2024-2025, All Rights Reserved
 """django-rest-framework serializers"""
 
 from dataclasses import dataclass

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -133,6 +133,11 @@ class ReverseRelatedRfcSerializer(serializers.Serializer):
     title = serializers.CharField(source="source.title")
 
 
+class ContainingSubseriesSerializer(serializers.Serializer):
+    name = serializers.CharField(source="source.name")
+    type = serializers.CharField(source="source.type_id")
+
+
 class RfcMetadataSerializer(serializers.ModelSerializer):
     """Serialize metadata of an RFC"""
     RFC_FORMATS = ("xml", "txt", "html", "htmlized", "pdf", "ps")
@@ -150,7 +155,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     obsoleted_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
     updates = RelatedRfcSerializer(many=True, read_only=True)
     updated_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
-    is_also = serializers.ListField(child=serializers.CharField(), read_only=True)
+    subseries = ContainingSubseriesSerializer(many=True, read_only=True)
     see_also = serializers.ListField(child=serializers.CharField(), read_only=True)
     formats = fields.MultipleChoiceField(choices=RFC_FORMATS)
     keywords = serializers.ListField(child=serializers.CharField(), read_only=True)
@@ -173,7 +178,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "obsoleted_by",
             "updates",
             "updated_by",
-            "is_also",
+            "subseries",
             "see_also",
             "draft",
             "abstract",


### PR DESCRIPTION
Changes the `is_also` field to `subseries` and populates it with a list of the names / types of the subseries doc that contains each RFC, if any. Adds a `titlepage_name` field to the author return value, but it is always empty for now. Cleans up some outdated typing syntax now that we're at python 3.12.