### PR TITLE
feat(agenda): Show calendar links to all the events

### DIFF
--- a/client/agenda/AgendaScheduleList.vue
+++ b/client/agenda/AgendaScheduleList.vue
@@ -398,16 +398,6 @@ const meetingEvents = computed(() => {
             color: 'teal'
           })
         }
-        // -> Calendar item
-        if (item.links.calendar) {
-          links.push({
-            id: `lnk-${item.id}-calendar`,
-            label: 'Calendar (.ics) entry for this session',
-            icon: 'calendar-check',
-            href: item.links.calendar,
-            color: 'pink'
-          })
-        }
       } else {
         // -> Post event
         if (meetingNumberInt >= 60) {
@@ -483,6 +473,16 @@ const meetingEvents = computed(() => {
           }
         }
       }
+    }
+    // Add Calendar item for all events that has a calendar link
+    if (item.adjustedEnd > current && item.links.calendar) {
+      links.push({
+        id: `lnk-${item.id}-calendar`,
+        label: 'Calendar (.ics) entry for this session',
+        icon: 'calendar-check',
+        href: item.links.calendar,
+        color: 'pink'
+      })
     }
 
     // Event icon

--- a/playwright/tests/meeting/agenda.spec.js
+++ b/playwright/tests/meeting/agenda.spec.js
@@ -1219,7 +1219,12 @@ test.describe('future - desktop', () => {
             await expect(eventButtons.locator(`#btn-lnk-${event.id}-calendar > i.bi`)).toBeVisible()
           }
         } else {
-          await expect(eventButtons).toHaveCount(0)
+          if (event.links.calendar) {
+            await expect(eventButtons.locator(`#btn-lnk-${event.id}-calendar`)).toHaveAttribute('href', event.links.calendar)
+            await expect(eventButtons.locator(`#btn-lnk-${event.id}-calendar > i.bi`)).toBeVisible()
+          } else {
+            await expect(eventButtons).toHaveCount(0)
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #7686 

This generates the agenda as follows for IETF 124 (with development data):
<img width="3024" height="18066" alt="Screenshot 2025-11-01 at 14-26-47 IETF 124 Meeting Agenda" src="https://github.com/user-attachments/assets/3735d4e4-77b2-439f-8870-2ad441e375e3" />

Calendar links are not shown on the past meeting agendas.
