### PR TITLE
fix: doc property authors needs refactoring

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -78,16 +78,16 @@ class AuthorPersonSerializer(serializers.ModelSerializer):
 
 
 class RfcWithAuthorsSerializer(serializers.ModelSerializer):
-    author_persons = AuthorPersonSerializer(many=True)
+    authors = AuthorPersonSerializer(many=True, source="author_persons")
 
     class Meta:
         model = Document
-        fields = ["rfc_number", "author_persons"]
+        fields = ["rfc_number", "authors"]
 
 
 class DraftWithAuthorsSerializer(serializers.ModelSerializer):
     draft_name = serializers.CharField(source="name")
-    authors = AuthorPersonSerializer(many=True)
+    authors = AuthorPersonSerializer(many=True, source="author_persons")
 
     class Meta:
         model = Document
@@ -242,6 +242,7 @@ class EditableRfcSerializer(serializers.ModelSerializer):
 
 
 class RfcPubSerializer(serializers.ModelSerializer):
+    """Write-only serializer for RFC publication"""
     # publication-related fields
     published = serializers.DateTimeField(default_timezone=datetime.timezone.utc)
     draft_name = serializers.RegexField(
@@ -295,6 +296,7 @@ class RfcPubSerializer(serializers.ModelSerializer):
             regex=r"^(bcp|std|fyi)[1-9][0-9]{0,4}$", 
         )
     )
+    # N.b., authors is _not_ a field on Document!
     authors = RfcAuthorSerializer(many=True)
 
     class Meta:

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -78,11 +78,11 @@ class AuthorPersonSerializer(serializers.ModelSerializer):
 
 
 class RfcWithAuthorsSerializer(serializers.ModelSerializer):
-    authors = AuthorPersonSerializer(many=True)
+    author_persons = AuthorPersonSerializer(many=True)
 
     class Meta:
         model = Document
-        fields = ["rfc_number", "authors"]
+        fields = ["rfc_number", "author_persons"]
 
 
 class DraftWithAuthorsSerializer(serializers.ModelSerializer):

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -15,7 +15,7 @@ from .models import Document, DocumentAuthor, RfcAuthor
 
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
-    """Serializer for a DocumentAuthor in a response"""
+    """Serializer for an RfcAuthor / DocumentAuthor in a response"""
     datatracker_person_path = serializers.URLField(
         source="person.get_absolute_url",
         required=False,

--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -1268,7 +1268,7 @@ def process_submission_text(filename, revision):
     if title:
         title = _normalize_title(title)
 
-    # Translation taable drops \r, \n, <, >.
+    # Translation table drops \r, \n, <, >.
     trans_table = str.maketrans("", "", "\r\n<>")
     authors = [
         {


### PR DESCRIPTION
relates to https://github.com/ietf-tools/datatracker/pull/10237

currently, endpoint `POST /api/purple/rfc/bulk_authors/` is broken