### PR TITLE
feat: button to push slide decks to Meetecho

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -7350,56 +7350,61 @@ class MaterialsTests(TestCase):
     )  # enough to trigger API calls
     @patch("ietf.meeting.views.SlidesManager")
     def test_notify_meetecho_of_all_slides(self, mock_slides_manager_cls):
-        session = SessionFactory(meeting__type_id="ietf")
-        meeting = session.meeting
+        for meeting_type in ["ietf", "interim"]:
+            # Reset for the sake of the second iteration
+            self.client.logout()
+            mock_slides_manager_cls.reset_mock()
 
-        # bad meeting
-        url = urlreverse(
-            "ietf.meeting.views.notify_meetecho_of_all_slides",
-            kwargs={"num": 9999, "acronym": session.group.acronym},
-        )
-        login_testing_unauthorized(self, "secretary", url)
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 404)
-        r = self.client.post(url)
-        self.assertEqual(r.status_code, 404)
-        self.assertFalse(mock_slides_manager_cls.called)
-        self.client.logout()
-
-        # good meeting
-        url = urlreverse(
-            "ietf.meeting.views.notify_meetecho_of_all_slides",
-            kwargs={"num": meeting.number, "acronym": session.group.acronym},
-        )
-        login_testing_unauthorized(self, "secretary", url)
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 405)
-        self.assertFalse(mock_slides_manager_cls.called)
-        mock_slides_manager = mock_slides_manager_cls.return_value
-        mock_slides_manager.send_update.return_value = True
-        r = self.client.post(url)
-        self.assertEqual(r.status_code, 302)
-        self.assertEqual(mock_slides_manager.send_update.call_count, 1)
-        self.assertEqual(mock_slides_manager.send_update.call_args, call(session))
-        r = self.client.get(r["Location"])
-        messages = list(r.context["messages"])
-        self.assertEqual(len(messages), 1)
-        self.assertEqual(
-            str(messages[0]), f"Notified Meetecho about slides for {session}"
-        )
-
-        mock_slides_manager.send_update.reset_mock()
-        mock_slides_manager.send_update.return_value = False
-        r = self.client.post(url)
-        self.assertEqual(r.status_code, 302)
-        self.assertEqual(mock_slides_manager.send_update.call_count, 1)
-        self.assertEqual(mock_slides_manager.send_update.call_args, call(session))
-        r = self.client.get(r["Location"])
-        messages = list(r.context["messages"])
-        self.assertEqual(len(messages), 1)
-        self.assertIn(
-            "No sessions were eligible for Meetecho slides update.", str(messages[0])
-        )
+            session = SessionFactory(meeting__type_id=meeting_type)
+            meeting = session.meeting
+    
+            # bad meeting
+            url = urlreverse(
+                "ietf.meeting.views.notify_meetecho_of_all_slides",
+                kwargs={"num": 9999, "acronym": session.group.acronym},
+            )
+            login_testing_unauthorized(self, "secretary", url)
+            r = self.client.get(url)
+            self.assertEqual(r.status_code, 404)
+            r = self.client.post(url)
+            self.assertEqual(r.status_code, 404)
+            self.assertFalse(mock_slides_manager_cls.called)
+            self.client.logout()
+    
+            # good meeting
+            url = urlreverse(
+                "ietf.meeting.views.notify_meetecho_of_all_slides",
+                kwargs={"num": meeting.number, "acronym": session.group.acronym},
+            )
+            login_testing_unauthorized(self, "secretary", url)
+            r = self.client.get(url)
+            self.assertEqual(r.status_code, 405)
+            self.assertFalse(mock_slides_manager_cls.called)
+            mock_slides_manager = mock_slides_manager_cls.return_value
+            mock_slides_manager.send_update.return_value = True
+            r = self.client.post(url)
+            self.assertEqual(r.status_code, 302)
+            self.assertEqual(mock_slides_manager.send_update.call_count, 1)
+            self.assertEqual(mock_slides_manager.send_update.call_args, call(session))
+            r = self.client.get(r["Location"])
+            messages = list(r.context["messages"])
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(
+                str(messages[0]), f"Notified Meetecho about slides for {session}"
+            )
+    
+            mock_slides_manager.send_update.reset_mock()
+            mock_slides_manager.send_update.return_value = False
+            r = self.client.post(url)
+            self.assertEqual(r.status_code, 302)
+            self.assertEqual(mock_slides_manager.send_update.call_count, 1)
+            self.assertEqual(mock_slides_manager.send_update.call_args, call(session))
+            r = self.client.get(r["Location"])
+            messages = list(r.context["messages"])
+            self.assertEqual(len(messages), 1)
+            self.assertIn(
+                "No sessions were eligible for Meetecho slides update.", str(messages[0])
+            )
 
 
 @override_settings(IETF_NOTES_URL='https://notes.ietf.org/')

