### PR TITLE
feat: add a sort filter for django for the lisdexylic of us (like me)

### DIFF
--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -129,8 +129,8 @@ def bracketpos(pos,posslug):
         return "[   ]"
 
 @register.filter(name='sort')
-def sortlist(li)
-    return li.sort()
+def sortlist(value):
+    return value.sort()
 
 register.filter('fill', fill)
 

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -130,7 +130,7 @@ def bracketpos(pos,posslug):
 
 @register.filter(name='sort')
 def sortlist(value):
-    return value.sort()
+    return sorted(value)
 
 register.filter('fill', fill)
 

--- a/ietf/doc/templatetags/ietf_filters.py
+++ b/ietf/doc/templatetags/ietf_filters.py
@@ -128,6 +128,10 @@ def bracketpos(pos,posslug):
     else:
         return "[   ]"
 
+@register.filter(name='sort')
+def sortlist(li)
+    return li.sort()
+
 register.filter('fill', fill)
 
 @register.filter

--- a/ietf/templates/doc/search/status_columns.html
+++ b/ietf/templates/doc/search/status_columns.html
@@ -87,11 +87,11 @@
         {{ doc.std_level|safe }} RFC
         {% if doc.obsoleted_by_list %}
             <br>
-            <span class="text-body-secondary">Obsoleted by {{ doc.obsoleted_by_list|join:", "|urlize_ietf_docs }}</span>
+            <span class="text-body-secondary">Obsoleted by {{ doc.obsoleted_by_list|sort|join:", "|urlize_ietf_docs }}</span>
         {% endif %}
         {% if doc.updated_by_list %}
             <br>
-            <span class="text-body-secondary">Updated by {{ doc.updated_by_list|join:", "|urlize_ietf_docs }}</span>
+            <span class="text-body-secondary">Updated by {{ doc.updated_by_list|sort|join:", "|urlize_ietf_docs }}</span>
         {% endif %}
         {% if doc.part_of %}
             <br>


### PR DESCRIPTION
# WARNING

**Eliot is playing with code he may not understand.**

Not quite sure how to test this in a sandbox, but happy to learn.

# Intent

The intent is to sort he list of RFCs that appear in the "obsoleted by" and "updated by" lists.  This makes it easier to spot RFCs in long lists, like that of RFC 2026, for instance.

# Method

Register a new function "sort" and then invoke it in the template.