### PR TITLE
fix(dev): Disable python terminal integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,6 @@
     "python.linting.pylintArgs": ["--load-plugins", "pylint_django"],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": false,
-    "python.linting.enabled": true
+    "python.linting.enabled": true,
+    "python.terminal.shellIntegration.enabled": false
 }


### PR DESCRIPTION
The integration corrupts the terminal, particularly when using the python shell.