--- a/ietf/meeting/urls.py
+++ b/ietf/meeting/urls.py
@@ -15,6 +15,7 @@ class AgendaRedirectView(RedirectView):
 
 safe_for_all_meeting_types = [
     url(r'^session/(?P<acronym>[-a-z0-9]+)/?$',  views.session_details),
+    url(r'^session/(?P<acronym>[-a-z0-9]+)/send_slide_notifications$',  views.notify_meetecho_of_all_slides),
     url(r'^session/(?P<session_id>\d+)/drafts$',  views.add_session_drafts),
     url(r'^session/(?P<session_id>\d+)/recordings$', views.add_session_recordings),
     url(r'^session/(?P<session_id>\d+)/attendance$', views.session_attendance),
@@ -30,7 +31,7 @@ safe_for_all_meeting_types = [
     url(r'^session/(?P<session_id>\d+)/doc/%(name)s/remove$' % settings.URL_REGEXPS, views.remove_sessionpresentation),
     url(r'^session/(?P<session_id>\d+)\.ics$',    views.agenda_ical),
     url(r'^sessions/(?P<acronym>[-a-z0-9]+)\.ics$', views.agenda_ical),
-    url(r'^slidesubmission/(?P<slidesubmission_id>\d+)$', views.approve_proposed_slides)
+    url(r'^slidesubmission/(?P<slidesubmission_id>\d+)$', views.approve_proposed_slides),
 ]
 
 

--- a/ietf/static/js/session_details.js
+++ b/ietf/static/js/session_details.js
@@ -1,0 +1,53 @@
+// Copyright The IETF Trust 2026, All Rights Reserved
+// Relies on other scripts being loaded, see usage in session_details.html
+document.addEventListener('DOMContentLoaded', () => {
+    // Init with best guess at local timezone.
+    ietf_timezone.set_tz_change_callback(timezone_changed) // cb is in upcoming.js
+    ietf_timezone.initialize('local')
+
+    // Set up sortable elements if the user can manage materials
+    if (document.getElementById('can-manage-materials-flag')) {
+        const sortables = []
+        const options = {
+            group: 'slides',
+            animation: 150,
+            handle: '.drag-handle',
+            onAdd: function (event) {onAdd(event)},
+            onRemove: function (event) {onRemove(event)},
+            onEnd: function (event) {onEnd(event)}
+        }
+
+        function onAdd (event) {
+            const old_session = event.from.getAttribute('data-session')
+            const new_session = event.to.getAttribute('data-session')
+            $.post(event.to.getAttribute('data-add-to-session'), {
+                'order': event.newIndex + 1,
+                'name': event.item.getAttribute('name')
+            })
+            $(event.item).find('td:eq(1)').find('a').each(function () {
+                $(this).attr('href', $(this).attr('href').replace(old_session, new_session))
+            })
+        }
+
+        function onRemove (event) {
+            const old_session = event.from.getAttribute('data-session')
+            $.post(event.from.getAttribute('data-remove-from-session'), {
+                'oldIndex': event.oldIndex + 1,
+                'name': event.item.getAttribute('name')
+            })
+        }
+
+        function onEnd (event) {
+            if (event.to == event.from) {
+                $.post(event.from.getAttribute('data-reorder-in-session'), {
+                    'oldIndex': event.oldIndex + 1,
+                    'newIndex': event.newIndex + 1
+                })
+            }
+        }
+
+        for (const elt of document.querySelectorAll('.slides tbody')) {
+            sortables.push(Sortable.create(elt, options))
+        }
+    }
+})

--- a/ietf/templates/meeting/session_details.html
+++ b/ietf/templates/meeting/session_details.html
@@ -53,12 +53,28 @@
             {% endif %}
         {% if forloop.last %}</div>{% endif %}
     {% endfor %}
+    {% if user|has_role:"Secretariat" %}
+        <div class="card text-dark bg-warning mt-5 mb-3">
+            <div class="card-header">
+                Secretariat Only
+            </div>
+            <div class="card-body">
+                <form method="post"
+                      action="{% url 'ietf.meeting.views.notify_meetecho_of_all_slides' num=meeting.number acronym=group.acronym %}">
+                    {% csrf_token %}
+                    <button class="btn btn-primary" type="submit">
+                        Notify Meetecho of Slides
+                    </button>
+                </form>
+            </div>
+        </div>
+    {% endif %}
     {% comment %}
     The existence of an element with id canManageMaterialsFlag is checked in
     session_details.js to determine whether it should init the sortable tables.
     Not the most elegant approach, but it works.
     {% endcomment %}
-    {% if can_manage_materials %} <div id="canManageMaterialsFlag"></div>{% endif %}
+    {% if can_manage_materials %} <div id="can-manage-materials-flag"></div>{% endif %}
 {% endblock %}
 {% block js %}
     <script src="{% static 'ietf/js/list.js' %}"></script>

--- a/ietf/templates/meeting/session_details.html
+++ b/ietf/templates/meeting/session_details.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{# Copyright The IETF Trust 2015, All Rights Reserved #}
+{# Copyright The IETF Trust 2015-2026, All Rights Reserved #}
 {% load origin ietf_filters static %}
 {% block title %}{{ meeting }} : {{ group.acronym }}{% endblock %}
 {% block morecss %}
@@ -53,69 +53,20 @@
             {% endif %}
         {% if forloop.last %}</div>{% endif %}
     {% endfor %}
+    {% comment %}
+    The existence of an element with id canManageMaterialsFlag is checked in
+    session_details.js to determine whether it should init the sortable tables.
+    Not the most elegant approach, but it works.
+    {% endcomment %}
+    {% if can_manage_materials %} <div id="canManageMaterialsFlag"></div>{% endif %}
 {% endblock %}
 {% block js %}
     <script src="{% static 'ietf/js/list.js' %}"></script>
     <script src="{% static 'ietf/js/moment.js' %}"></script>
     <script src="{% static 'ietf/js/upcoming.js' %}"></script>
     <script src="{% static 'ietf/js/timezone.js' %}"></script>
-    <script>
-    $(function () {
-            // Init with best guess at local timezone.
-            ietf_timezone.set_tz_change_callback(timezone_changed);
-            ietf_timezone.initialize('local');
-    });
-    </script>
     {% if can_manage_materials %}
         <script src="{% static 'ietf/js/sortable.js' %}"></script>
-        <script>
-            var sortables=[];
-            var options = {
-                group: "slides",
-                animation: 150,
-                handle: ".drag-handle",
-                onAdd: function(event) {onAdd(event)},
-                onRemove: function(event) {onRemove(event)},
-                onEnd: function(event) {onEnd(event)}
-            };
-
-            function onAdd(event) {
-                var old_session = event.from.getAttribute("data-session");
-                var new_session = event.to.getAttribute("data-session");
-                $.post(event.to.getAttribute("data-add-to-session"), {
-                    'order': event.newIndex + 1,
-                    'name': event.item.getAttribute("name")
-                });
-                $(event.item).find("td:eq(1)").find("a").each(function(){
-                    $(this).attr("href", $(this).attr("href").replace(old_session,new_session) );
-                });
-            }
-
-            function onRemove(event) {
-                var old_session = event.from.getAttribute("data-session");
-                $.post(event.from.getAttribute("data-remove-from-session"),{
-                    'oldIndex': event.oldIndex + 1,
-                    'name': event.item.getAttribute("name")
-                });
-            }
-
-            function onEnd(event) {
-                if (event.to == event.from) {
-                    $.post(event.from.getAttribute("data-reorder-in-session"),{
-                        'oldIndex': event.oldIndex + 1,
-                        'newIndex': event.newIndex + 1
-                    });
-                }
-            }
-
-            $(document).ready(function() {
-
-                $(".slides tbody").each(function() {
-                    sortables.push(Sortable.create(this, options));
-                });
-
-            });
-
-        </script>
     {% endif %}
+    <script src="{% static 'ietf/js/session_details.js' %}"></script>
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
         "ietf/static/js/moment.js",
         "ietf/static/js/password_strength.js",
         "ietf/static/js/select2.js",
+        "ietf/static/js/session_details.js",
         "ietf/static/js/session_details_form.js",
         "ietf/static/js/session_form.js",
         "ietf/static/js/session_request.js",


### PR DESCRIPTION
Fixes #9235

Adds a button to the bottom of the session details page for a meeting session that sends a slides update to Meetecho for all eligible sessions for the group. Button is only available to the secretariat.

Does a drive-by cleanup to move some inline javascript into the bundle.

<img width="370" height="476" alt="image" src="https://github.com/user-attachments/assets/8448b57f-d5d0-4f01-bf63-bc09101c1357" />
