### PR TITLE
feat: use rfcauthors for nomcom eligibility

### DIFF
--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import os
 
+import django.db
 import rfc2html
 
 from io import BufferedReader

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -3077,10 +3077,10 @@ class VolunteerDecoratorUnitTests(TestCase):
 
         author_person = PersonFactory()
         for i in range(2):
-            da = WgDocumentAuthorFactory(person=author_person)
+            doc = WgRfcFactory(authors=[author_person])
             DocEventFactory(
                 type='published_rfc',
-                doc=da.document,
+                doc=doc,
                 time=datetime.datetime(
                     elig_date.year - 3,
                     elig_date.month,

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -2463,7 +2463,8 @@ class EligibilityUnitTests(TestCase):
         start and end datetimes for the eligibility interval. Events are fixed in time
         and the start and end are adjusted to include various combinations.
         
-        This is not an exhaustive test of corner cases.
+        This is not an exhaustive test of corner cases. Overlaps considerably with
+        rfc8989EligibilityTests.test_elig_by_author().
         """
         people = PersonFactory.create_batch(2)
         base_qs = Person.objects.filter(pk__in=[person.pk for person in people])

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -1,5 +1,4 @@
-# Copyright The IETF Trust 2012-2023, All Rights Reserved
-# -*- coding: utf-8 -*-
+# Copyright The IETF Trust 2012-2025, All Rights Reserved
 
 
 import datetime
@@ -2849,33 +2848,41 @@ class rfc8989EligibilityTests(TestCase):
             ineligible = set()
 
             p = PersonFactory()
-            ineligible.add(p)
+            ineligible.add(p)  # no RFCs or iesg-approved drafts
+            p = PersonFactory()
+            doc = WgRfcFactory(authors=[p])
+            DocEventFactory(type='published_rfc', doc=doc, time=middle_date)
+            ineligible.add(p)  # only one RFC
 
             p = PersonFactory()
-            da = WgDocumentAuthorFactory(person=p)
-            DocEventFactory(type='published_rfc',doc=da.document,time=middle_date)
-            ineligible.add(p)
-
-            p = PersonFactory()
-            da = WgDocumentAuthorFactory(person=p)
+            da = WgDocumentAuthorFactory(
+                person=p,
+                document__states=[("draft", "active"), ("draft-rfceditor", "ref")],
+            )
             DocEventFactory(type='iesg_approved',doc=da.document,time=last_date)
-            da = WgDocumentAuthorFactory(person=p)
-            DocEventFactory(type='published_rfc',doc=da.document,time=first_date)
-            eligible.add(p)
+            doc = WgRfcFactory(authors=[p])
+            DocEventFactory(type='published_rfc', doc=doc, time=first_date)
+            eligible.add(p)  # one RFC and one iesg-approved draft
 
             p = PersonFactory()
-            da = WgDocumentAuthorFactory(person=p)
+            da = WgDocumentAuthorFactory(
+                person=p,
+                document__states=[("draft", "active"), ("draft-rfceditor", "ref")],
+            )
             DocEventFactory(type='iesg_approved',doc=da.document,time=middle_date)
-            da = WgDocumentAuthorFactory(person=p)
-            DocEventFactory(type='published_rfc',doc=da.document,time=day_before_first_date)
-            ineligible.add(p)
+            doc = WgRfcFactory(authors=[p])
+            DocEventFactory(type='published_rfc', doc=doc, time=day_before_first_date)
+            ineligible.add(p)  # RFC is out of the eligibility window
 
             p = PersonFactory()
-            da = WgDocumentAuthorFactory(person=p)
+            da = WgDocumentAuthorFactory(
+                person=p,
+                document__states=[("draft", "active"), ("draft-rfceditor", "ref")],
+            )
             DocEventFactory(type='iesg_approved',doc=da.document,time=day_after_last_date)
-            da = WgDocumentAuthorFactory(person=p)
-            DocEventFactory(type='published_rfc',doc=da.document,time=middle_date)
-            ineligible.add(p)
+            doc = WgRfcFactory(authors=[p])
+            DocEventFactory(type='published_rfc', doc=doc, time=middle_date)
+            ineligible.add(p)  # iesg approval is outside the eligibility window
 
             for person in eligible:
                 self.assertTrue(is_eligible(person,nomcom))

--- a/ietf/nomcom/utils.py
+++ b/ietf/nomcom/utils.py
@@ -629,7 +629,6 @@ def get_threerule_eligibility_querysets(date, base_qs, three_of_five_callable):
     rfcs_with_rfcauthors = qualifying_rfcs.filter(rfcauthor_count__gt=0).distinct()
     rfcs_without_rfcauthors = qualifying_rfcs.filter(rfcauthor_count=0).distinct()
 
-    # rfc_pks = set(qualifying_rfcs.values_list('doc__pk', flat=True))
     # Second, get the IESG-approved I-Ds in the RFC Editor queue, excluding any that
     # became RFCs already
     became_rfc_state = State.objects.filter(type_id="draft", slug="rfc").first()


### PR DESCRIPTION
Refactors computation of the authorship path for nomcom eligibility to fix up some stale logic. Uses `RfcAuthor` records instead of `DocumentAuthor` for RFCs that have the former.