### PR TITLE
feat: more API fields+filtering; drop RfcAuthor.email field

### DIFF
--- a/ietf/api/tests_views_rpc.py
+++ b/ietf/api/tests_views_rpc.py
@@ -159,7 +159,7 @@ class RpcApiTests(APITestCase):
                     "titlepage_name": f"titlepage {author.name}",
                     "is_editor": False,
                     "person": author,
-                    "email": author.email_address(),
+                    "email": author.email(),
                     "affiliation": "Some Affiliation",
                     "country": "CA",
                 }

--- a/ietf/api/tests_views_rpc.py
+++ b/ietf/api/tests_views_rpc.py
@@ -143,21 +143,22 @@ class RpcApiTests(APITestCase):
         self.assertEqual(rfc.title, "RFC " + draft.title)
         self.assertEqual(rfc.documentauthor_set.count(), 0)
         self.assertEqual(
-            list(
-                rfc.rfcauthor_set.values(
-                    "titlepage_name",
-                    "is_editor",
-                    "person",
-                    "email",
-                    "affiliation",
-                    "country",
-                )
-            ),
+            [
+                {
+                    "titlepage_name": ra.titlepage_name,
+                    "is_editor": ra.is_editor,
+                    "person": ra.person,
+                    "email": ra.email,
+                    "affiliation": ra.affiliation,
+                    "country": ra.country,
+                }
+                for ra in rfc.rfcauthor_set.all()
+            ],
             [
                 {
                     "titlepage_name": f"titlepage {author.name}",
                     "is_editor": False,
-                    "person": author.pk,
+                    "person": author,
                     "email": author.email_address(),
                     "affiliation": "Some Affiliation",
                     "country": "CA",

--- a/ietf/doc/admin.py
+++ b/ietf/doc/admin.py
@@ -242,6 +242,6 @@ admin.site.register(StoredObject, StoredObjectAdmin)
 
 class RfcAuthorAdmin(admin.ModelAdmin):
     list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'country', 'order']
-    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email__address', 'affiliation', 'country']
-    raw_id_fields = ["document", "person", "email"]
+    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email', 'affiliation', 'country']
+    raw_id_fields = ["document", "person"]
 admin.site.register(RfcAuthor, RfcAuthorAdmin)

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -42,10 +42,18 @@ class RfcLimitOffsetPagination(LimitOffsetPagination):
     max_limit = 500
 
 
+class NumberInFilter(filters.BaseInFilter, filters.NumberFilter):
+    """Filter against a comma-separated list of numbers"""
+    pass
+
+
 class RfcFilter(filters.FilterSet):
     published = filters.DateFromToRangeFilter()
     stream = filters.ModelMultipleChoiceFilter(
         queryset=StreamName.objects.filter(used=True)
+    )
+    numbers = NumberInFilter(
+        field_name="rfc_number"
     )
     group = filters.ModelMultipleChoiceFilter(
         queryset=Group.objects.all(),

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -48,7 +48,7 @@ class RfcFilter(filters.FilterSet):
         queryset=StreamName.objects.filter(used=True)
     )
     group = filters.ModelMultipleChoiceFilter(
-        queryset=Group.objects.wgs(),
+        queryset=Group.objects.all(),
         field_name="group__acronym",
         to_field_name="acronym",
     )

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -52,7 +52,7 @@ class RfcFilter(filters.FilterSet):
     stream = filters.ModelMultipleChoiceFilter(
         queryset=StreamName.objects.filter(used=True)
     )
-    numbers = NumberInFilter(
+    number = NumberInFilter(
         field_name="rfc_number"
     )
     group = filters.ModelMultipleChoiceFilter(

--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -391,7 +391,6 @@ class RfcAuthorFactory(factory.django.DjangoModelFactory):
         lambda obj: " ".join([obj.person.initials(), obj.person.last_name()])
     )
     person = factory.SubFactory('ietf.person.factories.PersonFactory')
-    email = factory.LazyAttribute(lambda obj: obj.person.email())
     affiliation = factory.Faker('company')
     order = factory.LazyAttribute(lambda o: o.document.rfcauthor_set.count() + 1)
 

--- a/ietf/doc/migrations/0031_remove_rfcauthor_email.py
+++ b/ietf/doc/migrations/0031_remove_rfcauthor_email.py
@@ -1,0 +1,16 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("doc", "0030_alter_dochistory_title_alter_document_title"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="rfcauthor",
+            name="email",
+        ),
+    ]

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -952,7 +952,7 @@ class RfcAuthor(models.Model):
 
     @property
     def email(self) -> Email | None:
-        return self.person.email() if self.person else ""
+        return self.person.email() if self.person else None
 
 
 class DocumentAuthorInfo(models.Model):

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -937,7 +937,6 @@ class RfcAuthor(models.Model):
     titlepage_name = models.CharField(max_length=128, blank=False)
     is_editor = models.BooleanField(default=False)
     person = ForeignKey(Person, null=True, blank=True, on_delete=models.PROTECT)
-    email = ForeignKey(Email, help_text="Email address used by author for submission", blank=True, null=True, on_delete=models.PROTECT)
     affiliation = models.CharField(max_length=100, blank=True, help_text="Organization/company used by author for submission")
     country = models.CharField(max_length=255, blank=True, help_text="Country used by author for submission")
     order = models.IntegerField(default=1)
@@ -950,6 +949,11 @@ class RfcAuthor(models.Model):
         indexes=[
             models.Index(fields=["document", "order"])
         ]
+
+    @property
+    def email(self) -> str:
+        return self.person.email_address() if self.person else ""
+
 
 class DocumentAuthorInfo(models.Model):
     person = ForeignKey(Person)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -951,8 +951,8 @@ class RfcAuthor(models.Model):
         ]
 
     @property
-    def email(self) -> str:
-        return self.person.email_address() if self.person else ""
+    def email(self) -> Email | None:
+        return self.person.email() if self.person else ""
 
 
 class DocumentAuthorInfo(models.Model):

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -16,6 +16,12 @@ from .models import Document, DocumentAuthor, RfcAuthor
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
     """Serializer for an RfcAuthor / DocumentAuthor in a response"""
+    email = serializers.EmailField(
+        source="person.email_address",
+        help_text="Author's current email address",
+        allow_blank=True,
+        read_only=True
+    )
 
     datatracker_person_path = serializers.URLField(
         source="person.get_absolute_url",
@@ -29,7 +35,7 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
             "titlepage_name",
             "is_editor",
             "person",
-            "email",  # relies on email.pk being email.address
+            "email",
             "affiliation",
             "country",
             "datatracker_person_path",

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -21,6 +21,7 @@ from .models import Document, DocumentAuthor, RfcAuthor
 class RfcAuthorSerializer(serializers.ModelSerializer):
     """Serializer for an RfcAuthor / DocumentAuthor in a response"""
 
+    email = serializers.EmailField(source="email.address", read_only=True)
     datatracker_person_path = serializers.URLField(
         source="person.get_absolute_url",
         required=False,
@@ -38,7 +39,6 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
             "country",
             "datatracker_person_path",
         ]
-        read_only_fields = ["email"]
 
     def to_representation(self, instance):
         """instance -> primitive data types

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -180,7 +180,7 @@ class RfcStatusSerializer(serializers.Serializer):
 
 
 class ShepherdSerializer(serializers.Serializer):
-    email = serializers.EmailField(source="formatted_email")
+    email = serializers.EmailField(source="email_address")
 
 
 class RelatedDraftSerializer(serializers.Serializer):
@@ -217,7 +217,7 @@ class RfcFormatSerializer(serializers.Serializer):
 
 class RfcMetadataSerializer(serializers.ModelSerializer):
     """Serialize metadata of an RFC
-    
+
     This needs to be called with a Document queryset that has been processed with
     api.augment_rfc_queryset() or it very likely will not work. Some of the typing
     refers to Document, but this should really be WithAnnotations[Document, ...].
@@ -308,10 +308,9 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
         else:
             # Fallback in case augment_rfc_queryset() was not called
             log.log(
-                f"Warning: {self.__class__}.get_draft() called without "
-                f"prefetched draft"
+                f"Warning: {self.__class__}.get_draft() called without prefetched draft"
             )
-            related_doc = doc.came_from_draft() 
+            related_doc = doc.came_from_draft()
         return RelatedDraftSerializer(related_doc).data
 
 

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -16,12 +16,6 @@ from .models import Document, DocumentAuthor, RfcAuthor
 
 class RfcAuthorSerializer(serializers.ModelSerializer):
     """Serializer for an RfcAuthor / DocumentAuthor in a response"""
-    email = serializers.EmailField(
-        source="person.email_address",
-        help_text="Author's current email address",
-        allow_blank=True,
-        read_only=True
-    )
 
     datatracker_person_path = serializers.URLField(
         source="person.get_absolute_url",
@@ -40,6 +34,7 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
             "country",
             "datatracker_person_path",
         ]
+        read_only_fields = ["email"]
 
     def to_representation(self, instance):
         """instance -> primitive data types
@@ -54,7 +49,6 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
                 titlepage_name=document_author.person.plain_name(),
                 is_editor=False,
                 person=document_author.person,
-                email=document_author.email,
                 affiliation=document_author.affiliation,
                 country=document_author.country,
                 order=document_author.order,

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1657,7 +1657,7 @@ def document_json(request, name, rev=None):
         doc.rfcauthor_set
         if doc.type_id == "rfc" and doc.rfcauthor_set.exists()
         else doc.documentauthor_set
-    ).select_related("person", "email").order_by("order")
+    ).select_related("person").prefetch_related("person__email_set").order_by("order")
     data["authors"] = [
         {
             "name": author.titlepage_name if hasattr(author, "titlepage_name") else author.person.name,

--- a/ietf/group/serializers.py
+++ b/ietf/group/serializers.py
@@ -1,9 +1,11 @@
 # Copyright The IETF Trust 2024-2026, All Rights Reserved
 """django-rest-framework serializers"""
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from .models import Group
+from ietf.person.models import Email
+from .models import Group, Role
 
 
 class GroupSerializer(serializers.ModelSerializer):
@@ -18,7 +20,13 @@ class AreaDirectorSerializer(serializers.Serializer):
     Works with Email or Role
     """
 
-    email = serializers.EmailField(source="formatted_email")
+    email = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.EmailField)
+    def get_email(self, instance: Email | Role):
+        if isinstance(instance, Role):
+            return instance.email.email_address()
+        return instance.email_address()
 
 
 class AreaSerializer(serializers.ModelSerializer):

--- a/ietf/group/serializers.py
+++ b/ietf/group/serializers.py
@@ -1,5 +1,6 @@
-# Copyright The IETF Trust 2024, All Rights Reserved
+# Copyright The IETF Trust 2024-2026, All Rights Reserved
 """django-rest-framework serializers"""
+
 from rest_framework import serializers
 
 from .models import Group
@@ -8,4 +9,21 @@ from .models import Group
 class GroupSerializer(serializers.ModelSerializer):
     class Meta:
         model = Group
-        fields = ["acronym", "name", "type"]
+        fields = ["acronym", "name", "type", "list_email"]
+
+
+class AreaDirectorSerializer(serializers.Serializer):
+    """Serialize an area director
+
+    Works with Email or Role
+    """
+
+    email = serializers.EmailField(source="formatted_email")
+
+
+class AreaSerializer(serializers.ModelSerializer):
+    ads = AreaDirectorSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Group
+        fields = ["acronym", "name", "type", "ads"]

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -2528,7 +2528,6 @@ class EligibilityUnitTests(TestCase):
             document=rfc,
             person=people[0],
             titlepage_name="P. Zero",
-            email=people[0].email_set.first(),
         )
         self.assertCountEqual(
             get_qualified_author_queryset(base_qs, now - 5 * one_year, now),


### PR DESCRIPTION
Drops the `email` field from `RfcAuthor`, replacing it with a passthrough to `person` when one is attached.

Adds fields to the `redDocList()` API response
* shepherd email
* ad email for RFC
* ad email for the originating draft
* ad emails for the area
* list email for the group

Adds filtering by RFC numbers. In the URL query string this looks like `?number=1,2,3` but the API client handles that detail. The call would be 
```python 
red_doc_list(number=[1,2,3])
```

The SQL queries that result from the changes have not been optimized carefully so this may slow the API down a bit. It does not seem obviously problematic in dev so far, but we can revisit that if needed.

As an example, for the request
```
curl -H 'X-Api-Key: <token>' http://localhost:8000/api/red/doc/\?number\=7991,8235
```
the return value is
```json
{
  "count": 2,
  "next": null,
  "previous": null,
  "results": [
    {
      "number": 8235,
      "title": "Schnorr Non-interactive Zero-Knowledge Proof",
      "published": "2017-09-05",
      "status": {
        "slug": "inf",
        "name": "informational"
      },
      "pages": 13,
      "authors": [
        {
          "titlepage_name": "Feng Hao",
          "is_editor": false,
          "person": 116619,
          "email": "haofeng66@gmail.com",
          "affiliation": "Newcastle University",
          "country": "United Kingdom",
          "datatracker_person_path": "/person/Feng%20Hao"
        }
      ],
      "group": {
        "acronym": "none",
        "name": "Individual Submissions",
        "type": "individ",
        "list_email": ""
      },
      "area": null,
      "stream": {
        "slug": "ise",
        "name": "ISE",
        "desc": "Independent Submission"
      },
      "ad": null,
      "group_list_email": "",
      "identifiers": [
        {
          "type": "doi",
          "value": "10.17487/RFC8235"
        }
      ],
      "obsoletes": [],
      "obsoleted_by": [],
      "updates": [],
      "updated_by": [],
      "subseries": [],
      "draft": {
        "id": 19850,
        "name": "draft-hao-schnorr",
        "title": "Schnorr Non-interactive Zero-Knowledge Proof",
        "shepherd": {
          "email": "Eliot Lear <rfc-ise@rfc-editor.org>"
        },
        "ad": null
      },
      "abstract": "This document describes the Schnorr non-interactive zero-knowledge (NIZK) proof, a non-interactive variant of the three-pass Schnorr identification scheme.  The Schnorr NIZK proof allows one to prove the knowledge of a discrete logarithm without leaking any information about its value.  It can serve as a useful building block for many cryptographic protocols to ensure that participants follow the protocol specification honestly.  This document specifies the Schnorr NIZK proof in both the finite field and the elliptic curve settings.",
      "formats": [
        {
          "fmt": "txt",
          "name": "txt/rfc8235.txt"
        },
        {
          "fmt": "html",
          "name": "html/rfc8235.html"
        },
        {
          "fmt": "json",
          "name": "json/rfc8235.json"
        }
      ],
      "keywords": [
        "keyword"
      ],
      "has_errata": true
    },
    {
      "number": 7991,
      "title": "The \"xml2rfc\" Version 3 Vocabulary",
      "published": "2016-12-16",
      "status": {
        "slug": "inf",
        "name": "informational"
      },
      "pages": 151,
      "authors": [
        {
          "titlepage_name": "Paul Hoffman",
          "is_editor": false,
          "person": 10083,
          "email": "paul.hoffman@icann.org",
          "affiliation": "ICANN",
          "country": "",
          "datatracker_person_path": "/person/Paul%20E.%20Hoffman"
        }
      ],
      "group": {
        "acronym": "iab",
        "name": "Internet Architecture Board",
        "type": "ietf",
        "list_email": "iab@iab.org"
      },
      "area": {
        "acronym": "ietf",
        "name": "IETF",
        "type": "ietf",
        "ads": []
      },
      "stream": {
        "slug": "iab",
        "name": "IAB",
        "desc": "Internet Architecture Board (IAB)"
      },
      "ad": null,
      "group_list_email": "iab@iab.org",
      "identifiers": [
        {
          "type": "doi",
          "value": "10.17487/RFC7991"
        }
      ],
      "obsoletes": [
        {
          "id": 129572,
          "number": 7749,
          "title": "The \"xml2rfc\" Version 2 Vocabulary"
        }
      ],
      "obsoleted_by": [],
      "updates": [],
      "updated_by": [
        {
          "id": 153627,
          "number": 9920,
          "title": "RFC Editor Model (Version 3)"
        }
      ],
      "subseries": [],
      "draft": {
        "id": 64140,
        "name": "draft-iab-xml2rfc",
        "title": "The \"xml2rfc\" Version 3 Vocabulary",
        "shepherd": null,
        "ad": null
      },
      "abstract": "This document defines the \"xml2rfc\" version 3 vocabulary: an XML-based language used for writing RFCs and Internet-Drafts.  It is heavily derived from the version 2 vocabulary that is also under discussion.  This document obsoletes the v2 grammar described in RFC 7749.",
      "formats": [
        {
          "fmt": "txt",
          "name": "txt/rfc7991.txt"
        },
        {
          "fmt": "html",
          "name": "html/rfc7991.html"
        },
        {
          "fmt": "json",
          "name": "json/rfc7991.json"
        }
      ],
      "keywords": [
        "keyword"
      ],
      "has_errata": true
    }
  ]
}
```