### PR TITLE
fix: Ensure more doc/html links stay in doc/html

### DIFF
--- a/ietf/static/js/document_html.js
+++ b/ietf/static/js/document_html.js
@@ -87,17 +87,17 @@ document.addEventListener("DOMContentLoaded", function (event) {
     document.activeElement.blur();
 
     // keep RFC links within the datatracker
-    const rfclink = /^https?:\/\/[^\/\.]*.(?:rfc-editor|ietf).org\/.*\/rfc(\d+)$/;
-    const docbase = document.location.origin + "/doc/html/rfc";
+    const rfclink = /^https?:\/\/[^\/\.]*.(?:rfc-editor|ietf).org\/.*\/((?:rfc|std|bcp)\d+)$/;
+    const docbase = document.location.origin + "/doc/html/";
     [...document.querySelectorAll(".references dd a:not([href='']:last-of-type)"),
      ...document.querySelectorAll("#identifiers a.eref")]
         .forEach(ref => {
-            const rfcnum = ref.href.match(rfclink);
-            if (!rfcnum) { return; }
+            const docnum = ref.href.match(rfclink);
+            if (!doccnum) { return; }
             if (ref.textContent === ref.href) {
-                ref.textContent = docbase + rfcnum[1];
+                ref.textContent = docbase + docnum[1];
             }
-            ref.href = docbase + rfcnum[1];
+            ref.href = docbase + docnum[1];
         });
 
     if (localStorage.getItem("reflinks") != "refsection") {

--- a/ietf/static/js/document_html.js
+++ b/ietf/static/js/document_html.js
@@ -86,6 +86,20 @@ document.addEventListener("DOMContentLoaded", function (event) {
     defpane.show();
     document.activeElement.blur();
 
+    // keep RFC links within the datatracker
+    const rfclink = /^https?:\/\/[^\/\.]*.(?:rfc-editor|ietf).org\/.*\/rfc(\d+)$/;
+    const docbase = document.location.origin + "/doc/html/rfc";
+    [...document.querySelectorAll(".references dd a:not([href='']:last-of-type)"),
+     ...document.querySelectorAll("#identifiers a.eref")]
+        .forEach(ref => {
+            const rfcnum = ref.href.match(rfclink);
+            if (!rfcnum) { return; }
+            if (ref.textContent === ref.href) {
+                ref.textContent = docbase + rfcnum[1];
+            }
+            ref.href = docbase + rfcnum[1];
+        });
+
     if (localStorage.getItem("reflinks") != "refsection") {
         // make links to references go directly to the referenced doc
         document.querySelectorAll("a[href^='#'].xref")
@@ -103,16 +117,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 const url = loc.querySelector(
                     "a:not([href='']:last-of-type)");
                 if (url) {
-                    const rfc = url.href.match(/(rfc\d+)$/i);
-                    if (rfc) {
-                        // keep RFC links within the datatracker
-                        const base = ref.href.match(
-                            /^(.*\/)rfc\d+.*$/i);
-                        if (base) {
-                            ref.href = base[1] + rfc[1];
-                            return;
-                        }
-                    }
                     ref.href = url.href;
                 }
             });


### PR DESCRIPTION
As far as I can tell, the code that was supposed to rewrite references was inoperative.  It just glued the same URL back together.  This version is effective.

The links to RFCs in the header of documents were being missed. I did not change the RFC link that appears in boilerplate.

I also update the text of the link if it is the same as the destination, to avoid surprises.

This also applies the fix unconditionally, so that the treatment is consistent regardless of what preference is chosen.