### PR TITLE
fix: remove double tag

### DIFF
--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -185,7 +185,6 @@ class SubseriesFilter(filters.FilterSet):
     )
 
 
-@extend_schema(tags=["purple", "red"])
 class SubseriesViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes: list[BasePermission] = []
     lookup_field = "name"


### PR DESCRIPTION
This was meant to include the API call in both purple and red API clients. It seems this does not work, at least with some generators. Need to investigate further, but we should be able to work around it.