### PR TITLE
fix: add OpenApi param definition doc_id

### DIFF
--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -37,6 +37,14 @@ from ietf.person.models import Email, Person
         operation_id="get_person_by_id",
         summary="Find person by ID",
         description="Returns a single person",
+        parameters=[
+            OpenApiParameter(
+                name="person_id",
+                type=int,
+                location="path",
+                description="Person ID identifying this person.",
+            ),
+        ],
     ),
 )
 class PersonViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -151,6 +151,14 @@ class RpcPersonSearch(generics.ListAPIView):
         operation_id="get_draft_by_id",
         summary="Get a draft",
         description="Returns the draft for the requested ID",
+        parameters=[
+            OpenApiParameter(
+                name="doc_id",
+                type=int,
+                location="path",
+                description="Doc ID identifying this draft.",
+            ),
+        ],
     ),
     submitted_to_rpc=extend_schema(
         operation_id="submitted_to_rpc",
@@ -196,6 +204,14 @@ class DraftViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
             "Returns the id and name of each normatively "
             "referenced Internet-Draft for the given docId"
         ),
+        parameters=[
+            OpenApiParameter(
+                name="doc_id",
+                type=int,
+                location="path",
+                description="Doc ID identifying this draft.",
+            ),
+        ],
         responses=ReferenceSerializer(many=True),
     )
     @action(detail=True, serializer_class=ReferenceSerializer)


### PR DESCRIPTION
define field `doc_id` as integer that was previously (by default) detected as string