### PR TITLE
feat(review): Add atom feed for review team actions.

### DIFF
--- a/ietf/feed_urls.py
+++ b/ietf/feed_urls.py
@@ -2,7 +2,7 @@ from django.views.generic import RedirectView
 from django.conf import settings
 
 from ietf.doc.feeds import DocumentChangesFeed, InLastCallFeed, RfcFeed
-from ietf.group.feeds import GroupChangesFeed
+from ietf.group.feeds import GroupChangesFeed, ReviewRequestFeed
 from ietf.iesg.feeds import IESGAgendaFeed
 from ietf.ipr.feeds import LatestIprDisclosuresFeed
 from ietf.liaisons.feeds import LiaisonStatementsFeed
@@ -20,4 +20,5 @@ urlpatterns = [
     url(r'^wg-proceedings/$', LatestMeetingMaterialFeed()),
     url(r'^rfc/(?P<year>\d{4})/?$', RfcFeed()),
     url(r'^rfc/$', RfcFeed()),
+    url(r'^review-requests/%(acronym)s/$' % settings.URL_REGEXPS, ReviewRequestFeed()),
 ]

--- a/ietf/group/feeds.py
+++ b/ietf/group/feeds.py
@@ -2,14 +2,18 @@
 # -*- coding: utf-8 -*-
 
 
+import datetime
+from django import forms
 from django.contrib.syndication.views import Feed, FeedDoesNotExist
 from django.utils.feedgenerator import Atom1Feed
 from django.urls import reverse as urlreverse
 from django.utils.html import strip_tags
 from django.template.defaultfilters import truncatewords
 
+from ietf.review.models import ReviewAssignment
 from ietf.group.models import Group, GroupEvent
 from ietf.doc.models import DocEvent
+from ietf.utils.timezone import datetime_today, DEADLINE_TZINFO
 
 class GroupChangesFeed(Feed):
     feed_type = Atom1Feed
@@ -53,3 +57,73 @@ class GroupChangesFeed(Feed):
             title = "Chartering: %s" % title
 
         return title
+
+class ReviewRequestFeedForm(forms.Form):
+    since = forms.IntegerField(min_value=1, max_value = 9999, required=False)
+    reviewer_email = forms.EmailField(required=False)
+
+class ReviewRequestFeed(Feed):
+    feed_type = Atom1Feed
+    description_template = "group/feed_request_description.html"
+    reviewer_email = None
+    date_limit = None
+    acronym = None
+
+    def get_object(self, request, acronym):
+        self.acronym = acronym
+        group = Group.objects.get(acronym=acronym)
+        if not group:
+            raise FeedDoesNotExist
+        if not group.features.has_reviews:
+            raise FeedDoesNotExist
+
+        params = ReviewRequestFeedForm(request.GET)
+        if not params.is_valid():
+            raise FeedDoesNotExist
+        self.reviewer_email = params.cleaned_data["reviewer_email"] or None
+        since = params.cleaned_data["since"] or None
+        if since:
+            self.date_limit = datetime.timedelta(days = since)
+
+        return group
+
+    def title(self, obj):
+        return "Changes for %s %s" % (obj.acronym, obj.type)
+
+    def link(self, obj):
+        return obj.about_url()
+
+    def description(self, obj):
+        return self.title(obj)
+
+    def items(self, obj):
+        if self.reviewer_email:
+            history = ReviewAssignment.history.model.objects.filter(
+                review_request__team__acronym=self.acronym,
+                reviewer=self.reviewer_email)
+        else:
+            history = ReviewAssignment.history.model.objects.filter(
+                review_request__team__acronym=obj.acronym)
+        if self.date_limit:
+            history = history.filter(
+                review_request__time__gte=datetime_today(DEADLINE_TZINFO) -
+                self.date_limit)
+        return history
+
+    def item_link(self, item):
+        return urlreverse('ietf.doc.views_review.review_request',
+                          kwargs=dict(name=item.review_request.doc.name,
+                                      request_id=item.review_request.pk))
+
+    def item_pubdate(self, item):
+        return item.history_date
+
+    def item_title(self, item):
+        title = "{} {} review for {} by {} state {}".format(item.review_request.type.name, item.review_request.team.acronym.upper(), item.review_request.doc, item.reviewer.person, item.state)
+        return title
+
+    def item_author_name(self, item):
+        return item.reviewer.person
+
+    def item_author_email(self, item):
+        return item.reviewer.email_address()

--- a/ietf/templates/group/feed_request_description.html
+++ b/ietf/templates/group/feed_request_description.html
@@ -1,0 +1,9 @@
+{% load tz %}<div>
+Date: {{ obj.history_date|utc|date:"Y-m-d H:i:s" }} <br>
+By: {{ obj.history_user.person }} <br>
+Document: {% if obj.reviewed_rev %}<a href="{% url "ietf.doc.views_doc.document_main" name=obj.review_request.doc.name rev=obj.reviewed_rev %}">{{ obj.review_request.doc.name }}-{{ obj.reviewed_rev }}</a>{% else %}<a href="{% url "ietf.doc.views_doc.document_main" name=obj.review_request.doc.name %}">{{ obj.review_request.doc.name }}</a>{% endif %} <br>
+State: <a href="{% url "ietf.doc.views_review.review_request" name=obj.review_request.doc.name request_id=obj.review_request.pk %}">{{ obj.state }} </a> <br>
+Reviewer: {{ obj.reviewer.person }} <br>
+Result: {% if obj.review %}<a href="{{ obj.review.get_absolute_url }}"> {{ obj.result }}</a> {% else %} {{ obj.result }} {% endif %} <br>
+Description: {{ obj.history_change_reason }} <br>
+</div>


### PR DESCRIPTION
Add atom feed for review team actions. The url is /feed/review-requests/<group>/, and it can have two parameters, since and reviewer_email that can limit the feed to specific reviewer (?reviewer_email) and for last n days (?since=). (Fixes #8652)