### PR TITLE
feat: unversioned proceedings cache

### DIFF
--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -5,7 +5,6 @@ import itertools
 import jsonschema
 import os
 import requests
-from hashlib import sha384
 
 import pytz
 import subprocess
@@ -1061,8 +1060,9 @@ def generate_proceedings_content(meeting, force_refresh=False):
             ",".join(draft_names),
         ]
 
-    bare_key = ".".join(key_components)
-    cache_key = sha384(bare_key.encode("utf8")).hexdigest()
+    # Key is potentially long, but the "proceedings" cache hashes it to a fixed
+    # length. If that changes, hash it separately here first.
+    cache_key = ".".join(key_components)
     if not force_refresh:
         cached_content = cache.get(cache_key, None)
         if cached_content is not None:

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -1026,7 +1026,7 @@ def generate_proceedings_content(meeting, force_refresh=False):
     :meeting: meeting whose proceedings should be rendered
     :force_refresh: true to force regeneration and cache refresh
     """
-    cache = caches["default"]
+    cache = caches["proceedings"]
     key_components = [
         "proceedings",
         str(meeting.number),

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1374,6 +1374,17 @@ if "CACHES" not in locals():
                 "LOCATION": f"{MEMCACHED_HOST}:{MEMCACHED_PORT}",
                 "VERSION": __version__,
                 "KEY_PREFIX": "ietf:dt",
+                # Key function is default except with sha384-encoded key
+                "KEY_FUNCTION": lambda key, key_prefix, version: (
+                    f"{key_prefix}:{version}:{sha384(str(key).encode('utf8')).hexdigest()}"
+                ),
+            },
+            "proceedings": {
+                "BACKEND": "ietf.utils.cache.LenientMemcacheCache",
+                "LOCATION": f"{MEMCACHED_HOST}:{MEMCACHED_PORT}",
+                # No release-specific VERSION setting.
+                "KEY_PREFIX": "ietf:dt:proceedings",
+                # Key function is default except with sha384-encoded key
                 "KEY_FUNCTION": lambda key, key_prefix, version: (
                     f"{key_prefix}:{version}:{sha384(str(key).encode('utf8')).hexdigest()}"
                 ),
@@ -1420,6 +1431,17 @@ if "CACHES" not in locals():
                 #'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
                 "VERSION": __version__,
                 "KEY_PREFIX": "ietf:dt",
+            },
+            "proceedings": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+                # "BACKEND": "ietf.utils.cache.LenientMemcacheCache",
+                # "LOCATION": "127.0.0.1:11211",
+                # No release-specific VERSION setting.
+                "KEY_PREFIX": "ietf:dt:proceedings",
+                # Key function is default except with sha384-encoded key
+                "KEY_FUNCTION": lambda key, key_prefix, version: (
+                    f"{key_prefix}:{version}:{sha384(str(key).encode('utf8')).hexdigest()}"
+                ),
             },
             "sessions": {
                 "BACKEND": "django.core.cache.backends.locmem.LocMemCache",


### PR DESCRIPTION
Avoids invalidating the cache on every new release. Future work: provide a convenient way to re-compute quckly if an important change needs to get picked up.