### PR TITLE
feat: tag subseries API endpoints for purple

### DIFF
--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -184,6 +184,7 @@ class SubseriesFilter(filters.FilterSet):
         queryset=DocTypeName.objects.filter(pk__in=SUBSERIES_DOC_TYPE_IDS)
     )
 
+
 @extend_schema(tags=["purple", "red"])
 class SubseriesViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes: list[BasePermission] = []

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -10,6 +10,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import BasePermission
 from rest_framework.viewsets import GenericViewSet
 
+from drf_spectacular.utils import extend_schema
 from ietf.group.models import Group
 from ietf.name.models import StreamName, DocTypeName
 from ietf.utils.timezone import RPC_TZINFO
@@ -183,7 +184,7 @@ class SubseriesFilter(filters.FilterSet):
         queryset=DocTypeName.objects.filter(pk__in=SUBSERIES_DOC_TYPE_IDS)
     )
 
-
+@extend_schema(tags=["purple", "red"])
 class SubseriesViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes: list[BasePermission] = []
     lookup_field = "name"


### PR DESCRIPTION
goal: make subseries API endpoints available to purple client (in addition to red), so that xfer script can import subseries info into purple