### PR TITLE
feat: edit authors via RFC update API

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -10,8 +10,8 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ietf.doc.expire import move_draft_files_to_archive
-from ietf.doc.models import DocumentAuthor, Document, RfcAuthor, RelatedDocument, State, \
-    DocEvent
+from ietf.doc.models import DocumentAuthor, Document, RelatedDocument, State, DocEvent
+from ietf.doc.serializers import RfcAuthorSerializer
 from ietf.doc.utils import default_consensus, prettify_std_name, update_action_holders
 from ietf.group.models import Group
 from ietf.name.models import StreamName, StdLevelName, FormalLanguageName
@@ -201,24 +201,6 @@ class ReferenceSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "name"]
 
 
-class AuthorSerializer(serializers.ModelSerializer):
-    """Serialize an RfcAuthor record
-
-    todo fix naming confusion with ietf.doc.serializers.RfcAuthorSerializer
-    """
-    class Meta:
-        model = RfcAuthor
-        fields = [
-            "id",
-            "titlepage_name",
-            "is_editor",
-            "person",
-            "email",
-            "affiliation",
-            "country",
-        ]
-
-
 class RfcPubSerializer(serializers.ModelSerializer):
     # publication-related fields
     published = serializers.DateTimeField(default_timezone=datetime.timezone.utc)
@@ -273,7 +255,7 @@ class RfcPubSerializer(serializers.ModelSerializer):
             regex=r"^(bcp|std|fyi)[1-9][0-9]{0,4}$", 
         )
     )
-    authors = AuthorSerializer(many=True)
+    authors = RfcAuthorSerializer(many=True)
 
     class Meta:
         model = Document

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -10,7 +10,14 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ietf.doc.expire import move_draft_files_to_archive
-from ietf.doc.models import DocumentAuthor, Document, RelatedDocument, State, DocEvent
+from ietf.doc.models import (
+    DocumentAuthor,
+    Document,
+    RelatedDocument,
+    State,
+    DocEvent,
+    RfcAuthor,
+)
 from ietf.doc.serializers import RfcAuthorSerializer
 from ietf.doc.utils import default_consensus, prettify_std_name, update_action_holders
 from ietf.group.models import Group
@@ -200,6 +207,40 @@ class ReferenceSerializer(serializers.ModelSerializer):
         fields = ["id", "name"]
         read_only_fields = ["id", "name"]
 
+
+class EditableRfcSerializer(serializers.ModelSerializer):
+    # Would be nice to reconcile this with ietf.doc.serializers.RfcSerializer.
+    # The purposes of that serializer (representing data for Red) and this one
+    # (accepting updates from Purple) are different enough that separate formats
+    # may be needed, but if not it'd be nice to have a single RfcSerializer that
+    # can serve both.
+    #
+    # For now, only handles authors
+    authors = RfcAuthorSerializer(many=True, min_length=1, source="rfcauthor_set")
+
+    class Meta:
+        model = Document
+        fields = ["id", "authors"]
+
+    def update(self, instance, validated_data):
+        authors_data = validated_data.pop("rfcauthor_set", None)
+        if authors_data is not None:
+            # Construct unsaved instances from validated author data
+            new_authors = []
+            for count, author_data in enumerate(authors_data):
+                new_authors.append(
+                    RfcAuthor(
+                        document=instance,
+                        order=count + 1,
+                        **author_data,
+                    )
+                )
+                # Commit author changes
+                with transaction.atomic():
+                    instance.rfcauthor_set.all().delete()
+                    for author in new_authors:
+                        author.save()
+        return instance
 
 class RfcPubSerializer(serializers.ModelSerializer):
     # publication-related fields

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -22,7 +22,6 @@ from rest_framework.filters import SearchFilter
 from rest_framework.pagination import LimitOffsetPagination
 
 from ietf.api.serializers_rpc import (
-    AuthorSerializer,
     PersonSerializer,
     FullDraftSerializer,
     DraftSerializer,
@@ -35,6 +34,7 @@ from ietf.api.serializers_rpc import (
     NotificationAckSerializer, RfcPubSerializer, RfcFileSerializer,
 )
 from ietf.doc.models import Document, DocHistory, RfcAuthor
+from ietf.doc.serializers import RfcAuthorSerializer
 from ietf.person.models import Email, Person
 
 
@@ -328,7 +328,7 @@ class RfcAuthorViewSet(viewsets.ModelViewSet):
     api_key_endpoint = "ietf.api.views_rpc"
 
     queryset = RfcAuthor.objects.all()
-    serializer_class = AuthorSerializer
+    serializer_class = RfcAuthorSerializer
     lookup_url_kwarg = "author_id"
     rfc_number_param = "rfc_number"
 

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -32,6 +32,7 @@ from ietf.api.serializers_rpc import (
     RfcWithAuthorsSerializer,
     DraftWithAuthorsSerializer,
     NotificationAckSerializer, RfcPubSerializer, RfcFileSerializer,
+    EditableRfcSerializer,
 )
 from ietf.doc.models import Document, DocHistory, RfcAuthor
 from ietf.doc.serializers import RfcAuthorSerializer
@@ -269,9 +270,11 @@ class DraftViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         responses=OriginalStreamSerializer(many=True),
     )
 )
-class RfcViewSet(viewsets.GenericViewSet):
+class RfcViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
     queryset = Document.objects.filter(type_id="rfc")
     api_key_endpoint = "ietf.api.views_rpc"
+    lookup_field = "rfc_number"
+    serializer_class = EditableRfcSerializer
 
     @action(detail=False, serializer_class=OriginalStreamSerializer)
     def rfc_original_stream(self, request):


### PR DESCRIPTION
This provides an API to update all authors for an RFC as a batch. It also begins building out the API that will eventually allow Purple to update RFC details. Reconciles the `AuthorSerializer` vs `RfcAuthorSerializer` naming conflict by unifying these.

This is a checkpoint PR that adds the new API but there is still work to be done on the handling of the call. This applies author updates by deleting existing `RfcAuthor` records and creating a new batch. It does not yet do logging of changes.

Requires a coordinated change to Purple because the API client's `AuthorRequest` is now `RfcAuthorRequest`.