### PR TITLE
feat: more RfcAuthor support

### DIFF
--- a/ietf/doc/admin.py
+++ b/ietf/doc/admin.py
@@ -238,7 +238,7 @@ class StoredObjectAdmin(admin.ModelAdmin):
 admin.site.register(StoredObject, StoredObjectAdmin)
 
 class RfcAuthorAdmin(admin.ModelAdmin):
-    list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'order']
-    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email__address', 'affiliation']
+    list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'country', 'order']
+    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email__address', 'affiliation', 'country']
     raw_id_fields = ["document", "person", "email"]
 admin.site.register(RfcAuthor, RfcAuthorAdmin)

--- a/ietf/doc/admin.py
+++ b/ietf/doc/admin.py
@@ -238,7 +238,7 @@ class StoredObjectAdmin(admin.ModelAdmin):
 admin.site.register(StoredObject, StoredObjectAdmin)
 
 class RfcAuthorAdmin(admin.ModelAdmin):
-    list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'country', 'order']
-    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email__address', 'affiliation', 'country']
+    list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'order']
+    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email__address', 'affiliation']
     raw_id_fields = ["document", "person", "email"]
 admin.site.register(RfcAuthor, RfcAuthorAdmin)

--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -393,7 +393,6 @@ class RfcAuthorFactory(factory.django.DjangoModelFactory):
     person = factory.SubFactory('ietf.person.factories.PersonFactory')
     email = factory.LazyAttribute(lambda obj: obj.person.email())
     affiliation = factory.Faker('company')
-    country = factory.Faker('country')
     order = factory.LazyAttribute(lambda o: o.document.rfcauthor_set.count() + 1)
 
 class WgDocumentAuthorFactory(DocumentAuthorFactory):

--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -387,7 +387,9 @@ class RfcAuthorFactory(factory.django.DjangoModelFactory):
         model = RfcAuthor
 
     document = factory.SubFactory(DocumentFactory)
-    titlepage_name = factory.Faker('name')
+    titlepage_name = factory.LazyAttribute(
+        lambda obj: " ".join([obj.person.initials(), obj.person.last_name()])
+    )
     person = factory.SubFactory('ietf.person.factories.PersonFactory')
     email = factory.LazyAttribute(lambda obj: obj.person.email())
     affiliation = factory.Faker('company')

--- a/ietf/doc/migrations/0027_rfcauthor.py
+++ b/ietf/doc/migrations/0027_rfcauthor.py
@@ -6,7 +6,6 @@ import ietf.utils.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("person", "0004_alter_person_photo_alter_person_photo_thumb"),
         ("doc", "0026_change_wg_state_descriptions"),
@@ -25,7 +24,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("titlepage_name", models.CharField(max_length=128)),
+                ("titlepage_name", models.CharField(max_length=128, blank=False)),
                 ("is_editor", models.BooleanField(default=False)),
                 (
                     "affiliation",

--- a/ietf/doc/migrations/0027_rfcauthor.py
+++ b/ietf/doc/migrations/0027_rfcauthor.py
@@ -38,7 +38,9 @@ class Migration(migrations.Migration):
                 (
                     "document",
                     ietf.utils.models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="doc.document"
+                        limit_choices_to={"type_id": "rfc"},
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="doc.document",
                     ),
                 ),
                 (

--- a/ietf/doc/migrations/0027_rfcauthor.py
+++ b/ietf/doc/migrations/0027_rfcauthor.py
@@ -7,7 +7,7 @@ import ietf.utils.models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("person", "0004_alter_person_photo_alter_person_photo_thumb"),
+        ("person", "0005_alter_historicalperson_pronouns_selectable_and_more"),
         ("doc", "0026_change_wg_state_descriptions"),
     ]
 
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("titlepage_name", models.CharField(max_length=128, blank=False)),
+                ("titlepage_name", models.CharField(max_length=128)),
                 ("is_editor", models.BooleanField(default=False)),
                 (
                     "affiliation",
@@ -54,6 +54,7 @@ class Migration(migrations.Migration):
                 (
                     "person",
                     ietf.utils.models.ForeignKey(
+                        blank=True,
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
                         to="person.person",

--- a/ietf/doc/migrations/0027_rfcauthor.py
+++ b/ietf/doc/migrations/0027_rfcauthor.py
@@ -34,6 +34,14 @@ class Migration(migrations.Migration):
                         max_length=100,
                     ),
                 ),
+                (
+                    "country",
+                    models.CharField(
+                        blank=True,
+                        help_text="Country used by author for submission",
+                        max_length=255,
+                    ),
+                ),
                 ("order", models.IntegerField(default=1)),
                 (
                     "document",

--- a/ietf/doc/migrations/0027_rfcauthor.py
+++ b/ietf/doc/migrations/0027_rfcauthor.py
@@ -35,14 +35,6 @@ class Migration(migrations.Migration):
                         max_length=100,
                     ),
                 ),
