### PR TITLE
feat: precompute blob lookups for meeting materials

### DIFF
--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -51,6 +51,7 @@ urlpatterns = [
     url(r'^iesg/position', views_ballot.api_set_position),
     # Find the blob to store for a given materials document path
     url(r'^meeting/(?:(?P<num>(?:interim-)?[a-z0-9-]+)/)?materials/%(document)s(?P<ext>\.[A-Za-z0-9]+)?/resolve/$' % settings.URL_REGEXPS, meeting_views.api_resolve_materials_name),
+    url(r'^meeting/(?:(?P<num>(?:interim-)?[a-z0-9-]+)/)?materials/%(document)s(?P<ext>\.[A-Za-z0-9]+)?/resolve-cached/$' % settings.URL_REGEXPS, meeting_views.api_resolve_materials_name_cached),
     url(r'^meeting/blob/(?P<bucket>[a-z0-9-]+)/(?P<name>[a-z][a-z0-9.-]+)$', meeting_views.api_retrieve_materials_blob),
     # Let Meetecho set session video URLs
     url(r'^meeting/session/video/url$', meeting_views.api_set_session_video_url),

--- a/ietf/meeting/admin.py
+++ b/ietf/meeting/admin.py
@@ -9,7 +9,7 @@ from ietf.meeting.models import (Attended, Meeting, Room, Session, TimeSlot, Con
     SchedTimeSessAssignment, ResourceAssociation, FloorPlan, UrlResource,
     SessionPresentation, ImportantDate, SlideSubmission, SchedulingEvent, BusinessConstraint,
     ProceedingsMaterial, MeetingHost, Registration, RegistrationTicket,
-    AttendanceTypeName)
+    AttendanceTypeName, ResolvedMaterial)
 
 
 class UrlResourceAdmin(admin.ModelAdmin):
@@ -288,3 +288,13 @@ class RegistrationTicketAdmin(admin.ModelAdmin):
     display_meeting.short_description = "Meeting"  # type: ignore # https://github.com/python/mypy/issues/2087
 
 admin.site.register(RegistrationTicket, RegistrationTicketAdmin)
+
+
+class ResolvedMaterialAdmin(admin.ModelAdmin):
+    model = ResolvedMaterial
+    list_display = ["name", "meeting_number", "bucket", "blob"]
+    list_filter = ["meeting_number", "bucket"]
+    search_fields = ["name", "blob"]
+    ordering = ["name"]
+
+admin.site.register(ResolvedMaterial, ResolvedMaterialAdmin)

--- a/ietf/meeting/migrations/0017_resolvedmaterial_and_more.py
+++ b/ietf/meeting/migrations/0017_resolvedmaterial_and_more.py
@@ -1,0 +1,48 @@
+# Copyright The IETF Trust 2025, All Rights Reserved
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("meeting", "0016_alter_meeting_country_alter_meeting_time_zone"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ResolvedMaterial",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(help_text="Name to resolve", max_length=300)),
+                (
+                    "meeting_number",
+                    models.CharField(
+                        help_text="Meeting material is related to", max_length=64
+                    ),
+                ),
+                (
+                    "bucket",
+                    models.CharField(help_text="Resolved bucket name", max_length=255),
+                ),
+                (
+                    "blob",
+                    models.CharField(help_text="Resolved blob name", max_length=300),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="resolvedmaterial",
+            constraint=models.UniqueConstraint(
+                fields=("name", "meeting_number"), name="unique_name_per_meeting"
+            ),
+        ),
+    ]

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -956,6 +956,27 @@ class SessionPresentation(models.Model):
     def __str__(self):
         return u"%s -> %s-%s" % (self.session, self.document.name, self.rev)
 
