### PR TITLE
feat: RFC publication API

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -307,7 +307,12 @@ class RfcPubSerializer(serializers.ModelSerializer):
                 )
             # todo check that draft is in the right state
 
-        rfc = self._create_rfc(validated_data)
+        rfc = self._create_rfc(
+            validated_data | {
+                "group": draft.group if draft else "none",
+                "formal_languages": draft.formal_languages.all() if draft else [],
+            }
+        )
         DocEvent.objects.create(
             doc=rfc,
             rev=rfc.rev,
@@ -399,16 +404,8 @@ class RfcPubSerializer(serializers.ModelSerializer):
                 )
                 draft.save_with_history(draft_events)
 
-        # todo set group properly
-        # doc.group = Group.objects.get(
-        #     type="individ"
-        # )  # fallback for newly created doc
-
-
         # todo add obsoletes / updates
         # todo add subseries relationships / clean up
-        # todo adjust errata tags
-        # todo formal languages from draft
         return rfc
 
     def _create_rfc(self, validated_data):

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -317,17 +317,21 @@ class RfcPubSerializer(serializers.ModelSerializer):
         if draft_name is not None:
             # validation enforces that draft_name and draft_rev are both present
             draft = Document.objects.filter(
-                type_id="draft", name=draft_name, rev=draft_rev,
+                type_id="draft",
+                name=draft_name,
+                rev=draft_rev,
+            ).exclude(
+                states__type_id="draft",
+                states__slug="rfc",
             ).first()
             if draft is None:
                 raise serializers.ValidationError(
                     {
-                        "draft_name": "No such draft",
-                        "draft_rev": "No such draft",
+                        "draft_name": "No such draft or draft already published as RFC",
+                        "draft_rev": "No such draft or draft already published as RFC",
                     },
                     code="invalid-draft"
                 )
-            # todo check that draft is in the right state
 
         # Transaction to clean up if something fails
         with transaction.atomic():

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -521,6 +521,17 @@ class RfcFileSerializer(serializers.Serializer):
             "file types, but filenames are otherwise ignored."
         ),
     )
+    replace = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text=(
+            "Replace existing files for this RFC. Defaults to false. When false, "
+            "if _any_ files already exist for the specified RFC the upload will be "
+            "rejected regardless of which files are being uploaded. When true,"
+            "existing files will be removed and new ones will be put in place. BE"
+            "VERY CAREFUL WITH THIS OPTION IN PRODUCTION."
+        ),
+    )
 
     def validate_contents(self, data):
         found_extensions = []

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -464,7 +464,7 @@ class RfcPubSerializer(serializers.ModelSerializer):
                     log.log("Warning while processing {}: draft {} stream is {} but RFC stream is {}".format(
                         rfc.name, draft.name, draft.stream, rfc.stream
                     ))
-                elif draft.stream.slug in ["iab", "irtf", "ise"]:
+                elif draft.stream.slug in ["iab", "irtf", "ise", "editorial"]:
                     stream_slug = f"draft-stream-{draft.stream.slug}"
                     prev_state = draft.get_state(stream_slug)
                     if prev_state is not None and prev_state.slug != "pub":

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -8,7 +8,6 @@ from django.urls import reverse as urlreverse
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
-from rest_framework.validators import UniqueValidator
 
 from ietf.doc.expire import move_draft_files_to_archive
 from ietf.doc.models import DocumentAuthor, Document, RfcAuthor, RelatedDocument, State, \

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -350,7 +350,6 @@ class RfcPubSerializer(serializers.ModelSerializer):
                     "group": (
                         draft.group if draft else Group.objects.get(acronym="none")
                     ),
-                    "shepherd": draft.shepherd if draft else None,
                 } | validated_data
             )
             DocEvent.objects.create(

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -254,14 +254,16 @@ class RfcPubSerializer(serializers.ModelSerializer):
         allow_null=True,
         required=False,
     )
