### PR TITLE
chore: drop apt-key + old pg utilities

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -10,12 +10,8 @@ ARG USER_GID=$USER_UID
 COPY docker/scripts/app-setup-debian.sh /tmp/library-scripts/docker-setup-debian.sh
 RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-debian.sh && chmod +x /tmp/library-scripts/docker-setup-debian.sh
 
-# Add Postgresql Apt Repository to get 14    
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y --no-install-recommends postgresql-client-14 pgloader \
+    && apt-get install -y --no-install-recommends pgloader \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -11,7 +11,6 @@ COPY docker/scripts/app-setup-debian.sh /tmp/library-scripts/docker-setup-debian
 RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-debian.sh && chmod +x /tmp/library-scripts/docker-setup-debian.sh
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y --no-install-recommends pgloader \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -11,21 +11,22 @@ RUN apt-get update \
 
 # Add Node.js Source
 RUN apt-get install -y --no-install-recommends ca-certificates curl gnupg \
-    && mkdir -p /etc/apt/keyrings\
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN echo "Package: nodejs" >> /etc/apt/preferences.d/preferences && \
-    echo "Pin: origin deb.nodesource.com" >> /etc/apt/preferences.d/preferences && \
-    echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/preferences
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "Package: nodejs" >> /etc/apt/preferences.d/preferences \
+    && echo "Pin: origin deb.nodesource.com" >> /etc/apt/preferences.d/preferences \
+    && echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/preferences
 
 # Add Docker Source
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list
 
-# Add PostgreSQL Source 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+# Add PostgreSQL Source
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/apt.postgresql.org.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
 # Install the packages we need
 RUN apt-get update --fix-missing && apt-get install -qy --no-install-recommends \

--- a/docker/celery.Dockerfile
+++ b/docker/celery.Dockerfile
@@ -10,12 +10,8 @@ ARG USER_GID=$USER_UID
 COPY docker/scripts/app-setup-debian.sh /tmp/library-scripts/docker-setup-debian.sh
 RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-debian.sh && chmod +x /tmp/library-scripts/docker-setup-debian.sh
 
-# Add Postgresql Apt Repository to get 14    
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y --no-install-recommends postgresql-client-14 pgloader \
+    && apt-get install -y --no-install-recommends pgloader \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user

--- a/docker/celery.Dockerfile
+++ b/docker/celery.Dockerfile
@@ -11,7 +11,6 @@ COPY docker/scripts/app-setup-debian.sh /tmp/library-scripts/docker-setup-debian
 RUN sed -i 's/\r$//' /tmp/library-scripts/docker-setup-debian.sh && chmod +x /tmp/library-scripts/docker-setup-debian.sh
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y --no-install-recommends pgloader \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user


### PR DESCRIPTION
Updates for modern ubuntu, which does not have apt-key. Drops pgloader + ancient postgres-client-14 that were used for mariadb transition.