+
+class ResolvedMaterial(models.Model):
+    # A Document name can be 255 characters; allow this name to be a bit longer
+    name = models.CharField(max_length=300, help_text="Name to resolve")
+    meeting_number = models.CharField(
+        max_length=64, help_text="Meeting material is related to"
+    )
+    bucket = models.CharField(max_length=255, help_text="Resolved bucket name")
+    blob = models.CharField(max_length=300, help_text="Resolved blob name")
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "meeting_number"], name="unique_name_per_meeting"
+            )
+        ]
+    
+    def __str__(self):
+        return f"{self.name}@{self.meeting_number} -> {self.bucket}:{self.blob}"
+
+
 constraint_cache_uses = 0
 constraint_cache_initials = 0
 

--- a/ietf/meeting/resources.py
+++ b/ietf/meeting/resources.py
@@ -11,11 +11,15 @@ from tastypie.cache import SimpleCache
 
 from ietf import api
 
-from ietf.meeting.models import ( Meeting, ResourceAssociation, Constraint, Room, Schedule, Session,
-                                TimeSlot, SchedTimeSessAssignment, SessionPresentation, FloorPlan,
-                                UrlResource, ImportantDate, SlideSubmission, SchedulingEvent,
-                                BusinessConstraint, ProceedingsMaterial, MeetingHost, Attended,
-                                Registration, RegistrationTicket)
+from ietf.meeting.models import (Meeting, ResourceAssociation, Constraint, Room,
+                                 Schedule, Session,
+                                 TimeSlot, SchedTimeSessAssignment, SessionPresentation,
+                                 FloorPlan,
+                                 UrlResource, ImportantDate, SlideSubmission,
+                                 SchedulingEvent,
+                                 BusinessConstraint, ProceedingsMaterial, MeetingHost,
+                                 Attended,
+                                 Registration, RegistrationTicket, ResolvedMaterial)
 
 from ietf.name.resources import MeetingTypeNameResource
 class MeetingResource(ModelResource):
@@ -472,3 +476,20 @@ class RegistrationTicketResource(ModelResource):
             "registration": ALL_WITH_RELATIONS,
         }
 api.meeting.register(RegistrationTicketResource())
+
+
+class ResolvedMaterialResource(ModelResource):
+    class Meta:
+        queryset = ResolvedMaterial.objects.all()
+        serializer = api.Serializer()
+        cache = SimpleCache()
+        #resource_name = 'resolvedmaterial'
+        ordering = ['id', ]
+        filtering = { 
+            "id": ALL,
+            "name": ALL,
+            "meeting_number": ALL,
+            "bucket": ALL,
+            "blob": ALL,
+        }
+api.meeting.register(ResolvedMaterialResource())

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -1011,7 +1011,7 @@ def resolve_materials_for_one_meeting(meeting: Meeting):
     )
     # Warn if any files were updated during the above process
     last_update = meeting_documents.aggregate(Max("time"))["time__max"]
-    if last_update > start_time:
+    if last_update and last_update > start_time:
         log(
             f"Warning: materials for meeting {meeting.number} "
             "changed during ResolvedMaterial update"

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -281,10 +281,14 @@ def _get_materials_doc(name, meeting=None) -> tuple[Document | DocHistory, str |
         docname, rev = name.rsplit("-", 1)
         if len(rev) == 2 and rev.isdigit():
             try:
-                doc = DocHistory.objects.get(name=docname, rev=rev)
-            except DocHistory.DoesNotExist:
                 # may raise Document.DoesNotExist
                 doc = Document.objects.get(name=docname, rev=rev)
+            except Document.DoesNotExist:
+                doc = DocHistory.objects.filter(
+                    name=docname, rev=rev,
+                ).order_by("-time").first()
+                if doc is None:
+                    raise
             if (
                 _matches_meeting(doc, meeting)
                 and rev in doc.revisions_by_newrevisionevent()


### PR DESCRIPTION
Looks up meeting materials and stores mapping to blob bucket/name using `ResolvedMaterial` model. Adds a `.../resolve-cached` API end point that uses this model to resolve materials names instead of doing the lookup at runtime. Adds a task that populates the `ResolvedMaterial` table.