### PR TITLE
fix: Milestones date sorting out of order

### DIFF
--- a/ietf/templates/group/milestones.html
+++ b/ietf/templates/group/milestones.html
@@ -39,7 +39,7 @@
                             <span class="badge rounded-pill {% if milestone.resolved|slugify == 'done' %}text-bg-success{% else %}text-bg-warning{% endif %}">{{ milestone.resolved|title }}</span>
                         {% else %}
                             {% if group.uses_milestone_dates %}
-                                 <span class="d-none">{{ milestone.due }}</span>{{ milestone.due|date:"M Y" }}
+                                 <span class="d-none" aria-hidden="true">{{ milestone.due }}</span>{{ milestone.due|date:"M Y" }}
                             {% else %}
                                 {% if forloop.first %}Last{% endif %}
                                 {% if forloop.last %}Next{% endif %}

--- a/ietf/templates/group/milestones.html
+++ b/ietf/templates/group/milestones.html
@@ -20,7 +20,7 @@
     <table class="table table-sm table-striped tablesorter">
         <thead>
             <tr>
-                <th class="col-2" scope="col"{% if group.uses_milestone_dates %} data-sort="num"{% endif %}>
+                <th class="col-2" scope="col"{% if group.uses_milestone_dates %} data-sort="num"{% endif %} data-default-sort="asc">
                     {% if group.uses_milestone_dates %}
                         Date
                     {% else %}
@@ -39,7 +39,7 @@
                             <span class="badge rounded-pill {% if milestone.resolved|slugify == 'done' %}text-bg-success{% else %}text-bg-warning{% endif %}">{{ milestone.resolved|title }}</span>
                         {% else %}
                             {% if group.uses_milestone_dates %}
-                                {{ milestone.due|date:"M Y" }}
+                                 <span class="d-none">{{ milestone.due }}</span>{{ milestone.due|date:"M Y" }}
                             {% else %}
                                 {% if forloop.first %}Last{% endif %}
                                 {% if forloop.last %}Next{% endif %}


### PR DESCRIPTION
Added hidden YYYY-MM-DD span field to sort and added data-default-sort='asc' on the date column header to automatically sort by milestones dates, which are displayed as Month Year

Fix #9864 