### PR TITLE
fix: actual RFC file extensions/locations + tests

### DIFF
--- a/ietf/api/routers.py
+++ b/ietf/api/routers.py
@@ -1,7 +1,5 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 """Custom django-rest-framework routers"""
-from typing import Protocol
-
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework import routers
 

--- a/ietf/api/routers.py
+++ b/ietf/api/routers.py
@@ -1,16 +1,33 @@
 # Copyright The IETF Trust 2024, All Rights Reserved
 """Custom django-rest-framework routers"""
+from typing import Protocol
+
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework import routers
 
-class PrefixedSimpleRouter(routers.SimpleRouter):
-    """SimpleRouter that adds a dot-separated prefix to its basename"""
+
+class PrefixedBasenameMixin:
+    """Mixin to add a prefix to the basename of a rest_framework BaseRouter"""
     def __init__(self, name_prefix="", *args, **kwargs):
         self.name_prefix = name_prefix
         if len(self.name_prefix) == 0 or self.name_prefix[-1] == ".":
             raise ImproperlyConfigured("Cannot use a name_prefix that is empty or ends with '.'")
         super().__init__(*args, **kwargs)
 
-    def get_default_basename(self, viewset):
-        basename = super().get_default_basename(viewset)
-        return f"{self.name_prefix}.{basename}"
+    def register(self, prefix, viewset, basename=None):
+        # Get the superclass "register" method from the class this is mixed-in with.
+        # This avoids typing issues with calling super().register() directly in a
+        # mixin class.
+        super_register = getattr(super(), "register")
+        if not super_register or not callable(super_register):
+            raise TypeError("Must mixin with superclass that has register() method")
+        super_register(prefix, viewset, basename=f"{self.name_prefix}.{basename}")
+
+
+class PrefixedSimpleRouter(PrefixedBasenameMixin, routers.SimpleRouter):
+    """SimpleRouter that adds a dot-separated prefix to its basename"""
+
+
+class PrefixedDefaultRouter(PrefixedBasenameMixin, routers.DefaultRouter):
+    """SimpleRouter that adds a dot-separated prefix to its basename"""
+

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -545,7 +545,14 @@ class RfcFileSerializer(serializers.Serializer):
     # in a ListField, so we use that to convey the file format of each item. There
     # are other options we could consider (e.g., a structured CharField) but this
     # works.
-    allowed_extensions = (".xml", ".txt", ".html", ".txt.pdf")
+    allowed_extensions = (
+        ".html",
+        ".json",
+        ".notprepped.xml",
+        ".pdf",
+        ".txt",
+        ".xml",
+    )
 
     rfc = serializers.SlugRelatedField(
         slug_field="rfc_number",

--- a/ietf/api/tests_views_rpc.py
+++ b/ietf/api/tests_views_rpc.py
@@ -1,37 +1,41 @@
 # Copyright The IETF Trust 2025, All Rights Reserved
 # -*- coding: utf-8 -*-
 
+from django.conf import settings
+from django.db.models import Max
 from django.test.utils import override_settings
 from django.urls import reverse as urlreverse
+from rest_framework.test import APIRequestFactory
 
 from ietf.doc.factories import IndividualDraftFactory
-from ietf.doc.models import RelatedDocument
-from ietf.utils.test_utils import TestCase, reload_db_objects
+from ietf.doc.models import RelatedDocument, Document
+from ietf.utils.test_utils import APITestCase, reload_db_objects
 
 
-class RpcApiTests(TestCase):
+class RpcApiTests(APITestCase):
     @override_settings(APP_API_TOKENS={"ietf.api.views_rpc": ["valid-token"]})
-    def test_api_refs(self):
+    def test_draftviewset_references(self):
+        viewname = "ietf.api.purple_api.draft-references"
+
         # non-existent draft
-        url = urlreverse("ietf.api.views_rpc.rpc_draft_refs", kwargs={"doc_id": 999999})
+        bad_id = Document.objects.aggregate(max_id=Max("id") + 100)["max_id"]
+        url = urlreverse(viewname, kwargs={"doc_id": bad_id})
+        # Without credentials
         r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 403)
+        # Add credentials
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
-        jsondata = r.json()
-        refs = jsondata["references"]
-        self.assertEqual(refs, [])
+        self.assertEqual(r.status_code, 404)
 
         # draft without any normative references
         draft = IndividualDraftFactory()
         draft = reload_db_objects(draft)
-        url = urlreverse(
-            "ietf.api.views_rpc.rpc_draft_refs", kwargs={"doc_id": draft.id}
-        )
+        url = urlreverse(viewname, kwargs={"doc_id": draft.id})
         r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 403)
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
-        jsondata = r.json()
-        refs = jsondata["references"]
+        self.assertEqual(r.status_code, 200)
+        refs = r.json()
         self.assertEqual(refs, [])
 
         # draft without any normative references but with an informative reference
@@ -40,14 +44,12 @@ class RpcApiTests(TestCase):
         RelatedDocument.objects.create(
             source=draft, target=draft_foo, relationship_id="refinfo"
         )
