### PR TITLE
chore: order is_auth'd middleware correctly

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -451,6 +451,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "ietf.middleware.is_authenticated_header_middleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     # comment in this to get logging of SQL insert and update statements:
@@ -461,7 +462,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "ietf.middleware.unicode_nfkc_normalization_middleware",
-    "ietf.middleware.is_authenticated_header_middleware",
 ]
 
 ROOT_URLCONF = 'ietf.urls'


### PR DESCRIPTION
Needs to be earlier than ConditionalGetMiddleware or the flag will not be set for 304 responses.