### PR TITLE
feat(meetings): Use "Decline and Delete" for slide disapprovals

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -7066,7 +7066,7 @@ class MaterialsTests(TestCase):
             self.assertFalse(exists_in_storage("staging", submission.filename))
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
-        self.assertRegex(r.content.decode(), r"These\s+slides\s+have\s+already\s+been\s+rejected")
+        self.assertRegex(r.content.decode(), r"These\s+slides\s+have\s+already\s+been\s+declined")
 
     @override_settings(MEETECHO_API_CONFIG="fake settings")  # enough to trigger API calls
     @patch("ietf.meeting.views.SlidesManager")

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -5291,7 +5291,7 @@ def approve_proposed_slides(request, slidesubmission_id, num):
             if request.POST.get('approve'):
                 # Ensure that we have a file to approve.  The system gets cranky otherwise.
                 if submission.filename is None or submission.filename == '' or not os.path.isfile(submission.staged_filepath()):
-                    return HttpResponseNotFound("The slides you attempted to approve could not be found.  Please disapprove and delete them instead.")
+                    return HttpResponseNotFound("The slides you attempted to approve could not be found.  Please decline and delete them instead.")
                 title = form.cleaned_data['title']
                 if existing_doc:
                    doc = Document.objects.get(name=name)

--- a/ietf/templates/meeting/approve_proposed_slides.html
+++ b/ietf/templates/meeting/approve_proposed_slides.html
@@ -34,6 +34,6 @@
         <button type="submit"
                 class="btn btn-warning"
                 name="disapprove"
-                value="disapprove">Disapprove and Delete</button>
+                value="disapprove">Decline and Delete</button>
     </form>
 {% endblock %}

--- a/ietf/templates/meeting/previously_approved_slides.html
+++ b/ietf/templates/meeting/previously_approved_slides.html
@@ -11,7 +11,7 @@
         {% if submission.status.slug == 'approved' %}
             approved
         {% else %}
-            rejected
+            declined
         {% endif %}
     </h1>
     <p>
@@ -19,7 +19,7 @@
         {% if submission.status.slug == 'approved' %}
             approved.
         {% else %}
-            rejected.
+            declined.
         {% endif %}
         No further action is needed.
     </p>


### PR DESCRIPTION
Changes use of "disapprove" and "rejected" to "decline" and "declined" when dealing with slides that have been submitted for approval. This PR also fixes a test failure in the previous PR #9840.