### PR TITLE
feat: more clickable message admin

### DIFF
--- a/ietf/message/admin.py
+++ b/ietf/message/admin.py
@@ -27,7 +27,8 @@ class MessageSentStatusListFilter(admin.SimpleListFilter):
 
 
 class MessageAdmin(admin.ModelAdmin):
-    list_display = ["sent_status", "subject", "by", "time", "groups"]
+    list_display = ["sent_status", "display_subject", "by", "time", "groups"]
+    list_display_links = ["display_subject"]
     search_fields = ["subject", "body"]
     raw_id_fields = ["by", "related_groups", "related_docs"]
     list_filter = [
@@ -36,6 +37,10 @@ class MessageAdmin(admin.ModelAdmin):
     ]
     ordering = ["-time"]
     actions = ["retry_send"]
+
+    @admin.display(description="Subject", empty_value="(no subject)")
+    def display_subject(self, instance):
+        return instance.subject or None  # None triggers the empty_value
 
     def groups(self, instance):
         return ", ".join(g.acronym for g in instance.related_groups.all())


### PR DESCRIPTION
Uses the subject instead of the "sent" icon as a link to the message instance. Adds a `display_subject` to ensure even messages that have no subject can still be clicked.