### PR TITLE
feat: robustness + date range for resolve materials task

### DIFF
--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -79,8 +79,11 @@ def resolve_meeting_materials_task(*, meetings=None, meetings_since=None):
         if meetings_since is not None:
             log.log("Ignoring meetings_since because specific meetings were requested.")
         meetings = Meeting.objects.filter(number__in=meetings)
-    for meeting in meetings:
-        log.log(f"Resolving materials for {meeting.type_id} meeting {meeting.number}...")
+    for meeting in meetings.order_by("date"):
+        log.log(
+            f"Resolving materials for {meeting.type_id} "
+            f"meeting {meeting.number} ({meeting.date})..."
+        )
         mark = timezone.now()
         resolve_materials_for_one_meeting(meeting)
         log.log(f"Resolved in {(timezone.now() - mark).total_seconds():0.3f} seconds.")

--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -111,5 +111,12 @@ def resolve_meeting_materials_task(
             f"meeting {meeting.number} ({meeting.date})..."
         )
         mark = timezone.now()
-        resolve_materials_for_one_meeting(meeting)
-        log.log(f"Resolved in {(timezone.now() - mark).total_seconds():0.3f} seconds.")
+        try:
+            resolve_materials_for_one_meeting(meeting)
+        except Exception as err:
+            log.log(
+                "Exception raised while resolving materials for "
+                f"meeting {meeting.number}: {err}"
+            )
+        else:
+            log.log(f"Resolved in {(timezone.now() - mark).total_seconds():0.3f} seconds.")

--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -80,10 +80,22 @@ def resolve_meeting_materials_task(
     if meetings_since == "zero":
         meetings_since = EARLIEST_MEETING_DATE
     elif meetings_since is not None:
-        meetings_since = datetime.datetime.fromisoformat(meetings_since)
+        try:
+            meetings_since = datetime.datetime.fromisoformat(meetings_since)
+        except ValueError:
+            log.log(
+                "Failed to parse meetings_since='{meetings_since}' with fromisoformat"
+            )
+            raise
 
     if meetings_until is not None:
-        meetings_until = datetime.datetime.fromisoformat(meetings_until)
+        try:
+            meetings_until = datetime.datetime.fromisoformat(meetings_until)
+        except ValueError:
+            log.log(
+                "Failed to parse meetings_until='{meetings_until}' with fromisoformat"
+            )
+            raise
         if meetings_since is None:
             # if we only got meetings_until, start from the first meeting
             meetings_since = EARLIEST_MEETING_DATE
@@ -103,7 +115,10 @@ def resolve_meeting_materials_task(
             log.log(f"Resolving materials for meetings since {meetings_since}")
     else:
         if meetings_since is not None:
-            log.log("Ignoring meetings_since because specific meetings were requested.")
+            log.log(
+                "Ignoring meetings_since and meetings_until "
+                "because specific meetings were requested."
+            )
         meetings = Meeting.objects.filter(number__in=meetings)
     for meeting in meetings.order_by("date"):
         log.log(

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -955,7 +955,9 @@ def resolve_one_material(
 def resolve_materials_for_one_meeting(meeting: Meeting):
     start_time = timezone.now()
     meeting_documents = (
-        Document.objects.exclude(type_id="draft").filter(
+        Document.objects.filter(
+            type_id__in=settings.MATERIALS_TYPES_SERVED_BY_WORKER
+        ).filter(
             Q(session__meeting=meeting) | Q(proceedingsmaterial__meeting=meeting)
         )
     ).distinct()

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -484,16 +484,6 @@ def api_retrieve_materials_blob(request, bucket, name):
     but a file with the same name but extension `.md` does, `.md` file will be rendered
     from markdown to html and returned / stored.
     """
-    ALLOWED_BUCKETS = {
-        "agenda",
-        "bluesheets",
-        "chatlog",
-        "minutes",
-        "narrativeminutes",
-        "polls",
-        "procmaterials",
-        "slides",
-    }
     DEFAULT_CONTENT_TYPES = {
         ".html": "text/html;charset=utf-8",
         ".md": "text/markdown;charset=utf-8",
@@ -504,7 +494,10 @@ def api_retrieve_materials_blob(request, bucket, name):
     def _default_content_type(blob_name: str):
         return DEFAULT_CONTENT_TYPES.get(Path(name).suffix, "application/octet-stream") 
 
-    if not settings.ENABLE_BLOBSTORAGE or bucket not in ALLOWED_BUCKETS:
+    if not (
+        settings.ENABLE_BLOBSTORAGE
+        and bucket in settings.MATERIALS_TYPES_SERVED_BY_WORKER
+    ):
         return HttpResponseNotFound(f"Bucket {bucket} not found.")
     storage = storages[bucket]  # if not configured, a server error will result
     assert isinstance(storage, BlobdbStorage)

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -816,6 +816,20 @@ for storagename in ARTIFACT_STORAGE_NAMES:
         "OPTIONS": {"bucket_name": storagename},
     }
 
+# Buckets / doc types of meeting materials the CF worker is allowed to serve. This
+# differs from the list in Session.meeting_related() by the omission of "recording"
+MATERIALS_TYPES_SERVED_BY_WORKER = [
+    "agenda",
+    "bluesheets",
+    "chatlog",
+    "minutes",
+    "narrativeminutes",
+    "polls",
+    "procmaterials",
+    "slides",
+]
+
+
 # Override this in settings_local.py if needed
 # *_PATH variables ends with a slash/ .
 


### PR DESCRIPTION
Limits resolution to meeting materials types (specifically to exclude charters, which get picked up via `session__meeting` filters) and sometimes have a revision like `00-00` that breaks assumptions in the resolver.

Logs failure to resolve a meeting if something goes wrong but continues. Outputs the date of each meeting as it's processed to assist in re-running if the task does fail.

Adds `meetings_until` task parameter in addition to `meetings_since` so an arbitrary range can be processed.