-        url = urlreverse(
-            "ietf.api.views_rpc.rpc_draft_refs", kwargs={"doc_id": draft.id}
-        )
+        url = urlreverse(viewname, kwargs={"doc_id": draft.id})
         r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 403)
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
-        jsondata = r.json()
-        refs = jsondata["references"]
+        self.assertEqual(r.status_code, 200)
+        refs = r.json()
         self.assertEqual(refs, [])
 
         # draft with a normative reference
@@ -56,14 +58,12 @@ class RpcApiTests(TestCase):
         RelatedDocument.objects.create(
             source=draft, target=draft_bar, relationship_id="refnorm"
         )
-        url = urlreverse(
-            "ietf.api.views_rpc.rpc_draft_refs", kwargs={"doc_id": draft.id}
-        )
+        url = urlreverse(viewname, kwargs={"doc_id": draft.id})
         r = self.client.get(url)
-        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 403)
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
-        jsondata = r.json()
-        refs = jsondata["references"]
+        self.assertEqual(r.status_code, 200)
+        refs = r.json()
         self.assertEqual(len(refs), 1)
         self.assertEqual(refs[0]["id"], draft_bar.id)
         self.assertEqual(refs[0]["name"], draft_bar.name)

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -6,9 +6,10 @@ from django.conf import settings
 from django.urls import include, path
 
 from ietf.api import views_rpc, views_rpc_demo
+from ietf.api.routers import PrefixedDefaultRouter
 from ietf.utils.urls import url
 
-router = routers.DefaultRouter(use_regex_path=False)
+router = PrefixedDefaultRouter(use_regex_path=False, name_prefix="ietf.api.purple_api")
 router.include_format_suffixes = False
 router.register(r"draft", views_rpc.DraftViewSet, basename="draft")
 router.register(r"person", views_rpc.PersonViewSet)

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -1,7 +1,4 @@
 # Copyright The IETF Trust 2023-2025, All Rights Reserved
-
-from rest_framework import routers
-
 from django.conf import settings
 from django.urls import include, path
 

--- a/ietf/api/urls_rpc.py
+++ b/ietf/api/urls_rpc.py
@@ -29,8 +29,16 @@ if settings.SERVER_MODE not in {"production", "test"}:
 urlpatterns = [
     url(r"^doc/drafts_by_names/", views_rpc.DraftsByNamesView.as_view()),
     url(r"^persons/search/", views_rpc.RpcPersonSearch.as_view()),
-    path(r"rfc/publish/", views_rpc.RfcPubNotificationView.as_view()),
-    path(r"rfc/publish/files/", views_rpc.RfcPubFilesView.as_view()),
+    path(
+        r"rfc/publish/",
+        views_rpc.RfcPubNotificationView.as_view(),
+        name="ietf.api.purple_api.notify_rfc_published",
+    ),
+    path(
+        r"rfc/publish/files/",
+        views_rpc.RfcPubFilesView.as_view(),
+        name="ietf.api.purple_api.upload_rfc_files",
+    ),
     path(r"subject/<str:subject_id>/person/", views_rpc.SubjectPersonView.as_view()),
 ]
 

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -8,7 +8,7 @@ from django.core.files.uploadedfile import UploadedFile
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import mixins, parsers, serializers, viewsets, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound, APIException
+from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
@@ -34,7 +34,7 @@ from ietf.api.serializers_rpc import (
     NotificationAckSerializer, RfcPubSerializer, RfcFileSerializer,
     EditableRfcSerializer,
 )
-from ietf.doc.models import Document, DocHistory, RfcAuthor, EditedRfcAuthorsDocEvent
+from ietf.doc.models import Document, DocHistory, RfcAuthor
 from ietf.doc.serializers import RfcAuthorSerializer
 from ietf.person.models import Email, Person
 

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -367,6 +367,15 @@ class RfcPubFilesView(APIView):
     api_key_endpoint = "ietf.api.views_rpc"
     parser_classes = [parsers.MultiPartParser]
 
+    def _destination(self, filename: str | Path) -> Path:
+        """Destination for an uploaded RFC file
+        
+        Strips any path components in filename and returns an absolute Path.
+        """
+        rfc_path = Path(settings.RFC_PATH)
+        filename = Path(filename)  # could potentially have directory components
+        return rfc_path / filename.name
+
     @extend_schema(
         operation_id="upload_rfc_files",
         summary="Upload files for a published RFC",
@@ -383,11 +392,10 @@ class RfcPubFilesView(APIView):
         uploaded_files: list[UploadedFile] = serializer.validated_data["contents"]
         replace = serializer.validated_data["replace"]
         dest_stem = f"rfc{rfc.rfc_number}"
-        dest_path = Path(settings.RFC_PATH)
 
         # List of files that might exist for an RFC
         possible_rfc_files = [
-            (dest_path / dest_stem).with_suffix(ext)
+            self._destination(dest_stem + ext)
             for ext in serializer.allowed_extensions
         ]
         if not replace:
@@ -400,23 +408,24 @@ class RfcPubFilesView(APIView):
                     )
 
         with TemporaryDirectory() as tempdir:
