### PR TITLE
feat: format+has_errata, drop see_also for red API

### DIFF
--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -1,7 +1,17 @@
 # Copyright The IETF Trust 2024-2026, All Rights Reserved
 """Doc API implementations"""
 
-from django.db.models import OuterRef, Subquery, Prefetch, Value, JSONField, QuerySet
+from django.db.models import (
+    BooleanField,
+    Count,
+    JSONField,
+    OuterRef,
+    Prefetch,
+    Q,
+    QuerySet,
+    Subquery,
+    Value,
+)
 from django.db.models.functions import TruncDate
 from django_filters import rest_framework as filters
 from rest_framework import filters as drf_filters
@@ -133,11 +143,19 @@ def augment_rfc_queryset(queryset: QuerySet[Document]):
         )
         .annotate(published=TruncDate("published_datetime", tzinfo=RPC_TZINFO))
         .annotate(
+            has_errata=Count(
+                "tags",
+                filter=Q(
+                    tags__slug="verified-errata",
+                ),
+                output_field=BooleanField(),
+            )
+        )
+        .annotate(
             # TODO implement these fake fields for real
             see_also=Value([], output_field=JSONField()),
             formats=Value(["txt", "xml"], output_field=JSONField()),
             keywords=Value(["keyword"], output_field=JSONField()),
-            errata=Value([], output_field=JSONField()),
         )
     )
 

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -153,8 +153,7 @@ def augment_rfc_queryset(queryset: QuerySet[Document]):
             )
         )
         .annotate(
-            # TODO implement these fake fields for real
-            see_also=Value([], output_field=JSONField()),
+            # TODO implement this fake field for real
             keywords=Value(["keyword"], output_field=JSONField()),
         )
     )

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -155,7 +155,6 @@ def augment_rfc_queryset(queryset: QuerySet[Document]):
         .annotate(
             # TODO implement these fake fields for real
             see_also=Value([], output_field=JSONField()),
-            formats=Value(["txt", "xml"], output_field=JSONField()),
             keywords=Value(["keyword"], output_field=JSONField()),
         )
     )

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -143,6 +143,7 @@ def augment_rfc_queryset(queryset: QuerySet[Document]):
         )
         .annotate(published=TruncDate("published_datetime", tzinfo=RPC_TZINFO))
         .annotate(
+            # Count of "verified-errata" tags will be 1 or 0, convert to Boolean
             has_errata=Count(
                 "tags",
                 filter=Q(

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -1292,7 +1292,10 @@ class Document(StorableMixin, DocumentInfo):
         if self.type_id != "rfc":
             raise RuntimeError("Only allowed for type=rfc")
         return [
-            Path(object_name).parts[0]
+            {
+                "fmt": Path(object_name).parts[0],
+                "name": object_name,
+            }
             for object_name in StoredObject.objects.filter(
                 store="rfc", doc_name=self.name, doc_rev=self.rev
             ).values_list("name", flat=True)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -1284,6 +1284,21 @@ class Document(StorableMixin, DocumentInfo):
         iesg_state = self.get_state('draft-iesg')
         return iesg_state and iesg_state.slug != 'idexists'
 
+    def formats(self):
+        """List of file formats available
+        
+        Only implemented for RFCs. Relies on StoredObject.
+        """
+        if self.type_id != "rfc":
+            raise RuntimeError("Only allowed for type=rfc")
+        return [
+            Path(object_name).parts[0]
+            for object_name in StoredObject.objects.filter(
+                store="rfc", doc_name=self.name, doc_rev=self.rev
+            ).values_list("name", flat=True)
+        ]
+
+
 class DocumentURL(models.Model):
     doc  = ForeignKey(Document)
     tag  = ForeignKey(DocUrlTagName)

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -210,7 +210,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     see_also = serializers.ListField(child=serializers.CharField(), read_only=True)
     formats = serializers.MultipleChoiceField(choices=RFC_FORMATS)
     keywords = serializers.ListField(child=serializers.CharField(), read_only=True)
-    errata = serializers.ListField(child=serializers.CharField(), read_only=True)
+    has_errata = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = Document
@@ -235,7 +235,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "abstract",
             "formats",
             "keywords",
-            "errata",
+            "has_errata",
         ]
 
 

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -16,6 +16,7 @@ from .models import Document, DocumentAuthor, RfcAuthor
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
     """Serializer for an RfcAuthor / DocumentAuthor in a response"""
+
     datatracker_person_path = serializers.URLField(
         source="person.get_absolute_url",
         required=False,
@@ -36,7 +37,7 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         """instance -> primitive data types
-        
+
         Translates a DocumentAuthor into an equivalent RfcAuthor we can use the same
         serializer for either type.
         """
@@ -87,7 +88,15 @@ class DocIdentifierSerializer(serializers.Serializer):
 
 
 type RfcStatusSlugT = Literal[
-    "std", "ps", "ds", "bcp", "inf", "exp", "hist", "unkn", "not-issued",
+    "std",
+    "ps",
+    "ds",
+    "bcp",
+    "inf",
+    "exp",
+    "hist",
+    "unkn",
+    "not-issued",
 ]
 
 
@@ -188,10 +197,15 @@ class ContainingSubseriesSerializer(serializers.Serializer):
     type = serializers.CharField(source="source.type_id")
 
 
+class RfcFormatSerializer(serializers.Serializer):
+    RFC_FORMATS = ("xml", "txt", "html", "pdf", "ps", "json", "notprepped")
+
+    fmt = serializers.ChoiceField(choices=RFC_FORMATS)
+    name = serializers.CharField(help_text="Name of blob in the blob store")
+
+
 class RfcMetadataSerializer(serializers.ModelSerializer):
     """Serialize metadata of an RFC"""
-
-    RFC_FORMATS = ("xml", "txt", "html", "pdf", "ps", "json", "notprepped")
 
     number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()
@@ -208,7 +222,9 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     updated_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
     subseries = ContainingSubseriesSerializer(many=True, read_only=True)
     see_also = serializers.ListField(child=serializers.CharField(), read_only=True)
-    formats = serializers.MultipleChoiceField(choices=RFC_FORMATS)
+    formats = RfcFormatSerializer(
+        many=True, read_only=True, help_text="Available formats"
+    )
     keywords = serializers.ListField(child=serializers.CharField(), read_only=True)
     has_errata = serializers.BooleanField(read_only=True)
 
@@ -237,7 +253,6 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "keywords",
             "has_errata",
         ]
-
 
     @extend_schema_field(RfcAuthorSerializer(many=True))
     def get_authors(self, doc: Document):

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -245,7 +245,6 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
             "updates",
             "updated_by",
             "subseries",
-            "see_also",
             "draft",
             "abstract",
             "formats",

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -191,7 +191,7 @@ class ContainingSubseriesSerializer(serializers.Serializer):
 class RfcMetadataSerializer(serializers.ModelSerializer):
     """Serialize metadata of an RFC"""
 
-    RFC_FORMATS = ("xml", "txt", "html", "htmlized", "pdf", "ps")
+    RFC_FORMATS = ("xml", "txt", "html", "pdf", "ps", "json", "notprepped")
 
     number = serializers.IntegerField(source="rfc_number")
     published = serializers.DateField()

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -221,7 +221,6 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     updates = RelatedRfcSerializer(many=True, read_only=True)
     updated_by = ReverseRelatedRfcSerializer(many=True, read_only=True)
     subseries = ContainingSubseriesSerializer(many=True, read_only=True)
-    see_also = serializers.ListField(child=serializers.CharField(), read_only=True)
     formats = RfcFormatSerializer(
         many=True, read_only=True, help_text="Available formats"
     )


### PR DESCRIPTION
This pull request cleans up the red RFC list API. Specifically
* replaces the fake (always empty) `errata` list with a boolean `has_errata` flag that is true when the RFC document has the `verified-errata` tag in datatracker
* replaces the fake (always `["txt", "xml"]`) `formats` list with a structured list of available formats and the name of the blob for each format.
* eliminates the `see_also` field

The `formats` section of the response is derived from the `StoredObject` table. It lists _all_ available formats the datatracker has, including json and notprepped. If some of these shouldn't be included in red's output, that decision belongs to red and it should filter them there. It now includes the name of the blob so that red does not have to hard-code the naming convention that datatracker uses.

The `see_also` field will not be used. Subseries memberships are conveyed through the `subseries` value already.

Red should link to the correct errata site page for a URL when `has_errata` is true.

For reference, this is the `formats` section of the updated API for an example RFC:

```json
      "formats": [
        {
          "fmt": "xml",
          "name": "xml/rfc10101.xml"
        },
        {
          "fmt": "txt",
          "name": "txt/rfc10101.txt"
        },
        {
          "fmt": "html",
          "name": "html/rfc10101.html"
        },
        {
          "fmt": "pdf",
          "name": "pdf/rfc10101.pdf"
        },
        {
          "fmt": "json",
          "name": "json/rfc10101.json"
        },
        {
          "fmt": "notprepped",
          "name": "notprepped/rfc10101.notprepped.xml"
        }
      ],
```