### PR TITLE
fix: unbreak EmptyAwareJSONField

### DIFF
--- a/ietf/utils/db.py
+++ b/ietf/utils/db.py
@@ -1,11 +1,4 @@
-# Copyright The IETF Trust 2021, All Rights Reserved
-# -*- coding: utf-8 -*-
-
-# Taken from/inspired by
-# https://stackoverflow.com/questions/55147169/django-admin-jsonfield-default-empty-dict-wont-save-in-admin
-# 
-# JSONField should recognize {}, (), and [] as valid, non-empty JSON
-# values.  However, the base Field class excludes them
+# Copyright The IETF Trust 2021-2025, All Rights Reserved
 
 import jsonfield
 from django.db import models
@@ -14,8 +7,15 @@ from ietf.utils.fields import IETFJSONField as FormIETFJSONField, EmptyAwareJSON
 
 
 class EmptyAwareJSONField(models.JSONField):
-    form_class = FormEmptyAwareJSONField
+    """JSONField that allows empty JSON values when model specifies empty=False
 
+        Taken from/inspired by
+        https://stackoverflow.com/questions/55147169/django-admin-jsonfield-default-empty-dict-wont-save-in-admin
+        
+        JSONField should recognize {}, (), and [] as valid, non-empty JSON values.
+        
+        If customizing the formfield, the field must accept the `empty_values` argument.
+    """
     def __init__(self, *args, empty_values=FormEmptyAwareJSONField.empty_values, accepted_empty_values=None, **kwargs):
         if accepted_empty_values is None:
             accepted_empty_values = []
@@ -25,9 +25,12 @@ class EmptyAwareJSONField(models.JSONField):
         super().__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
-        if 'form_class' not in kwargs or issubclass(kwargs['form_class'], FormEmptyAwareJSONField):
-            kwargs.setdefault('empty_values', self.empty_values)
-        return super().formfield(**{**kwargs})
+        defaults = {
+            "form_class": FormEmptyAwareJSONField,
+            "empty_values": self.empty_values, 
+        }
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
 
 
 class IETFJSONField(jsonfield.JSONField):  # pragma: no cover

--- a/ietf/utils/db.py
+++ b/ietf/utils/db.py
@@ -3,31 +3,39 @@
 import jsonfield
 from django.db import models
 
-from ietf.utils.fields import IETFJSONField as FormIETFJSONField, EmptyAwareJSONField as FormEmptyAwareJSONField
+from ietf.utils.fields import (
+    IETFJSONField as FormIETFJSONField,
+    EmptyAwareJSONField as FormEmptyAwareJSONField,
+)
 
 
 class EmptyAwareJSONField(models.JSONField):
     """JSONField that allows empty JSON values when model specifies empty=False
 
-        Taken from/inspired by
-        https://stackoverflow.com/questions/55147169/django-admin-jsonfield-default-empty-dict-wont-save-in-admin
-        
-        JSONField should recognize {}, (), and [] as valid, non-empty JSON values.
-        
-        If customizing the formfield, the field must accept the `empty_values` argument.
+    Taken from/inspired by
+    https://stackoverflow.com/questions/55147169/django-admin-jsonfield-default-empty-dict-wont-save-in-admin
+
+    JSONField should recognize {}, (), and [] as valid, non-empty JSON values.
+
+    If customizing the formfield, the field must accept the `empty_values` argument.
     """
-    def __init__(self, *args, empty_values=FormEmptyAwareJSONField.empty_values, accepted_empty_values=None, **kwargs):
+
+    def __init__(
+        self,
+        *args,
+        empty_values=FormEmptyAwareJSONField.empty_values,
+        accepted_empty_values=None,
+        **kwargs,
+    ):
         if accepted_empty_values is None:
             accepted_empty_values = []
-        self.empty_values = [x
-                             for x in empty_values
-                             if x not in accepted_empty_values]
+        self.empty_values = [x for x in empty_values if x not in accepted_empty_values]
         super().__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
         defaults = {
             "form_class": FormEmptyAwareJSONField,
-            "empty_values": self.empty_values, 
+            "empty_values": self.empty_values,
         }
         defaults.update(kwargs)
         return super().formfield(**defaults)
@@ -39,15 +47,21 @@ class IETFJSONField(jsonfield.JSONField):  # pragma: no cover
     # Remove this class when migrations are squashed and it is no longer referenced
     form_class = FormIETFJSONField
 
-    def __init__(self, *args, empty_values=FormIETFJSONField.empty_values, accepted_empty_values=None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        empty_values=FormIETFJSONField.empty_values,
+        accepted_empty_values=None,
+        **kwargs,
+    ):
         if accepted_empty_values is None:
             accepted_empty_values = []
-        self.empty_values = [x
-                             for x in empty_values
-                             if x not in accepted_empty_values]
+        self.empty_values = [x for x in empty_values if x not in accepted_empty_values]
         super().__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
-        if 'form_class' not in kwargs or issubclass(kwargs['form_class'], FormIETFJSONField):
-            kwargs.setdefault('empty_values', self.empty_values)
+        if "form_class" not in kwargs or issubclass(
+            kwargs["form_class"], FormIETFJSONField
+        ):
+            kwargs.setdefault("empty_values", self.empty_values)
         return super().formfield(**{**kwargs})


### PR DESCRIPTION
The class was incorrectly translated from jsonfield.JSONField to Django's `models.JSONField` class. In particular, the `form_class` class variable convention is a jsonfield feature not used in Django's implementation.