### PR TITLE
feat: api key for red api

### DIFF
--- a/dev/deploy-to-container/settings_local.py
+++ b/dev/deploy-to-container/settings_local.py
@@ -72,6 +72,7 @@ SLIDE_STAGING_PATH = '/test/staging/'
 DE_GFM_BINARY = '/usr/local/bin/de-gfm'
 
 APP_API_TOKENS = {
+  "ietf.api.red_api" : ["redtoken"],  # Not a real secret
   "ietf.api.views.ingest_email_test": ["ingestion-test-token"],  # Not a real secret
   "ietf.api.views_rpc" : ["devtoken"],  # Not a real secret
 }

--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -102,5 +102,6 @@ for storagename in ARTIFACT_STORAGE_NAMES:
     }
 
 APP_API_TOKENS = {
+    "ietf.api.red_api" : ["redtoken"],  # Not a real secret
     "ietf.api.views_rpc" : ["devtoken"],  # Not a real secret
 }

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2024-2025, All Rights Reserved
+# Copyright The IETF Trust 2024-2026, All Rights Reserved
 """Doc API implementations"""
 
 from django.db.models import OuterRef, Subquery, Prefetch, Value, JSONField, QuerySet
@@ -7,7 +7,6 @@ from django_filters import rest_framework as filters
 from rest_framework import filters as drf_filters
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.permissions import BasePermission
 from rest_framework.viewsets import GenericViewSet
 
 from ietf.group.models import Group
@@ -144,7 +143,7 @@ def augment_rfc_queryset(queryset: QuerySet[Document]):
 
 
 class RfcViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
-    permission_classes: list[BasePermission] = []
+    api_key_endpoint = "ietf.api.red_api"  # matches prefix in ietf/api/urls.py
     lookup_field = "rfc_number"
     queryset = augment_rfc_queryset(
         Document.objects.filter(type_id="rfc", rfc_number__isnull=False)
@@ -185,7 +184,7 @@ class SubseriesFilter(filters.FilterSet):
 
 
 class SubseriesViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
-    permission_classes: list[BasePermission] = []
+    api_key_endpoint = "ietf.api.red_api"  # matches prefix in ietf/api/urls.py
     lookup_field = "name"
     serializer_class = SubseriesDocSerializer
     queryset = Document.objects.subseries_docs().prefetch_related(


### PR DESCRIPTION
We'll need to arrange for the red API client to include an api key header before deploying this.