### PR TITLE
fix: no autoescape for bluesheet template

### DIFF
--- a/ietf/templates/meeting/bluesheet.txt
+++ b/ietf/templates/meeting/bluesheet.txt
@@ -1,7 +1,8 @@
-Bluesheet for {{session}}
+{% autoescape off %}Bluesheet for {{session}}
 ========================================================================
 
 {{ data|length }} attendees.
 
 {% for item in data %}
 {{ item.name }}	{{ item.affiliation }}{% endfor %}
+{% endautoescape %}


### PR DESCRIPTION
Replaces #9854 (minus the accidentally included work)

@kesara 