### PR TITLE
chore: fix docker-compose comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     db:
         image: ghcr.io/ietf-tools/datatracker-db:latest
         #  build:
-        #      context: ..
+        #      context: .
         #      dockerfile: docker/db.Dockerfile
         restart: unless-stopped
         volumes:


### PR DESCRIPTION
Allows the commented-out options to work if uncommented.