### PR TITLE
style: update text color in timeline bar for better visibility in dark mode

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -319,8 +319,9 @@ th,
         dominant-baseline: central;
     }
 
+    $timeline-bar-text-color: $gray-900;
     .bar text {
-        fill: var(--bs-body-color);
+        fill: $timeline-bar-text-color;
         dominant-baseline: central;
         pointer-events: none;
     }


### PR DESCRIPTION
fix #9905 - show dark color text on timeline bar in both light & dark modes