### PR TITLE
fix: don't use DocHistory to find materials

### DIFF
--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -50,7 +50,6 @@ urlpatterns = [
     # Let IESG members set positions programmatically
     url(r'^iesg/position', views_ballot.api_set_position),
     # Find the blob to store for a given materials document path
-    url(r'^meeting/(?:(?P<num>(?:interim-)?[a-z0-9-]+)/)?materials/%(document)s(?P<ext>\.[A-Za-z0-9]+)?/resolve/$' % settings.URL_REGEXPS, meeting_views.api_resolve_materials_name),
     url(r'^meeting/(?:(?P<num>(?:interim-)?[a-z0-9-]+)/)?materials/%(document)s(?P<ext>\.[A-Za-z0-9]+)?/resolve-cached/$' % settings.URL_REGEXPS, meeting_views.api_resolve_materials_name_cached),
     url(r'^meeting/blob/(?P<bucket>[a-z0-9-]+)/(?P<name>[a-z][a-z0-9.-]+)$', meeting_views.api_retrieve_materials_blob),
     # Let Meetecho set session video URLs

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -48,7 +48,6 @@ from ietf.doc.models import (
     State,
     NewRevisionDocEvent,
     StateDocEvent,
-    DocHistory,
     StoredObject,
 )
 from ietf.doc.models import DocEvent

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -861,7 +861,7 @@ class BlobSpec:
 
 
 def resolve_one_material(
-    doc: Document | DocHistory, rev: str | None, ext: str | None
+    doc: Document, rev: str | None, ext: str | None
 ) -> BlobSpec | None:
     if doc.type_id is None:
         log(f"Cannot resolve a doc with no type: {doc.name}")
@@ -995,12 +995,7 @@ def resolve_materials_for_one_meeting(meeting: Meeting):
         other_revisions = doc.revisions_by_newrevisionevent()
         other_revisions.remove(doc.rev)
         for rev in other_revisions:
-            old_doc = DocHistory.objects.filter(
-                doc=doc, rev=rev
-            ).order_by("-time").first()
-            if old_doc is None:
-                continue
-            blob = resolve_one_material(old_doc, rev=rev, ext=None)
+            blob = resolve_one_material(doc, rev=rev, ext=None)
             if blob is not None:
                 resolved.append(
                     ResolvedMaterial(

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -274,7 +274,7 @@ def _get_materials_doc(name, meeting=None):
         return doc.get_related_meeting() == meeting
 
     # try an exact match first
-    doc: Document | None = Document.objects.filter(name=name).first()
+    doc = Document.objects.filter(name=name).first()
     if doc is not None and _matches_meeting(doc, meeting):
         return doc, None
 


### PR DESCRIPTION
Reverts changes to the `_get_materials_doc()` helper because the DocHistory records are incomplete and, in particular, -00 revs are often missing. Removes the experimental API that led to those changes and adjusts the ResolvedMaterial construction utility not to use DocHistory.