### PR TITLE
feat: speed up agenda.ics; cache more agenda data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,10 +62,6 @@ services:
         image: ghcr.io/ietf-tools/static:latest
         restart: unless-stopped
 
-    memcache:
-        image: memcached:1.6-alpine
-        restart: unless-stopped
-
     mq:
         image: rabbitmq:3-alpine
         restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,10 @@ services:
         image: ghcr.io/ietf-tools/static:latest
         restart: unless-stopped
 
+    memcache:
+        image: memcached:1.6-alpine
+        restart: unless-stopped
+
     mq:
         image: rabbitmq:3-alpine
         restart: unless-stopped

--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -33,7 +33,7 @@ def agenda_data_refresh(num=None):
 
 
 @shared_task
-def agenda_data_refresh_all(*, batch_size=10):
+def agenda_data_refresh_all_task(*, batch_size=10):
     """Refresh agenda data for all plenary meetings
 
     Executes as a chain of tasks, each computing up to `batch_size` meetings

--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -31,7 +31,12 @@ def agenda_data_refresh_task(num=None):
     log.log(
         f"Refreshing agenda data for {f"IETF-{num}" if num else "current IETF meeting"}"
     )
-    generate_agenda_data(num, force_refresh=True)
+    try:
+        generate_agenda_data(num, force_refresh=True)
+    except Exception as err:
+        # Log and swallow exceptions so failure on one meeting won't break a chain of
+        # tasks. This is used by agenda_data_refresh_all_task().
+        log.log(f"ERROR: Refreshing agenda data failed for num={num}: {err}")
 
 
 @shared_task

--- a/ietf/meeting/tasks.py
+++ b/ietf/meeting/tasks.py
@@ -23,13 +23,25 @@ from .utils import fetch_attendance_from_meetings
 
 
 @shared_task
-def agenda_data_refresh(num=None):
+def agenda_data_refresh_task(num=None):
     """Refresh agenda data for one plenary meeting
 
     If `num` is `None`, refreshes data for the current meeting.
     """
-    log.log(f"Refreshing agenda data for IETF-{num}")
+    log.log(
+        f"Refreshing agenda data for {f"IETF-{num}" if num else "current IETF meeting"}"
+    )
     generate_agenda_data(num, force_refresh=True)
+
+
+@shared_task
+def agenda_data_refresh():
+    """Deprecated. Use agenda_data_refresh_task() instead.
+    
+    TODO remove this after switching the periodic task to the new name
+    """
+    log.log("Deprecated agenda_data_refresh task called!")
+    agenda_data_refresh_task()
 
 
 @shared_task
@@ -50,7 +62,7 @@ def agenda_data_refresh_all_task(*, batch_size=10):
     # at a time.
     batched_task_chain = chain(
         *(
-            agenda_data_refresh.map(nums)
+            agenda_data_refresh_task.map(nums)
             for nums in batched(meeting_numbers, batch_size)
         )
     )

--- a/ietf/meeting/tests_tasks.py
+++ b/ietf/meeting/tests_tasks.py
@@ -5,7 +5,11 @@ from unittest.mock import patch, call
 from ietf.utils.test_utils import TestCase
 from ietf.utils.timezone import date_today
 from .factories import MeetingFactory
-from .tasks import proceedings_content_refresh_task, agenda_data_refresh
+from .tasks import (
+    proceedings_content_refresh_task,
+    agenda_data_refresh,
+    agenda_data_refresh_all_task,
+)
 from .tasks import fetch_meeting_attendance_task
 
 
@@ -14,14 +18,38 @@ class TaskTests(TestCase):
     def test_agenda_data_refresh(self, mock_generate):
         agenda_data_refresh()
         self.assertTrue(mock_generate.called)
-        self.assertEqual(mock_generate.call_args, call(force_refresh=True))
+        self.assertEqual(mock_generate.call_args, call(None, force_refresh=True))
+
+    @patch("ietf.meeting.tasks.agenda_data_refresh")
+    @patch("ietf.meeting.tasks.chain")
+    def test_agenda_data_refresh_all_task(self, mock_chain, mock_agenda_data_refresh):
+        # Patch the agenda_data_refresh task with a mock whose `.map` attribute
+        # converts its argument, which is expected to be an iterator,  to a list
+        # and returns it. We'll use this to check that the expected task chain
+        # was set up, but we don't actually run any celery tasks.
+        mock_agenda_data_refresh.map.side_effect = lambda x: list(x)
+
+        meetings = MeetingFactory.create_batch(5, type_id="ietf")
+        numbers = sorted(int(m.number) for m in meetings)
+        agenda_data_refresh_all_task(batch_size=2)
+        self.assertTrue(mock_chain.called)
+        self.assertEqual(
+            mock_chain.call_args,
+            call(
+                [numbers[0], numbers[1]],
+                [numbers[2], numbers[3]],
+                [numbers[4]],
+            ),
+        )
+        self.assertEqual(mock_agenda_data_refresh.call_count, 0)
+        self.assertEqual(mock_agenda_data_refresh.map.call_count, 3)
 
     @patch("ietf.meeting.tasks.generate_proceedings_content")
     def test_proceedings_content_refresh_task(self, mock_generate):
         # Generate a couple of meetings
         meeting120 = MeetingFactory(type_id="ietf", number="120")  # 24 * 5
         meeting127 = MeetingFactory(type_id="ietf", number="127")  # 24 * 5 + 7
-        
+
         # Times to be returned
         now_utc = datetime.datetime.now(tz=datetime.UTC)
         hour_00_utc = now_utc.replace(hour=0)
@@ -34,19 +62,19 @@ class TaskTests(TestCase):
         self.assertEqual(mock_generate.call_count, 1)
         self.assertEqual(mock_generate.call_args, call(meeting120, force_refresh=True))
         mock_generate.reset_mock()
-    
+
         # hour 01 - should call no meetings
         with patch("ietf.meeting.tasks.timezone.now", return_value=hour_01_utc):
             proceedings_content_refresh_task()
         self.assertEqual(mock_generate.call_count, 0)
-    
+
         # hour 07 - should call meeting with number % 24 == 0
         with patch("ietf.meeting.tasks.timezone.now", return_value=hour_07_utc):
             proceedings_content_refresh_task()
         self.assertEqual(mock_generate.call_count, 1)
         self.assertEqual(mock_generate.call_args, call(meeting127, force_refresh=True))
         mock_generate.reset_mock()
-        
+
         # With all=True, all should be called regardless of time. Reuse hour_01_utc which called none before
         with patch("ietf.meeting.tasks.timezone.now", return_value=hour_01_utc):
             proceedings_content_refresh_task(all=True)
@@ -61,10 +89,10 @@ class TaskTests(TestCase):
             MeetingFactory(type_id="ietf", date=today - datetime.timedelta(days=3)),
         ]
         data = {
-            'created': 1,
-            'updated': 2,
-            'deleted': 0,
-            'processed': 3,
+            "created": 1,
+            "updated": 2,
+            "deleted": 0,
+            "processed": 3,
         }
 
         mock_fetch_attendance.return_value = [data, data]

--- a/ietf/meeting/tests_tasks.py
+++ b/ietf/meeting/tests_tasks.py
@@ -7,7 +7,7 @@ from ietf.utils.timezone import date_today
 from .factories import MeetingFactory
 from .tasks import (
     proceedings_content_refresh_task,
-    agenda_data_refresh,
+    agenda_data_refresh_task,
     agenda_data_refresh_all_task,
 )
 from .tasks import fetch_meeting_attendance_task
@@ -16,14 +16,14 @@ from .tasks import fetch_meeting_attendance_task
 class TaskTests(TestCase):
     @patch("ietf.meeting.tasks.generate_agenda_data")
     def test_agenda_data_refresh(self, mock_generate):
-        agenda_data_refresh()
+        agenda_data_refresh_task()
         self.assertTrue(mock_generate.called)
         self.assertEqual(mock_generate.call_args, call(None, force_refresh=True))
 
-    @patch("ietf.meeting.tasks.agenda_data_refresh")
+    @patch("ietf.meeting.tasks.agenda_data_refresh_task")
     @patch("ietf.meeting.tasks.chain")
     def test_agenda_data_refresh_all_task(self, mock_chain, mock_agenda_data_refresh):
-        # Patch the agenda_data_refresh task with a mock whose `.map` attribute
+        # Patch the agenda_data_refresh_task task with a mock whose `.map` attribute
         # converts its argument, which is expected to be an iterator,  to a list
         # and returns it. We'll use this to check that the expected task chain
         # was set up, but we don't actually run any celery tasks.

--- a/ietf/meeting/tests_tasks.py
+++ b/ietf/meeting/tests_tasks.py
@@ -15,10 +15,19 @@ from .tasks import fetch_meeting_attendance_task
 
 class TaskTests(TestCase):
     @patch("ietf.meeting.tasks.generate_agenda_data")
-    def test_agenda_data_refresh(self, mock_generate):
+    def test_agenda_data_refresh_task(self, mock_generate):
         agenda_data_refresh_task()
         self.assertTrue(mock_generate.called)
         self.assertEqual(mock_generate.call_args, call(None, force_refresh=True))
+        
+        mock_generate.reset_mock()
+        mock_generate.side_effect = RuntimeError
+        try:
+            agenda_data_refresh_task()
+        except Exception as err:
+            self.fail(
+                f"agenda_data_refresh_task should not raise exceptions (got {repr(err)})"
+            )
 
     @patch("ietf.meeting.tasks.agenda_data_refresh_task")
     @patch("ietf.meeting.tasks.chain")

--- a/ietf/meeting/tests_tasks.py
+++ b/ietf/meeting/tests_tasks.py
@@ -42,6 +42,9 @@ class TaskTests(TestCase):
         numbers = sorted(int(m.number) for m in meetings)
         agenda_data_refresh_all_task(batch_size=2)
         self.assertTrue(mock_chain.called)
+        # The lists in the call() below are the output of the lambda we patched in
+        # via mock_agenda_data_refresh.map.side_effect above. I.e., this tests that
+        # map() was called with the correct batched data.
         self.assertEqual(
             mock_chain.call_args,
             call(

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2600,11 +2600,9 @@ def agenda_ical(request, num=None, acronym=None, session_id=None):
     else:
         meeting = get_meeting(num, type_in=None)  # get requested meeting, whatever its type
 
-    if meeting.type_id == "ietf" and request.GET.get("precomp"):  # todo enable without get param
-        print("precomp")
+    if meeting.type_id == "ietf":
         try:
-            # todo simplify the next line - only needed to strip out the precomp debug param
-            filt_params = parse_agenda_filter_params({k: v for k, v in request.GET.items() if k != "precomp"})
+            filt_params = parse_agenda_filter_params(request.GET)
         except ValueError as e:
             return HttpResponseBadRequest(str(e))
         agenda_data = generate_agenda_data(meeting.number, force_refresh=False)

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2000,7 +2000,7 @@ def agenda_extract_schedule (item):
             "showAgenda": True if (item.session.agenda() is not None or item.session.remote_instructions) else False
         },
         "agenda": {
-            "url": item.session.agenda().get_href()
+            "url": item.session.agenda().get_versionless_href()
         } if item.session.agenda() is not None else {
             "url": None
         },
@@ -2419,7 +2419,6 @@ def generate_agenda_ical_precomp(agenda_data):
                 description_parts.append(f"See in schedule: {agenda_url}#row-{slug}")
 
         if item["agenda"] and item["agenda"]["url"]:
-            # todo was get_versionless_href()
             description_parts.append(f"Agenda {item["agenda"]["url"]}")
 
         # Join all description parts with 2 newlines

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -2600,6 +2600,9 @@ def agenda_ical(request, num=None, acronym=None, session_id=None):
     else:
         meeting = get_meeting(num, type_in=None)  # get requested meeting, whatever its type
 
+    if isinstance(session_id, str) and session_id.isdigit():
+        session_id = int(session_id)
+
     if meeting.type_id == "ietf":
         try:
             filt_params = parse_agenda_filter_params(request.GET)

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1519,11 +1519,17 @@ if SERVER_MODE != 'production':
         NOMCOM_APP_SECRET = b'\x9b\xdas1\xec\xd5\xa0SI~\xcb\xd4\xf5t\x99\xc4i\xd7\x9f\x0b\xa9\xe8\xfeY\x80$\x1e\x12tN:\x84'
 
     ALLOWED_HOSTS = ['*',]
-    
+
     try:
         # see https://github.com/omarish/django-cprofile-middleware
-        import django_cprofile_middleware # pyflakes:ignore
-        MIDDLEWARE = MIDDLEWARE + ['django_cprofile_middleware.middleware.ProfilerMiddleware', ]
+        import django_cprofile_middleware  # pyflakes:ignore
+
+        MIDDLEWARE = MIDDLEWARE + [
+            "django_cprofile_middleware.middleware.ProfilerMiddleware",
+        ]
+        DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF = (
+            False  # Do not use this setting for a public site!
+        )
     except ImportError:
         pass
 

--- a/ietf/settings_testcrawl.py
+++ b/ietf/settings_testcrawl.py
@@ -27,6 +27,9 @@ CACHES = {
             'MAX_ENTRIES': 10000,
         },
     },
+    'agenda': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
     'proceedings': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -306,6 +306,16 @@ CACHES = {
             f"{key_prefix}:{version}:{sha384(str(key).encode('utf8')).hexdigest()}"
         ),
     },
+    "agenda": {
+        "BACKEND": "ietf.utils.cache.LenientMemcacheCache",
+        "LOCATION": f"{MEMCACHED_HOST}:{MEMCACHED_PORT}",
+        # No release-specific VERSION setting.
+        "KEY_PREFIX": "ietf:dt:agenda",
+        # Key function is default except with sha384-encoded key
+        "KEY_FUNCTION": lambda key, key_prefix, version: (
+            f"{key_prefix}:{version}:{sha384(str(key).encode('utf8')).hexdigest()}"
+        ),
+    },
     "proceedings": {
         "BACKEND": "ietf.utils.cache.LenientMemcacheCache",
         "LOCATION": f"{MEMCACHED_HOST}:{MEMCACHED_PORT}",


### PR DESCRIPTION
Speeds up agenda.ics endpoints for full IETF meetings to near instant. Assuming we keep the caches warm as intended, it will also speed up all agenda page loads. The updates do not affect interim meetings, only `type_id="ietf"`.

* Refactors the `agenda_ical()` and its helpers to use the same precomputed data that is supplied to the agenda-neue frontend.
* Adds agenda caching for all meetings, not just the current meeting, with a week-scale cache lifetime for non-current meetings.
* Changes the ical links to use versionless agenda hrefs so they'll always point to the current revision.
* Adds a task to populate/refresh the cache for all meetings so it will always be warm.
* Renames `agenda_data_refresh` to `agenda_data_refresh_task` (keeps/deprecates old task until we deploy and update our config to use the new name)
* Fixes #10355

I propose that we continue refreshing the agenda data for the "current" meeting every 5 minutes but only weekly for other meetings. That was assumed in choosing the new constants in `settings.py`. This does not add a mechanism for invalidating the cache dynamically if the agenda is changed. A change like that will need a manual cache refresh if waiting for the next regular refresh is not acceptable.

Note: The cache is kept in memcache. Data for each meeting is 200-300 kB, so it fits well within memcache's size limit. Restarting memcached will lose cached data, though. I think this is acceptable because memcached restarts are rare and the cache will recover on its own as requests come in, usually with at most one slow request per meeting.