### PR TITLE
feat: basic RfcAuthor API

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -7,7 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from ietf.doc.models import DocumentAuthor, Document
+from ietf.doc.models import DocumentAuthor, Document, RfcAuthor
 from ietf.doc.utils import default_consensus
 from ietf.person.models import Person
 
@@ -86,7 +86,7 @@ class DocumentAuthorSerializer(serializers.ModelSerializer):
 
     def get_plain_name(self, document_author: DocumentAuthor) -> str:
         return document_author.person.plain_name()
-
+    
 
 class FullDraftSerializer(serializers.ModelSerializer):
     # Redefine these fields so they don't pick up the regex validator patterns.
@@ -192,3 +192,21 @@ class ReferenceSerializer(serializers.ModelSerializer):
         model = Document
         fields = ["id", "name"]
         read_only_fields = ["id", "name"]
+
+
+class AuthorSerializer(serializers.ModelSerializer):
+    """Serialize an RfcAuthor record
+    
+    todo fix naming confusion with ietf.doc.serializers.RfcAuthorSerializer
+    """
+    class Meta:
+        model = RfcAuthor
+        fields = [
+            "id",
+            "titlepage_name",
+            "is_editor",
+            "person",
+            "email",
+            "affiliation",
+            "country",
+        ]

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -86,7 +86,7 @@ class DocumentAuthorSerializer(serializers.ModelSerializer):
 
     def get_plain_name(self, document_author: DocumentAuthor) -> str:
         return document_author.person.plain_name()
-    
+
 
 class FullDraftSerializer(serializers.ModelSerializer):
     # Redefine these fields so they don't pick up the regex validator patterns.

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -9,6 +9,7 @@ from ietf.api import views_rpc, views_rpc_demo
 from ietf.utils.urls import url
 
 router = routers.DefaultRouter()
+router.include_format_suffixes = False
 router.register(r"draft", views_rpc.DraftViewSet, basename="draft")
 router.register(r"person", views_rpc.PersonViewSet)
 router.register(r"rfc", views_rpc.RfcViewSet, basename="rfc")

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -8,11 +8,17 @@ from django.urls import include, path
 from ietf.api import views_rpc, views_rpc_demo
 from ietf.utils.urls import url
 
-router = routers.DefaultRouter()
+router = routers.DefaultRouter(use_regex_path=False)
 router.include_format_suffixes = False
 router.register(r"draft", views_rpc.DraftViewSet, basename="draft")
 router.register(r"person", views_rpc.PersonViewSet)
 router.register(r"rfc", views_rpc.RfcViewSet, basename="rfc")
+
+router.register(
+    r"rfc/<int:rfc_number>/authors",
+    views_rpc.RfcAuthorViewSet,
+    basename="rfc-authors",
+)
 
 if settings.SERVER_MODE not in {"production", "test"}:
     # for non production demos

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -260,7 +260,7 @@ class RfcViewSet(viewsets.GenericViewSet):
         responses=RfcWithAuthorsSerializer(many=True),
     )
     @action(detail=False, methods=["post"], serializer_class=RfcWithAuthorsSerializer)
-    def authors(self, request):
+    def bulk_authors(self, request):
         rfcs = self.get_queryset().filter(rfc_number__in=request.data)
         serializer = self.get_serializer(rfcs, many=True)
         return Response(serializer.data)

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -306,9 +306,6 @@ class RfcAuthorViewSet(viewsets.ModelViewSet):
             )
         )
 
-    def create(self, request, *args, **kwargs):
-        return super().create(request, *args, **kwargs)
-    
     def perform_create(self, serializer):
         rfc = Document.objects.filter(
             type_id="rfc",


### PR DESCRIPTION
Adds basic RfcAuthor management endpoints. Serializer naming is a bit less than ideal because `RfcAuthorSerializer` is already in use for the red API. I'll clean that up when I add RfcAuthor support to that API and then rename the serializer.

This is similar to purple's `RfcAuthor` API, but does not provide the `set_order()` action. We could add that, but I think it's unlikely to be used on this interface. Instead, delete all the existing authors for an RFC and add the correct set from scratch.