-                (
-                    "country",
-                    models.CharField(
-                        blank=True,
-                        help_text="Country used by author for submission",
-                        max_length=255,
-                    ),
-                ),
                 ("order", models.IntegerField(default=1)),
                 (
                     "document",

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -895,7 +895,11 @@ class RfcAuthor(models.Model):
     ignored.
     """
 
-    document = ForeignKey("Document", on_delete=models.CASCADE)
+    document = ForeignKey(
+        "Document",
+        on_delete=models.CASCADE,
+        limit_choices_to={"type_id": "rfc"},  # only affects ModelForms (e.g., admin)
+    )
     titlepage_name = models.CharField(max_length=128, blank=False)
     is_editor = models.BooleanField(default=False)
     person = ForeignKey(Person, null=True, blank=True, on_delete=models.PROTECT)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -409,17 +409,20 @@ class DocumentInfo(models.Model):
 
     def author_names(self):
         names = []
-        if self.type_id=="rfc" and self.rfcauthor_set.exists():
+        if self.type_id == "rfc" and self.rfcauthor_set.exists():
             for author in self.rfcauthor_set.all():
                 if author.person:
                     names.append(author.person.name)
                 else:
                     # titlepage_name cannot be blank
-                    names.append(author.titlepage_name) 
+                    names.append(author.titlepage_name)
         else:
-            names = [author.person.name for author in self.documentauthor_set.all()]
+            names = [
+                author.person.name
+                for author in self.documentauthor_set.select_related("person")
+            ]
         return names
-    
+
     def author_persons_or_names(self):
         Author = namedtuple("Author", "person titlepage_name")
         persons_or_names = []

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -885,7 +885,7 @@ class RfcAuthor(models.Model):
     """Captures the authors of an RFC as represented on the RFC title page.
 
     This deviates from DocumentAuthor in that it does not get moved into the DocHistory
-    hierarchy as documents are saved. It will attempt to preserve email and affiliation
+    hierarchy as documents are saved. It will attempt to preserve email, country, and affiliation
     from the DocumentAuthor objects associated with the draft leading to this RFC (which
     may be wrong if the author moves or changes affiliation while the document is in the
     queue).
@@ -908,6 +908,7 @@ class RfcAuthor(models.Model):
     person = ForeignKey(Person, null=True, blank=True, on_delete=models.PROTECT)
     email = ForeignKey(Email, help_text="Email address used by author for submission", blank=True, null=True, on_delete=models.PROTECT)
     affiliation = models.CharField(max_length=100, blank=True, help_text="Organization/company used by author for submission")
+    country = models.CharField(max_length=255, blank=True, help_text="Country used by author for submission")
     order = models.IntegerField(default=1)
 
     def __str__(self):

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -433,10 +433,14 @@ class DocumentInfo(models.Model):
 
 
     def author_list(self):
-        if self.type_id == "rfc":
-            raise NotImplementedError
+        """List of author emails"""
+        author_qs = (
+            self.rfcauthor_set
+            if self.type_id == "rfc" and self.rfcauthor_set.exists()
+            else self.documentauthor_set
+        ).select_related("email").order_by("order")
         best_addresses = []
-        for author in self.documentauthor_set.all():
+        for author in author_qs:
             if author.email:
                 if author.email.active or not author.email.person:
                     best_addresses.append(author.email.address)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -898,7 +898,7 @@ class RfcAuthor(models.Model):
     document = ForeignKey("Document", on_delete=models.CASCADE)
     titlepage_name = models.CharField(max_length=128, blank=False)
     is_editor = models.BooleanField(default=False)
-    person = ForeignKey(Person, null=True, on_delete=models.PROTECT)
+    person = ForeignKey(Person, null=True, blank=True, on_delete=models.PROTECT)
     email = ForeignKey(Email, help_text="Email address used by author for submission", blank=True, null=True, on_delete=models.PROTECT)
     affiliation = models.CharField(max_length=100, blank=True, help_text="Organization/company used by author for submission")
     order = models.IntegerField(default=1)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -878,7 +878,7 @@ class RfcAuthor(models.Model):
     """Captures the authors of an RFC as represented on the RFC title page.
 
     This deviates from DocumentAuthor in that it does not get moved into the DocHistory
-    hierarchy as documents are saved. It will attempt to preserve email, country, and affiliation
+    hierarchy as documents are saved. It will attempt to preserve email and affiliation
     from the DocumentAuthor objects associated with the draft leading to this RFC (which
     may be wrong if the author moves or changes affiliation while the document is in the
     queue).
@@ -897,7 +897,6 @@ class RfcAuthor(models.Model):
     person = ForeignKey(Person, null=True, on_delete=models.PROTECT)
     email = ForeignKey(Email, help_text="Email address used by author for submission", blank=True, null=True, on_delete=models.PROTECT)
     affiliation = models.CharField(max_length=100, blank=True, help_text="Organization/company used by author for submission")
-    country = models.CharField(max_length=255, blank=True, help_text="Country used by author for submission")
     order = models.IntegerField(default=1)
 
     def __str__(self):

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -7,7 +7,6 @@ import datetime
 import logging
 import os
 
-import django.db
 import rfc2html
 
 from io import BufferedReader
@@ -414,8 +413,9 @@ class DocumentInfo(models.Model):
             for author in self.rfcauthor_set.all():
                 if author.person:
                     names.append(author.person.name)
-                elif author.titlepage_name != "":
-                    names.append(author.titlepage_name)
+                else:
+                    # titlepage_name cannot be blank
+                    names.append(author.titlepage_name) 
         else:
             names = [author.person.name for author in self.documentauthor_set.all()]
         return names
@@ -892,7 +892,7 @@ class RfcAuthor(models.Model):
     """
 
     document = ForeignKey("Document", on_delete=models.CASCADE)
-    titlepage_name = models.CharField(max_length=128)
+    titlepage_name = models.CharField(max_length=128, blank=False)
     is_editor = models.BooleanField(default=False)
     person = ForeignKey(Person, null=True, on_delete=models.PROTECT)
     email = ForeignKey(Email, help_text="Email address used by author for submission", blank=True, null=True, on_delete=models.PROTECT)

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1643,12 +1643,19 @@ def document_json(request, name, rev=None):
     data["state"] = extract_name(doc.get_state())
     data["intended_std_level"] = extract_name(doc.intended_std_level)
     data["std_level"] = extract_name(doc.std_level)
+    author_qs = (
+        doc.rfcauthor_set
+        if doc.type_id == "rfc" and doc.rfcauthor_set.exists()
+        else doc.documentauthor_set
+    ).select_related("person", "email").order_by("order")
     data["authors"] = [
-        dict(name=author.person.name,
-             email=author.email.address if author.email else None,
-             affiliation=author.affiliation)
-        for author in doc.documentauthor_set.all().select_related("person", "email").order_by("order")
-    ] # TODO: report differntly if we have RfcAuthors
+        {
+            "name": author.titlepage_name if hasattr(author, "titlepage_name") else author.person.name,
+            "email": author.email.address if author.email else None,
+            "affiliation": author.affiliation,
+        }
+        for author in author_qs
+    ]
     data["shepherd"] = doc.shepherd.formatted_email() if doc.shepherd else None
     data["ad"] = doc.ad.role_email("ad").formatted_email() if doc.ad else None
 

