### PR TITLE
feat: use RfcAuthor for red API

### DIFF
--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -16,6 +16,11 @@ from .models import Document, DocumentAuthor, RfcAuthor
 class RfcAuthorSerializer(serializers.ModelSerializer):
     """Serializer for a DocumentAuthor in a response"""
     email = serializers.EmailField(source="email.address", required=False)
+    datatracker_person_path = serializers.URLField(
+        source="person.get_absolute_url",
+        required=False,
+        help_text="URL for person link (relative to datatracker base URL)",
+    )
 
     class Meta:
         model = RfcAuthor
@@ -26,6 +31,7 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
             "email",
             "affiliation",
             "country",
+            "datatracker_person_path",
         ]
 
     def to_representation(self, instance):
@@ -35,7 +41,7 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
         serializer for either type.
         """
         if isinstance(instance, DocumentAuthor):
-            # create a non-persisted RfcAuthor as a shim
+            # create a non-persisted RfcAuthor as a shim - do not save it!
             document_author = instance
             instance = RfcAuthor(
                 titlepage_name=document_author.person.plain_name(),

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -6,7 +6,7 @@ from typing import Literal, ClassVar
 
 from django.db.models.manager import BaseManager
 from drf_spectacular.utils import extend_schema_field
-from rest_framework import serializers, fields
+from rest_framework import serializers
 
 from ietf.group.serializers import GroupSerializer
 from ietf.name.serializers import StreamNameSerializer
@@ -174,7 +174,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     group = GroupSerializer()
     area = GroupSerializer(source="group.area", required=False)
     stream = StreamNameSerializer()
-    identifiers = fields.SerializerMethodField()
+    identifiers = serializers.SerializerMethodField()
     draft = serializers.SerializerMethodField()
     obsoletes = RelatedRfcSerializer(many=True, read_only=True)
     obsoleted_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
@@ -182,7 +182,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     updated_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
     subseries = ContainingSubseriesSerializer(many=True, read_only=True)
     see_also = serializers.ListField(child=serializers.CharField(), read_only=True)
-    formats = fields.MultipleChoiceField(choices=RFC_FORMATS)
+    formats = serializers.MultipleChoiceField(choices=RFC_FORMATS)
     keywords = serializers.ListField(child=serializers.CharField(), read_only=True)
     errata = serializers.ListField(child=serializers.CharField(), read_only=True)
 


### PR DESCRIPTION
Changes the `RfcAuthor` schema to match the `RfcAuthor` model and returns data from `doc.rfcauthor_set` if that is not empty. Otherwise, it uses `doc.documentauthor_set` data. The same serialized schema is used regardless of the data source.

The new schema is below. Note that `titlepage_name` is the only guaranteed non-empty field. This is the only name field included - the old `name` field has been dropped. A new `datatracker_person_path` field is added. This is the URL  path for the author's "person page", relative to datatracker's root. If this is empty, no link should be rendered.

When representing a `DocumentAuthor`:
*  `titlepage_name` will be `person.plain_name()` (same value as the `name` field prior to this refactor)
*  `is_editor` is _always_ `False`
*  `person` is _always_ non-null

```yaml
    RfcAuthor:
      type: object
      description: Serializer for a DocumentAuthor in a response
      properties:
        titlepage_name:
          type: string
          maxLength: 128
        is_editor:
          type: boolean
        person:
          type: integer
          nullable: true
        email:
          type: string
          format: email
        affiliation:
          type: string
          description: Organization/company used by author for submission
          maxLength: 100
        country:
          type: string
          description: Country used by author for submission
          maxLength: 255
        datatracker_person_path:
          type: string
          format: uri
          description: URL for person link (relative to datatracker base URL)
      required:
      - titlepage_name
```