-    obsoletes = serializers.PrimaryKeyRelatedField(
+    obsoletes = serializers.SlugRelatedField(
         many=True,
         required=False,
+        slug_field="rfc_number",
         queryset=Document.objects.filter(type_id="rfc"),
     )
-    updates = serializers.PrimaryKeyRelatedField(
+    updates = serializers.SlugRelatedField(
         many=True,
         required=False,
+        slug_field="rfc_number",
         queryset=Document.objects.filter(type_id="rfc"),
     )
     subseries = serializers.ListField(

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -290,7 +290,7 @@ class RfcPubSerializer(serializers.ModelSerializer):
             "formal_languages",
             "std_level",
             "ad",
-            "external_url",
+            "note",
             "obsoletes",
             "updates",
             "subseries",
@@ -350,6 +350,7 @@ class RfcPubSerializer(serializers.ModelSerializer):
                     "group": (
                         draft.group if draft else Group.objects.get(acronym="none")
                     ),
+                    "note": draft.note if draft else "",
                 } | validated_data
             )
             DocEvent.objects.create(

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -541,6 +541,7 @@ class RfcFileSerializer(serializers.Serializer):
                     f"More than one file uploaded with extension '{ext}'",
                     code="duplicate-filename-ext",
                 )
+        return data
 
 
 class NotificationAckSerializer(serializers.Serializer):

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -28,6 +28,7 @@ if settings.SERVER_MODE not in {"production", "test"}:
 urlpatterns = [
     url(r"^doc/drafts_by_names/", views_rpc.DraftsByNamesView.as_view()),
     url(r"^persons/search/", views_rpc.RpcPersonSearch.as_view()),
+    path(r"rfc/publish/", views_rpc.RfcPubNotificationView.as_view()),
     path(r"subject/<str:subject_id>/person/", views_rpc.SubjectPersonView.as_view()),
 ]
 

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -29,6 +29,7 @@ urlpatterns = [
     url(r"^doc/drafts_by_names/", views_rpc.DraftsByNamesView.as_view()),
     url(r"^persons/search/", views_rpc.RpcPersonSearch.as_view()),
     path(r"rfc/publish/", views_rpc.RfcPubNotificationView.as_view()),
+    path(r"rfc/publish/files/", views_rpc.RfcPubFilesView.as_view()),
     path(r"subject/<str:subject_id>/person/", views_rpc.SubjectPersonView.as_view()),
 ]
 

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -1,7 +1,7 @@
 # Copyright The IETF Trust 2023-2025, All Rights Reserved
 
 from drf_spectacular.utils import OpenApiParameter
-from rest_framework import serializers, viewsets, mixins
+from rest_framework import mixins, parsers, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.views import APIView
@@ -27,7 +27,7 @@ from ietf.api.serializers_rpc import (
     EmailPersonSerializer,
     RfcWithAuthorsSerializer,
     DraftWithAuthorsSerializer,
-    NotificationAckSerializer, RfcPubSerializer,
+    NotificationAckSerializer, RfcPubSerializer, RfcFileSerializer,
 )
 from ietf.doc.models import Document, DocHistory, RfcAuthor
 from ietf.person.models import Email, Person
@@ -362,4 +362,28 @@ class RfcPubNotificationView(APIView):
         serializer.is_valid(raise_exception=True)
         # Create RFC
         serializer.save()
+        return Response(NotificationAckSerializer().data)
+
+
+class RfcPubFilesView(APIView):
+    api_key_endpoint = "ietf.api.views_rpc"
+    parser_classes = [parsers.MultiPartParser]
+
+    @extend_schema(
+        operation_id="upload_rfc_files",
+        summary="Upload files for a published RFC",
+        request=RfcFileSerializer,
+        responses=NotificationAckSerializer,
+    )
+    def post(self, request):
+        print(request.POST)  # todo remove debug
+        serializer = RfcFileSerializer(
+            # many=True,
+            data=request.data,
+        )
+        serializer.is_valid(raise_exception=True)
+
+        print(">>> Got some files")
+        from pprint import pp
+        pp(serializer.validated_data)
         return Response(NotificationAckSerializer().data)

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -27,6 +27,7 @@ from ietf.api.serializers_rpc import (
     EmailPersonSerializer,
     RfcWithAuthorsSerializer,
     DraftWithAuthorsSerializer,
+    NotificationAckSerializer, RfcPubSerializer,
 )
 from ietf.doc.models import Document, DocHistory, RfcAuthor
 from ietf.person.models import Email, Person
@@ -345,3 +346,26 @@ class RfcAuthorViewSet(viewsets.ModelViewSet):
             .get("max_order")
         )
         serializer.save(document=rfc, order=max_order + 1)
