### PR TITLE
fix: more accurate group areas (red API)

### DIFF
--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -300,7 +300,7 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
         if doc.group is None:
             return None
         parent = doc.group.parent
-        if parent.is_active and parent.type_id == "area":
+        if parent.type_id == "area":
             return AreaSerializer(parent).data
         return None
 

--- a/ietf/group/serializers.py
+++ b/ietf/group/serializers.py
@@ -30,8 +30,15 @@ class AreaDirectorSerializer(serializers.Serializer):
 
 
 class AreaSerializer(serializers.ModelSerializer):
-    ads = AreaDirectorSerializer(many=True, read_only=True)
+    ads = serializers.SerializerMethodField()
 
     class Meta:
         model = Group
         fields = ["acronym", "name", "type", "ads"]
+
+    @extend_schema_field(AreaDirectorSerializer(many=True))
+    def get_ads(self, area: Group):
+        return AreaDirectorSerializer(
+            area.ads() if area.is_active else Role.objects.none(),
+            many=True,
+        ).data


### PR DESCRIPTION
In the red / errata API, only show area for IETF stream docs whose group parent has `type_id="area"`. Only include area ADs if the area is currently active.