### PR TITLE
fix: recognize Editorial Stream in queue2.xml

### DIFF
--- a/ietf/sync/rfceditor.py
+++ b/ietf/sync/rfceditor.py
@@ -115,6 +115,8 @@ def parse_queue(response):
                     stream = "irtf"
                 elif name.startswith("INDEPENDENT"):
                     stream = "ise"
+                elif name.startswith("Editorial Stream"):
+                    stream = "editorial"
                 else:
                     stream = None
                     warnings.append("unrecognized section " + name)


### PR DESCRIPTION
This quiets a warning. The `stream` value that's parsed from queue2.xml is not used as far as I can see, though, so this just squelches a warning.