--- a/ietf/ipr/views.py
+++ b/ietf/ipr/views.py
@@ -81,8 +81,8 @@ def get_document_emails(ipr):
 
         addrs = gather_address_lists('ipr_posted_on_doc',doc=doc).as_strings(compact=False)
 
-        # TODO: consider how rfcauthor impacts this
-        author_names = ', '.join(a.person.name for a in doc.documentauthor_set.select_related("person"))
+        # Get a list of author names for the salutation in the body of the email
+        author_names = ', '.join(doc.author_names())
     
         context = dict(
             settings=settings,

--- a/ietf/nomcom/utils.py
+++ b/ietf/nomcom/utils.py
@@ -691,19 +691,42 @@ def three_of_five_eligible_9389(previous_five, queryset=None):
             counts[id] += 1
     return queryset.filter(pk__in=[id for id, count in counts.items() if count >= 3])
 
-def suggest_affiliation(person):
+def suggest_affiliation(person) -> str:
+    """Heuristically suggest a current affiliation for a Person"""
     recent_meeting = person.registration_set.order_by('-meeting__date').first()
-    affiliation = recent_meeting.affiliation if recent_meeting else ''
-    if not affiliation:
-        recent_volunteer = person.volunteer_set.order_by('-nomcom__group__acronym').first()
-        if recent_volunteer:
-            affiliation = recent_volunteer.affiliation 
-    if not affiliation:
-        recent_draft_revision =  NewRevisionDocEvent.objects.filter(doc__type_id='draft',doc__documentauthor__person=person).order_by('-time').first()
-        if recent_draft_revision:
-            affiliation = recent_draft_revision.doc.documentauthor_set.filter(person=person).first().affiliation
-    # TODO: When RfcAuthor affiliation comes from something other than copyforward from DocumentAuthor, add a clause that looks there too. Maybe just add it now as a no-op.
-    return affiliation
+    if recent_meeting and recent_meeting.affiliation:
+        return recent_meeting.affiliation
+
+    recent_volunteer = person.volunteer_set.order_by('-nomcom__group__acronym').first()
+    if recent_volunteer and recent_volunteer.affiliation:
+        return recent_volunteer.affiliation 
+
+    recent_draft_revision =  NewRevisionDocEvent.objects.filter(
+        doc__type_id="draft",
+        doc__documentauthor__person=person,
+    ).order_by("-time").first()
+    if recent_draft_revision:
+        draft_author = recent_draft_revision.doc.documentauthor_set.filter(
+            person=person
+        ).first()
+        if draft_author and draft_author.affiliation:
+            return draft_author.affiliation
+    
+    recent_rfc_publication = DocEvent.objects.filter(
+        Q(doc__documentauthor__person=person) | Q(doc__rfcauthor__person=person),
+        doc__type_id="rfc",
+        type="published_rfc",
+    ).order_by("-time").first()
+    if recent_rfc_publication:
+        rfc = recent_rfc_publication.doc
+        if rfc.rfcauthor_set.exists():
+            rfc_author = rfc.rfcauthor_set.filter(person=person).first()
+        else:
+            rfc_author = rfc.documentauthor_set.filter(person=person).first()
+        if rfc_author and rfc_author.affiliation:
+            return rfc_author.affiliation
+    return ""
+
 
 def extract_volunteers(year):
     nomcom = get_nomcom_by_year(year)

--- a/ietf/sync/rfceditor.py
+++ b/ietf/sync/rfceditor.py
@@ -466,14 +466,18 @@ def update_docs_from_rfc_index(
             doc.set_state(rfc_published_state)
             if draft:
                 doc.formal_languages.set(draft.formal_languages.all())
-                for author in draft.documentauthor_set.all(): # BIG TODO: instead of (in addition to?) just copying forward from the draft, populate rfcauthor from the index
+                # Create authors based on the last draft in the datatracker. This
+                # path will go away when we publish via the modernized RPC workflow
+                # but until then, these are the only data we have for authors that
+                # are easily connected to Person records.
+                for documentauthor in draft.documentauthor_set.all():
                     # Copy the author but point at the new doc.
                     # See https://docs.djangoproject.com/en/4.2/topics/db/queries/#copying-model-instances
-                    author.pk = None
-                    author.id = None
-                    author._state.adding = True
-                    author.document = doc
-                    author.save()
+                    documentauthor.pk = None
+                    documentauthor.id = None
+                    documentauthor._state.adding = True
+                    documentauthor.document = doc
+                    documentauthor.save()
 
         if draft:
             draft_events = []

--- a/ietf/templates/doc/opengraph.html
+++ b/ietf/templates/doc/opengraph.html
@@ -1,4 +1,4 @@
-{# Copyright The IETF Trust 2016-2020, All Rights Reserved #}
+{# Copyright The IETF Trust 2016-2025, All Rights Reserved #}
 {% load origin %}
 {% load static %}
 {% load ietf_filters %}


### PR DESCRIPTION
Completes a few TODO items, fixes the admin handling of RfcAuthor records, and fixes various minor things.

The "BIG TODO" for RFC Editor sync is removed without implementation. That's a big enough task we'll track it out of band rather than via a code TODO.