### PR TITLE
feat: bofreq timestamp fixup task

### DIFF
--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -153,5 +153,5 @@ def rebuild_reference_relations_task(doc_names: list[str]):
 
 
 @shared_task
-def fixup_bofreq_timestamps_task():
+def fixup_bofreq_timestamps_task():  # pragma: nocover
     fixup_bofreq_timestamps()

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2024-2025, All Rights Reserved
+# Copyright The IETF Trust 2024-2026, All Rights Reserved
 #
 # Celery task definitions
 #
@@ -34,6 +34,7 @@ from .utils import (
     ensure_draft_bibxml_path_exists,
     investigate_fragment,
 )
+from .utils_bofreq import fixup_bofreq_timestamps
 
 
 @shared_task
@@ -149,3 +150,8 @@ def rebuild_reference_relations_task(doc_names: list[str]):
             rebuild_reference_relations(doc, filenames)
         else:
             log.log(f"Found no content for {stem}")
+
+
+@shared_task
+def fixup_bofreq_timestamps_task():
+    fixup_bofreq_timestamps()

--- a/ietf/doc/utils_bofreq.py
+++ b/ietf/doc/utils_bofreq.py
@@ -1,12 +1,122 @@
-# Copyright The IETF Trust 2021 All Rights Reserved
+# Copyright The IETF Trust 2021-2026 All Rights Reserved
+import datetime
+from pathlib import Path
 
-from ietf.doc.models import BofreqEditorDocEvent, BofreqResponsibleDocEvent
+from django.conf import settings
+
+from ietf.doc.models import (
+    BofreqEditorDocEvent,
+    BofreqResponsibleDocEvent,
+    DocEvent,
+    DocHistory,
+    Document,
+)
 from ietf.person.models import Person
+
 
 def bofreq_editors(bofreq):
     e = bofreq.latest_event(BofreqEditorDocEvent)
     return e.editors.all() if e else Person.objects.none()
 
+
 def bofreq_responsible(bofreq):
     e = bofreq.latest_event(BofreqResponsibleDocEvent)
     return e.responsible.all() if e else Person.objects.none()
+
+
+def fixup_bofreq_timestamps():
+    """Fixes bofreq event / document timestamps
+
+    Timestamp errors resulted from the bug fixed by
+    https://github.com/ietf-tools/datatracker/pull/10333
+    """
+    FIX_DEPLOYMENT_TIME = "2026-02-03T01:16:00+00:00"  # 12.58.0 -> production
+
+    def _get_doc_time(doc_name: str, rev: str):
+        path = Path(settings.BOFREQ_PATH) / f"{doc_name}-{rev}.md"
+        return datetime.datetime.fromtimestamp(path.stat().st_mtime, datetime.UTC)
+
+    # Find affected DocEvents and DocHistories
+    new_bofreq_events = (
+        DocEvent.objects.filter(
+            doc__type="bofreq", type="new_revision", time__lt=FIX_DEPLOYMENT_TIME
+        )
+        .exclude(rev="00")
+        .order_by("doc__name", "rev")
+    )
+    document_fixups = {}
+    for e in new_bofreq_events:
+        name = e.doc.name
+        rev = e.rev
+        filesystem_time = _get_doc_time(name, rev)
+        assert e.time < filesystem_time, (
+            f"Rev {rev} event timestamp for {name} unexpectedly later than the "
+            "filesystem timestamp!"
+        )
+        try:
+            dochistory = DocHistory.objects.filter(
+                name=name, time__lt=filesystem_time
+            ).get(rev=rev)
+        except DocHistory.MultipleObjectsReturned as err:
+            raise RuntimeError(
+                f"Multiple DocHistories for {name} rev {rev} exist earlier than the "
+                "filesystem timestamp!"
+            ) from err
+        except DocHistory.DoesNotExist as err:
+            if rev == "00":
+                dochistory = None
+            else:
+                raise RuntimeError(
+                    f"No DocHistory for {name} rev {rev} exists earlier than the "
+                    f"filesystem timestamp!"
+                ) from err
+
+        if name not in document_fixups:
+            document_fixups[name] = []
+        document_fixups[name].append(
+            {
+                "event": e,
+                "dochistory": dochistory,
+                "filesystem_time": filesystem_time,
+            }
+        )
+
+    # Now do the actual fixup
+    system_person = Person.objects.get(name="(System)")
+    for doc_name, fixups in document_fixups.items():
+        bofreq = Document.objects.get(type="bofreq", name=doc_name)
+        adjusted_revs = []
+        for fixup in fixups:
+            event_to_fix = fixup["event"]
+            dh_to_fix = fixup["dochistory"]
+            new_time = fixup["filesystem_time"]
+
+            adjusted_revs.append(event_to_fix.rev)
+            if event_to_fix.rev == bofreq.rev and bofreq.time < new_time:
+                # Update the Document without calling save(). Only update if
+                # the time has not changed so we don't inadvertently overwrite
+                # a concurrent update.
+                Document.objects.filter(pk=bofreq.pk, time=bofreq.time).update(
+                    time=new_time
+                )
+                bofreq.refresh_from_db()
+
+            # Fix up the event
+            event_to_fix.time = new_time
+            event_to_fix.save()
+
+            # Fix up the DocHistory
+            dh_to_fix.time = new_time
+            dh_to_fix.save()
+
+        # Fix up the Document, if necessary, and add a record of the adjustment
+        change_event = DocEvent.objects.create(
+            type="added_comment",
+            by=system_person,
+            doc=bofreq,
+            rev=bofreq.rev,
+            desc=(
+                "Corrected inaccurate document and new revision event timestamps for "
+                f"revs {', '.join(adjusted_revs)}"
+            ),
+        )

--- a/ietf/doc/utils_bofreq.py
+++ b/ietf/doc/utils_bofreq.py
@@ -25,7 +25,7 @@ def bofreq_responsible(bofreq):
     return e.responsible.all() if e else Person.objects.none()
 
 
-def fixup_bofreq_timestamps():
+def fixup_bofreq_timestamps():  # pragma: nocover
     """Fixes bofreq event / document timestamps
 
     Timestamp errors resulted from the bug fixed by


### PR DESCRIPTION
Adds a task to fix DocEvent, DocHistory, and Document timestamps for bofreqs affected by #5893. That was fixed for new uploads by #10333 - this fixes up the existing data.

Creates a task to be run once. In dev, takes less than 10 seconds. Emits some ugly logs that record exactly what was touched. A DocEvent comment is added to the Document's history indicating that the fixup occurred and identifying the affected revisions.

Fixes #5893