+
+
+class RfcPubNotificationView(APIView):
+    api_key_endpoint = "ietf.api.views_rpc"
+
+    @extend_schema(
+        operation_id="notify_rfc_published",
+        summary="Notify datatracker of RFC publication",
+        request=RfcPubSerializer,
+        responses=NotificationAckSerializer,
+    )
+    def post(self, request):
+        print(request.POST)  # todo remove debug
+        serializer = RfcPubSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        
+        # Create RFC
+        serializer.save()
+        
+        print(">>> Notified of RFC publication!!")
+        from pprint import pp
+        pp(serializer.validated_data)
+        return Response(NotificationAckSerializer().data)

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -358,14 +358,8 @@ class RfcPubNotificationView(APIView):
         responses=NotificationAckSerializer,
     )
     def post(self, request):
-        print(request.POST)  # todo remove debug
         serializer = RfcPubSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        
         # Create RFC
         serializer.save()
-        
-        print(">>> Notified of RFC publication!!")
-        from pprint import pp
-        pp(serializer.validated_data)
         return Response(NotificationAckSerializer().data)


### PR DESCRIPTION
Creating as draft, as there's some additional refactoring to be done.

## Summary
Adds two API calls. The first, `notify_rfc_published()` (`/api/purple/rfc/publish/`) creates a new RFC `Document`, using similar procedures to the `ietf.sync.rfceditor.update_docs_from_rfc_index()` method. The second, `upload_rfc_files()` (`/api/purple/rfc/publish/files/`) accepts one or more content files and puts these in place for a specified RFC. The expected publication procedure is to call these in that order. There will be a brief period where the datatracker knows about the RFC but does not yet have its contents, but that is not new behavior compared to the existing sync mechanisms.

### `notify_rfc_published` API
Payload example
```json
{
  "published": "2025-11-20T18:30:12.403Z",
  "draft_name": "draft-QrLqCeSlPaVyKb5",
  "draft_rev": "78",
  "rfc_number": 1,
  "title": "blah blah blah",
  "authors": [
    {
      "titlepage_name": "string",
      "is_editor": true,
      "person": 0,
      "email": "string",
      "affiliation": "string",
      "country": "string"
    }
  ],
  "stream": "string",
  "group": "tools",
  "abstract": "string",
  "pages": 12,
  "words": 2500,
  "formal_languages": [
    "string"
  ],
  "std_level": "string",
  "ad": 0,
  "external_url": "string",
  "obsoletes": [
    0
  ],
  "updates": [
    0
  ],
  "subseries": [
    "std9524"
  ]
```

The `draft_name` and `draft_rev` fields are optional. If present, the RFC is linked as having been published from that draft. If `ad`, `group`, or `formal_languages` are not specified in the API call these are inherited from the draft. Passing null for `ad`/`group` or `[]` for `formal_languages` will override the draft values with empty ones if needed. All other fields are expected to be supplied in the API call and are not copied from the draft.

### `upload_rfc_files` API
The `upload_rfc_files` API differs from our existing API in that it expects multipart/form-data encoding of the request to allow chunked file uploads. The code generator we use to generate the Python client for using the API does not seem to handle nested serialization at all with multipart/form-data and has other limitations on the shape of the API it can handle. This is why the file upload API was split from the metadata / RFC creation API call.

Using the generated API client, the upload call looks like
```python
api.upload_rfc_files(rfc=5545, contents=["test.txt"], replace=True)
```
The `rfc` parameter is an integer identifying the existing RFC by number. The `contents` parameter is a list of filenames to be uploaded. The `replace` option, which defaults to False, specifies whether files already existing for the RFC should prevent the upload from taking place.

The files in `contents` are uploaded along with their original filenames. Only the extensions are significant and these are used to identify the format of each file. Currently, only `.xml`, `.txt`, `.txt.pdf`, and `.html` are allowed, and there can only be up to one of each type. The rest of the filename is discarded and files are named like `rfcNNNN.{ext}` when put in place.

When `replace` is True, any existing files like `rfcNNNN.{ext}` for any of the allowed extensions will be unlinked before moving uploaded files into place. My hope is that this will not be used in production except in rare cases. It should _not_ be part of the standard publication workflow except maybe during the early deployment when the old sync mechanism may be running.