-            # save files with desired names in a temporary directory
+            # Save files in a temporary directory. Use the uploaded filename
+            # extensions to identify files, but ignore the stems and generate our own.
             files_to_move: list[Path] = []
             tmpfile_stem = Path(tempdir) / dest_stem
             for upfile in uploaded_files:
-                uploaded_filename = Path(upfile.name)
+                uploaded_filename = Path(upfile.name)  # name supplied by request
                 uploaded_ext = "".join(uploaded_filename.suffixes)
-                dest_filename = tmpfile_stem.with_suffix(uploaded_ext)
-                with dest_filename.open("wb") as dest:
+                tempfile_path = tmpfile_stem.with_suffix(uploaded_ext)
+                with tempfile_path.open("wb") as dest:
                     for chunk in upfile.chunks():
                         dest.write(chunk)
-                files_to_move.append(dest_filename)
+                files_to_move.append(tempfile_path)
             # copy files to final location, removing any existing ones first if the
             # remove flag was set
             if replace:
                 for possible_existing_file in possible_rfc_files:
                     possible_existing_file.unlink(missing_ok=True)
             for ftm in files_to_move:
-                shutil.move(ftm, dest_path)
+                shutil.move(ftm, self._destination(ftm))
 
         return Response(NotificationAckSerializer().data)

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -430,5 +430,6 @@ class RfcPubFilesView(APIView):
                     possible_existing_file.unlink(missing_ok=True)
             for ftm in files_to_move:
                 shutil.move(ftm, self._destination(ftm))
+                # todo store in blob storage as well (need a bucket for RFCs)
 
         return Response(NotificationAckSerializer().data)

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -374,6 +374,9 @@ class RfcPubFilesView(APIView):
         """
         rfc_path = Path(settings.RFC_PATH)
         filename = Path(filename)  # could potentially have directory components
+        extension = "".join(filename.suffixes)
+        if extension == ".notprepped.xml":
+            return rfc_path / "prerelease" / filename.name
         return rfc_path / filename.name
 
     @extend_schema(

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -10,7 +10,6 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import BasePermission
 from rest_framework.viewsets import GenericViewSet
 
-from drf_spectacular.utils import extend_schema
 from ietf.group.models import Group
 from ietf.name.models import StreamName, DocTypeName
 from ietf.utils.timezone import RPC_TZINFO

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -19,7 +19,6 @@ from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.contrib import messages
 from django.core.cache import caches
-from django.db import transaction
 from django.db.models import OuterRef
 from django.forms import ValidationError
 from django.http import Http404

--- a/ietf/nomcom/utils.py
+++ b/ietf/nomcom/utils.py
@@ -27,7 +27,7 @@ from django.template.loader import render_to_string
 from django.shortcuts import get_object_or_404
 
 from ietf.dbtemplate.models import DBTemplate
-from ietf.doc.models import DocEvent, NewRevisionDocEvent, State, Document
+from ietf.doc.models import DocEvent, NewRevisionDocEvent, Document
 from ietf.group.models import Group, Role
 from ietf.person.models import Email, Person
 from ietf.mailtrigger.utils import gather_address_lists
@@ -35,7 +35,7 @@ from ietf.meeting.models import Meeting
 from ietf.meeting.utils import participants_for_meeting
 from ietf.utils.pipe import pipe
 from ietf.utils.mail import send_mail_text, send_mail, get_payload_text
-from ietf.utils.log import assertion, log
+from ietf.utils.log import log
 from ietf.person.name import unidecode_name
 from ietf.utils.timezone import date_today, datetime_from_date, DEADLINE_TZINFO
 

--- a/ietf/utils/test_utils.py
+++ b/ietf/utils/test_utils.py
@@ -38,6 +38,7 @@ import tempfile
 import re
 import email
 import html5lib
+import rest_framework.test
 import requests_mock
 import shutil
 import sys
@@ -312,3 +313,11 @@ class TestCase(django.test.TestCase):
             shutil.rmtree(dir)
         self.requests_mock.stop()
         super().tearDown()
+
+
+class APITestCase(TestCase):
+    """Test case that uses rest_framework's APIClient
+    
+    This is equivalent to rest_framework.test.APITestCase, but picks up our 
+    """
+    client_class = rest_framework.test.APIClient


### PR DESCRIPTION
Functional changes:
* accept the actual RFC publication file extensions
* put the `.notprepped.xml` file in the `prerelease/` subdirectory

Refactors:
* better naming/readability of the temp file handling when accepting uploaded RFC files
* fixed up the DRF routers / API view names to be more consistent

Tests:
* added tests of the RFC publication APIs
* fixed the broken references test

This almost gets tests working for me. There are some mypy failures left, but they're fighting back enough I'll leave them for another PR.

This PR allows https://github.com/ietf-tools/purple/pull/711 to work
