### PR TITLE
fix: authors API for xfer

### DIFF
--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -219,7 +219,7 @@ class DraftViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         responses=DraftWithAuthorsSerializer(many=True),
     )
     @action(detail=False, methods=["post"], serializer_class=DraftWithAuthorsSerializer)
-    def authors(self, request):
+    def bulk_authors(self, request):
         drafts = self.get_queryset().filter(name__in=request.data)
         serializer = self.get_serializer(drafts, many=True)
         return Response(serializer.data)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -463,8 +463,15 @@ class DocumentInfo(models.Model):
         return ", ".join(best_addresses)
 
     def authors(self):
-        if self.type_id == "rfc":
-            raise NotImplementedError
+        if self.type_id == "rfc" and self.rfcauthor_set.exists():
+            # todo deal with non-Person RfcAuthors if they exist
+            rfc_authors = [a.person for a in self.rfcauthor_set.all()]
+            if None in rfc_authors:
+                log.log(
+                    f"FIXME: authors() cannot handle non-Person authors in {self}"
+                )
+                rfc_authors.remove(None)
+            return rfc_authors
         return [ a.person for a in self.documentauthor_set.all() ]
 
     # This, and several other ballot related functions here, assume that there is only one active ballot for a document at any point in time.


### PR DESCRIPTION
Also renames `/api/purple/draft/authors` -> `/api/purple/draft/bulk_authors` to match the change made to the `/api/purple/rfc/...` path