### PR TITLE
fix: add most recent ballot hint to History tab. 

### DIFF
--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -697,7 +697,7 @@ def last_ballot_doc_revision(doc, person):
     balloters = get_active_balloters(ballot.ballot_type)
     if person not in balloters:
         return None
-    position_queryset = BallotPositionDocEvent.objects.filter(type="changed_ballot_position", balloter=person, ballot=ballot)
+    position_queryset = BallotPositionDocEvent.objects.filter(type="changed_ballot_position", balloter=person, ballot=ballot).order_by("-time")
     if not position_queryset.exists():
         return None
     ballot_time = position_queryset.first().time

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -692,7 +692,7 @@ def last_ballot_doc_revision(doc, person):
     """ Return the document revision for the most recent ballot position
         by the provided user. """
     ballot = doc.active_ballot()
-    if ballot == None or person == None:
+    if ballot is None or person is None:
         return None    
     balloters = get_active_balloters(ballot.ballot_type)
     if person not in balloters:

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -695,7 +695,7 @@ def last_ballot_doc_revision(doc, person):
     if ballot == None or person == None:
         return None    
     balloters = get_active_balloters(ballot.ballot_type)
-    if not person in balloters:
+    if person not in balloters:
         return None
     position_queryset = BallotPositionDocEvent.objects.filter(type="changed_ballot_position", balloter=person, ballot=ballot)
     if not position_queryset.exists():

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -36,11 +36,12 @@ from ietf.community.utils import docs_tracked_by_community_list
 from ietf.doc.models import Document, DocHistory, State, DocumentAuthor, DocHistoryAuthor
 from ietf.doc.models import RelatedDocument, RelatedDocHistory, BallotType, DocReminder
 from ietf.doc.models import DocEvent, ConsensusDocEvent, BallotDocEvent, IRSGBallotDocEvent, NewRevisionDocEvent, StateDocEvent
-from ietf.doc.models import TelechatDocEvent, DocumentActionHolder, EditedAuthorsDocEvent
+from ietf.doc.models import TelechatDocEvent, DocumentActionHolder, EditedAuthorsDocEvent, BallotPositionDocEvent
 from ietf.name.models import DocReminderTypeName, DocRelationshipName
 from ietf.group.models import Role, Group, GroupFeatures
 from ietf.ietfauth.utils import has_role, is_authorized_in_doc_stream, is_individual_draft_author, is_bofreq_editor
 from ietf.person.models import Email, Person
+from ietf.person.utils import get_active_balloters
 from ietf.review.models import ReviewWish
 from ietf.utils import draft, log
 from ietf.utils.mail import parseaddr, send_mail
@@ -686,6 +687,22 @@ def nice_consensus(consensus):
         False: "No"
         }
     return mapping[consensus]
+
+def last_ballot_doc_revision(doc, person):
+    """ Return the document revision for the most recent ballot position
+        by the provided user. """
+    ballot = doc.active_ballot()
+    if ballot == None or person == None:
+        return None    
+    balloters = get_active_balloters(ballot.ballot_type)
+    if not person in balloters:
+        return None
+    position_queryset = BallotPositionDocEvent.objects.filter(type="changed_ballot_position", balloter=person, ballot=ballot)
+    if not position_queryset.exists():
+        return None
+    ballot_time = position_queryset.first().time
+    doc_rev = NewRevisionDocEvent.objects.filter(doc=doc, time__lte=ballot_time).order_by('-time').first().rev
+    return doc_rev
 
 def has_same_ballot(doc, date1, date2=None):
     """ Test if the most recent ballot created before the end of date1

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -79,6 +79,7 @@ from ietf.utils.history import find_history_active_at
 from ietf.doc.views_ballot import parse_ballot_edit_return_point
 from ietf.doc.forms import InvestigateForm, TelechatForm, NotifyForm, ActionHoldersForm, DocAuthorForm, DocAuthorChangeBasisForm
 from ietf.doc.mails import email_comment, email_remind_action_holders
+from ietf.doc.utils import last_ballot_doc_revision
 from ietf.mailtrigger.utils import gather_relevant_expansions
 from ietf.meeting.models import Session, SessionPresentation
 from ietf.meeting.utils import group_sessions, get_upcoming_manageable_sessions, sort_sessions, add_event_info_to_session_qs
@@ -1225,6 +1226,10 @@ def document_history(request, name):
             request.user, ("Area Director", "Secretariat", "IRTF Chair")
         )
 
+    # if the current user has balloted on this document, give them a revision hint
+    ballot_doc_rev = None
+    if request.user.is_authenticated:
+        ballot_doc_rev = last_ballot_doc_revision(doc, request.user.person)
 
     return render(
         request,
@@ -1235,6 +1240,7 @@ def document_history(request, name):
             "diff_revisions": diff_revisions,
             "events": events,
             "can_add_comment": can_add_comment,
+            "ballot_doc_rev": ballot_doc_rev,
         },
     )
 

--- a/ietf/templates/doc/document_history.html
+++ b/ietf/templates/doc/document_history.html
@@ -20,6 +20,11 @@
         <h2 class="my-3">Revision differences</h2>
         {% include "doc/document_history_form.html" with doc=doc diff_revisions=diff_revisions action=rfcdiff_base_url snapshot=snapshot only %}
     {% endif %}
+    {% if ballot_doc_rev %}
+        <p class="alert alert-info my-3">
+            Your most recent ballot position was provided on revision {{ ballot_doc_rev }}.
+        </p>
+    {% endif %}
     <h2 class="my-3">Document history</h2>
     {% if doc.came_from_draft %}
         <ul class="nav nav-tabs my-3">

--- a/ietf/templates/doc/document_history.html
+++ b/ietf/templates/doc/document_history.html
@@ -22,7 +22,7 @@
     {% endif %}
     {% if ballot_doc_rev %}
         <p class="alert alert-info my-3">
-            Your most recent ballot position was provided on revision {{ ballot_doc_rev }}.
+            Your most recent ballot position was provided when the document was at version {{ ballot_doc_rev }}.
         </p>
     {% endif %}
     <h2 class="my-3">Document history</h2>


### PR DESCRIPTION
Fixes #9696.
Add a hint to the History tab for balloters that tells the revision of the document associated with the most recent ballot.