### PR TITLE
ci: imagePullPolicy for migration container

### DIFF
--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -115,6 +115,7 @@ spec:
       initContainers:
         - name: migration
           image: "ghcr.io/ietf-tools/datatracker:$APP_IMAGE_TAG"
+          imagePullPolicy: Always
           env:
             - name: "CONTAINER_ROLE"
               value: "migrations"


### PR DESCRIPTION
Fixes issues with staging deploys where the `migration` initContainer runs the old version of the code. We have never seen this for our automated deployments, only manual deploys, so we're likely being protected by the way we explicitly destroy the deployments when doing a prod deploy.