### PR TITLE
chore: optional opentelemetry

### DIFF
--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -135,6 +135,9 @@ def post_request(worker, req, environ, resp):
 def post_fork(server, worker):
     server.log.info("Worker spawned (pid: %s)", worker.pid)
 
+    # Setting DATATRACKER_OPENTELEMETRY_ENABLE=all in the environment will enable all
+    # opentelemetry instrumentations. Individual instrumentations can be selected by
+    # using a space-separated list. See the code below for available instrumentations.
     telemetry_env = os.environ.get("DATATRACKER_OPENTELEMETRY_ENABLE", "").strip()
     if telemetry_env != "":
         enabled_telemetry = [tok.strip().lower() for tok in telemetry_env.split()]

--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -135,21 +135,27 @@ def post_request(worker, req, environ, resp):
 def post_fork(server, worker):
     server.log.info("Worker spawned (pid: %s)", worker.pid)
 
-    resource = Resource.create(attributes={
-        "service.name": "datatracker",
-        "service.version": ietf.__version__,
-        "service.instance.id": worker.pid,
-        "service.namespace": "datatracker",
-        "deployment.environment.name": os.environ.get("DATATRACKER_SERVICE_ENV", "dev")
-    })
-
-    trace.set_tracer_provider(TracerProvider(resource=resource))
-    otlp_exporter = OTLPSpanExporter(endpoint="https://heimdall-otlp.ietf.org/v1/traces")
-
-    trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(otlp_exporter))
-
-    # Instrumentations
-    DjangoInstrumentor().instrument()
-    Psycopg2Instrumentor().instrument()
-    PymemcacheInstrumentor().instrument()
-    RequestsInstrumentor().instrument()
+    telemetry_env = os.environ.get("DATATRACKER_OPENTELEMETRY_ENABLE", "").strip()
+    if telemetry_env != "":
+        enabled_telemetry = [tok.strip().lower() for tok in telemetry_env.split()]
+        resource = Resource.create(attributes={
+            "service.name": "datatracker",
+            "service.version": ietf.__version__,
+            "service.instance.id": worker.pid,
+            "service.namespace": "datatracker",
+            "deployment.environment.name": os.environ.get("DATATRACKER_SERVICE_ENV", "dev")
+        })
+        trace.set_tracer_provider(TracerProvider(resource=resource))
+        otlp_exporter = OTLPSpanExporter(endpoint="https://heimdall-otlp.ietf.org/v1/traces")
+    
+        trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(otlp_exporter))
+    
+        # Instrumentations
+        if "all" in enabled_telemetry or "django" in enabled_telemetry: 
+            DjangoInstrumentor().instrument()
+        if "all" in enabled_telemetry or "psycopg2" in enabled_telemetry: 
+            Psycopg2Instrumentor().instrument()
+        if "all" in enabled_telemetry or "pymemcache" in enabled_telemetry: 
+            PymemcacheInstrumentor().instrument()
+        if "all" in enabled_telemetry or "requests" in enabled_telemetry: 
+            RequestsInstrumentor().instrument()


### PR DESCRIPTION
Add `DATATRACKER_OPENTELEMETRY_ENABLE=all` to environment to enable, or space-separated list of django/psycopg2/pymemcache/requests to enable only certain instrumentation. Omit to disable opentelemetry.