### PR TITLE
fix: ask google not to index <noscript> content

### DIFF
--- a/ietf/templates/base.html
+++ b/ietf/templates/base.html
@@ -96,7 +96,7 @@
                     </div>
                 {% endif %}
                 <div class="col mx-lg-3 ietf-auto-nav" id="content">
-                    <noscript>
+                    <noscript data-nosnippet>
                         <div class="alert alert-danger alert-ignore my-3">
                             <b>Javascript disabled?</b> Like other modern websites, the IETF Datatracker relies on Javascript.
                             Please enable Javascript for full functionality.


### PR DESCRIPTION
## fix

* As noted by @larseggert in #9667 Google is indexing `<noscript>` content which appears in search results telling users to turn on JavaScript, so we should use [`data-nosnippet`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) to ask Google not to index that
<img width="1308" height="648" alt="497846230-1a8739c3-525f-45a1-b292-830dcf7b060b" src="https://github.com/user-attachments/assets/05559ef2-63b8-46ec-a35b-edbe1488c06a" />


