### PR TITLE
fix: blank not null for StoredObject doc_name/doc_rev

### DIFF
--- a/ietf/doc/migrations/0031_storedobject_blank_not_null.py
+++ b/ietf/doc/migrations/0031_storedobject_blank_not_null.py
@@ -1,0 +1,24 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("doc", "0030_alter_dochistory_title_alter_document_title"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="storedobject",
+            name="doc_name",
+            field=models.CharField(blank=True, default="", max_length=255),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name="storedobject",
+            name="doc_rev",
+            field=models.CharField(blank=True, default="", max_length=16),
+            preserve_default=False,
+        ),
+    ]

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -827,7 +827,7 @@ class StorableMixin:
         file: Union[File, BufferedReader],
         allow_overwrite: bool = False,
         doc_name: str = "",
-        doc_rev: str = ","
+        doc_rev: str = "",
     ) -> None:
         return utils_store_file(self.type_id, name, file, allow_overwrite, self.name, self.rev)
 

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -1751,8 +1751,8 @@ class StoredObject(models.Model):
         null=False,
         help_text="Last instant object was modified. May not be the same as the storage's modified value for the instance. It will hold mtime for objects imported from older disk storage unless they've actually been overwritten more recently"
     )
-    doc_name = models.CharField(max_length=255, null=True, blank=True)
-    doc_rev = models.CharField(max_length=16, null=True, blank=True)
+    doc_name = models.CharField(max_length=255, null=False, blank=True)
+    doc_rev = models.CharField(max_length=16, null=False, blank=True)
     deleted = models.DateTimeField(null=True)
 
     class Meta:

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -816,8 +816,8 @@ class StorableMixin:
         name: str,
         content: bytes,
         allow_overwrite: bool = False,
-        doc_name: Optional[str] = None,
-        doc_rev: Optional[str] = None
+        doc_name: str = "",
+        doc_rev: str = "",
     ) -> None:
         return utils_store_bytes(self.type_id, name, content, allow_overwrite, self.name, self.rev)
 
@@ -826,8 +826,8 @@ class StorableMixin:
         name: str,
         file: Union[File, BufferedReader],
         allow_overwrite: bool = False,
-        doc_name: Optional[str] = None,
-        doc_rev: Optional[str] = None
+        doc_name: str = "",
+        doc_rev: str = ","
     ) -> None:
         return utils_store_file(self.type_id, name, file, allow_overwrite, self.name, self.rev)
 

--- a/ietf/doc/storage.py
+++ b/ietf/doc/storage.py
@@ -18,7 +18,7 @@ from ietf.utils.timezone import timezone
 
 class StoredObjectFile(MetadataFile):
     """Django storage File object that represents a StoredObject"""
-    def __init__(self, file, name, mtime=None, content_type="", store=None, doc_name=None, doc_rev=None):
+    def __init__(self, file, name, mtime=None, content_type="", store=None, doc_name="", doc_rev=""):
         super().__init__(
             file=file,
             name=name,
@@ -131,12 +131,12 @@ class StoredObjectBlobdbStorage(BlobdbStorage):
                 doc_name=getattr(
                     content,
                     "doc_name",  # Note that these are assumed to be invariant
-                    None,  # should be blank?
+                    "",
                 ),
                 doc_rev=getattr(
                     content,
                     "doc_rev",  # for a given name
-                    None,  # should be blank?
+                    "",
                 ),
             ),
         )

--- a/ietf/doc/storage_utils.py
+++ b/ietf/doc/storage_utils.py
@@ -66,8 +66,8 @@ def store_file(
     name: str,
     file: Union[File, BufferedReader],
     allow_overwrite: bool = False,
-    doc_name: Optional[str] = None,
-    doc_rev: Optional[str] = None,
+    doc_name: str = "",
+    doc_rev: str = "",
     content_type: str="",
     mtime: Optional[datetime.datetime]=None,
 ) -> None:
@@ -106,8 +106,8 @@ def store_bytes(
     name: str,
     content: bytes,
     allow_overwrite: bool = False,
-    doc_name: Optional[str] = None,
-    doc_rev: Optional[str] = None,
+    doc_name: str = "",
+    doc_rev: str = "",
     content_type: str = "",
     mtime: Optional[datetime.datetime] = None,
 ) -> None:
@@ -136,8 +136,8 @@ def store_str(
     name: str,
     content: str,
     allow_overwrite: bool = False,
-    doc_name: Optional[str] = None,
-    doc_rev: Optional[str] = None,
+    doc_name: str = "",
+    doc_rev: str = "",
     content_type: str = "",
     mtime: Optional[datetime.datetime] = None,
 ) -> None:

--- a/ietf/sync/utils.py
+++ b/ietf/sync/utils.py
@@ -42,7 +42,7 @@ def load_rfcs_into_blobdb(numbers: list[int]):
                             content=bytes,
                             allow_overwrite=False,  # Intentionally not allowing overwrite.
                             doc_name=f"rfc{num}",
-                            doc_rev=None,
+                            doc_rev="",
                             # Not setting content_type
                             mtime=datetime.datetime.fromtimestamp(
                                 mtime, tz=datetime.UTC
@@ -65,7 +65,7 @@ def load_rfcs_into_blobdb(numbers: list[int]):
                         content=bytes,
                         allow_overwrite=False,  # Intentionally not allowing overwrite.
                         doc_name=f"rfc{num}",
-                        doc_rev=None,
+                        doc_rev="",
                         # Not setting content_type
                         mtime=datetime.datetime.fromtimestamp(mtime, tz=datetime.UTC),
                     )


### PR DESCRIPTION
Allows matching a doc via `StoredObject.objects.filter(doc_name=doc.name, doc_rev=doc.rev)`, which doesn't work if those fields are `None`. Will want to confirm that the migration is not slow in staging.

Todo before promoting from draft PR:
- [x] Confirm that `StoredObject` does not need explicit defaults for those fields
- [x] Time migration in dev

If / when this is merged, we can roll back #10401.