### PR TITLE
feat: RFC metadata update API

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -675,7 +675,8 @@ class EditableRfcSerializer(serializers.ModelSerializer):
                         desc=f"Removed {rfc.name} from {stale_subseries_doc.name}",
                     )
                 stale_subseries_relations.delete()
-            rfc.save_with_history(rfc_events)
+            if len(rfc_events) > 0:
+                rfc.save_with_history(rfc_events)
         return rfc
 
 

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -560,6 +560,7 @@ class EditableRfcSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             # update the rfc Document itself
             rfc_changes = []
+            rfc_events = []
             
             for attr, new_value in validated_data.items():
                 old_value = getattr(instance, attr)
@@ -570,22 +571,15 @@ class EditableRfcSerializer(serializers.ModelSerializer):
                     setattr(instance, attr, new_value)
             if len(rfc_changes) > 0:
                 rfc_change_summary = f" ({', '.join(rfc_changes)})"
-            else:
-                rfc_change_summary = ""
-            rfc_events = [
-                (
+                rfc_events.append(
                     DocEvent.objects.create(
                         doc=rfc,
                         rev=rfc.rev,
                         by=system_person,
                         type="sync_from_rfc_editor",
-                        desc=(
-                            "Metadata changes received from RFC Editor"
-                            + rfc_change_summary
-                        ),
+                        desc=f"Changed metadata: {rfc_change_summary}",
                     )
                 )
-            ]
             if authors_data is not omitted:
                 rfc_events.extend(_update_authors(instance, authors_data))
 

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -218,7 +218,7 @@ class ReferenceSerializer(serializers.ModelSerializer):
 
 def _update_authors(rfc, authors_data):
     # Construct unsaved instances from validated author data
-    new_authors = [RfcAuthor(**ad) for ad in authors_data]
+    new_authors = [RfcAuthor(**authdata) for authdata in authors_data]
     # Update the RFC with the new author set
     with transaction.atomic():
         change_events = update_rfcauthors(rfc, new_authors)

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -563,12 +563,12 @@ class EditableRfcSerializer(serializers.ModelSerializer):
             rfc_events = []
             
             for attr, new_value in validated_data.items():
-                old_value = getattr(instance, attr)
+                old_value = getattr(rfc, attr)
                 if new_value != old_value:
                     rfc_changes.append(
                         f"changed {attr} to '{new_value}' from '{old_value}'"
                     )
-                    setattr(instance, attr, new_value)
+                    setattr(rfc, attr, new_value)
             if len(rfc_changes) > 0:
                 rfc_change_summary = f" ({', '.join(rfc_changes)})"
                 rfc_events.append(
@@ -675,7 +675,7 @@ class EditableRfcSerializer(serializers.ModelSerializer):
                         desc=f"Removed {rfc.name} from {stale_subseries_doc.name}",
                     )
                 stale_subseries_relations.delete()
-                rfc.save_with_history(rfc_events)
+            rfc.save_with_history(rfc_events)
         return rfc
 
 

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -570,7 +570,7 @@ class EditableRfcSerializer(serializers.ModelSerializer):
                     )
                     setattr(rfc, attr, new_value)
             if len(rfc_changes) > 0:
-                rfc_change_summary = f" ({', '.join(rfc_changes)})"
+                rfc_change_summary = f"{', '.join(rfc_changes)}"
                 rfc_events.append(
                     DocEvent.objects.create(
                         doc=rfc,

--- a/ietf/api/tests_serializers_rpc.py
+++ b/ietf/api/tests_serializers_rpc.py
@@ -56,6 +56,7 @@ class EditableRfcSerializerTests(TestCase):
         )
         self.assertTrue(serializer.is_valid())
         result = serializer.save()
+        result.refresh_from_db()
         self.assertEqual(result.title, "Yadda yadda yadda")
         self.assertEqual(
             list(
@@ -86,7 +87,7 @@ class EditableRfcSerializerTests(TestCase):
     def test_partial_update(self):
         # We could test other permutations of fields, but authors is a partial update
         # we know we are going to use, so verifying that one in particular.
-        rfc = WgRfcFactory(pages=10, abstract="do or do not", title="jedi master")
+        rfc = WgRfcFactory(pages=10, abstract="do or do not", title="padawan")
         serializer = EditableRfcSerializer(
             partial=True,
             instance=rfc,
@@ -103,7 +104,8 @@ class EditableRfcSerializerTests(TestCase):
         )
         self.assertTrue(serializer.is_valid())
         result = serializer.save()
-        self.assertEqual(rfc.title, "jedi master")
+        result.refresh_from_db()
+        self.assertEqual(rfc.title, "padawan")
         self.assertEqual(
             list(
                 result.rfcauthor_set.values(
@@ -124,3 +126,14 @@ class EditableRfcSerializerTests(TestCase):
         self.assertEqual(result.pages, 10)
         self.assertEqual(result.std_level_id, "ps")
         self.assertEqual(result.part_of(), [])
+
+        # Test only a field on the Document itself to be sure that it works
+        serializer = EditableRfcSerializer(
+            partial=True,
+            instance=rfc,
+            data={"title": "jedi master"},
+        )
+        self.assertTrue(serializer.is_valid())
+        result = serializer.save()
+        result.refresh_from_db()
+        self.assertEqual(rfc.title, "jedi master")

--- a/ietf/api/tests_serializers_rpc.py
+++ b/ietf/api/tests_serializers_rpc.py
@@ -1,0 +1,126 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+from django.utils import timezone
+
+from ietf.utils.test_utils import TestCase
+from ietf.doc.models import Document
+from ietf.doc.factories import WgRfcFactory
+from .serializers_rpc import EditableRfcSerializer
+
+
+class EditableRfcSerializerTests(TestCase):
+    def test_create(self):
+        serializer = EditableRfcSerializer(
+            data={
+                "published": timezone.now(),
+                "title": "Yadda yadda yadda",
+                "authors": [
+                    {
+                        "titlepage_name": "B. Fett",
+                        "is_editor": False,
+                        "affiliation": "DBA Galactic Empire",
+                        "country": "",
+                    },
+                ],
+                "stream": "ietf",
+                "abstract": "A long time ago in a galaxy far, far away...",
+                "pages": 3,
+                "std_level": "inf",
+                "subseries": ["fyi999"],
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        with self.assertRaises(RuntimeError, msg="serializer does not allow create()"):
+            serializer.save()
+
+    def test_update(self):
+        rfc = WgRfcFactory(pages=10)
+        serializer = EditableRfcSerializer(
+            instance=rfc,
+            data={
+                "published": timezone.now(),
+                "title": "Yadda yadda yadda",
+                "authors": [
+                    {
+                        "titlepage_name": "B. Fett",
+                        "is_editor": False,
+                        "affiliation": "DBA Galactic Empire",
+                        "country": "",
+                    },
+                ],
+                "stream": "ise",
+                "abstract": "A long time ago in a galaxy far, far away...",
+                "pages": 3,
+                "std_level": "inf",
+                "subseries": ["fyi999"],
+            },
+        )
+        self.assertTrue(serializer.is_valid())
+        result = serializer.save()
+        self.assertEqual(result.title, "Yadda yadda yadda")
+        self.assertEqual(
+            list(
+                result.rfcauthor_set.values(
+                    "titlepage_name", "is_editor", "affiliation", "country"
+                )
+            ),
+            [
+                {
+                    "titlepage_name": "B. Fett",
+                    "is_editor": False,
+                    "affiliation": "DBA Galactic Empire",
+                    "country": "",
+                },
+            ],
+        )
+        self.assertEqual(result.stream_id, "ise")
+        self.assertEqual(
+            result.abstract, "A long time ago in a galaxy far, far away..."
+        )
+        self.assertEqual(result.pages, 3)
+        self.assertEqual(result.std_level_id, "inf")
+        self.assertEqual(
+            result.part_of(),
+            [Document.objects.get(name="fyi999")],
+        )
+
+    def test_partial_update(self):
+        # We could test other permutations of fields, but authors is a partial update
+        # we know we are going to use, so verifying that one in particular.
+        rfc = WgRfcFactory(pages=10, abstract="do or do not", title="jedi master")
+        serializer = EditableRfcSerializer(
+            partial=True,
+            instance=rfc,
+            data={
+                "authors": [
+                    {
+                        "titlepage_name": "B. Fett",
+                        "is_editor": False,
+                        "affiliation": "DBA Galactic Empire",
+                        "country": "",
+                    },
+                ],
+            },
+        )
+        self.assertTrue(serializer.is_valid())
+        result = serializer.save()
+        self.assertEqual(rfc.title, "jedi master")
+        self.assertEqual(
+            list(
+                result.rfcauthor_set.values(
+                    "titlepage_name", "is_editor", "affiliation", "country"
+                )
+            ),
+            [
+                {
+                    "titlepage_name": "B. Fett",
+                    "is_editor": False,
+                    "affiliation": "DBA Galactic Empire",
+                    "country": "",
+                },
+            ],
+        )
+        self.assertEqual(result.stream_id, "ietf")
+        self.assertEqual(result.abstract, "do or do not")
+        self.assertEqual(result.pages, 10)
+        self.assertEqual(result.std_level_id, "ps")
+        self.assertEqual(result.part_of(), [])

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -35,9 +35,7 @@ from ietf.api.serializers_rpc import (
     NotificationAckSerializer, RfcPubSerializer, RfcFileSerializer,
     EditableRfcSerializer,
 )
-from ietf.doc.api import PrefetchRelatedDocument
-from ietf.doc.models import Document, DocHistory, RfcAuthor, SUBSERIES_DOC_TYPE_IDS, \
-    DocEvent
+from ietf.doc.models import Document, DocHistory, RfcAuthor, DocEvent
 from ietf.doc.serializers import RfcAuthorSerializer
 from ietf.doc.storage_utils import remove_from_storage, store_file, exists_in_storage
 from ietf.person.models import Email, Person

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -286,7 +286,7 @@ class RfcViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
             rev=serializer.instance.rev,
             by=Person.objects.get(name="(System)"),
             type="sync_from_rfc_editor",
-            desc="Metadata sync from RFC Editor",
+            desc="Metadata update from RFC Editor",
         )
         super().perform_update(serializer)
 

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -275,24 +275,7 @@ class DraftViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     )
 )
 class RfcViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
-    queryset = Document.objects.filter(type_id="rfc").prefetch_related(
-        PrefetchRelatedDocument(
-            to_attr="subseries",
-            relationship_id="contains",
-            reverse=True,
-            doc_type_ids=SUBSERIES_DOC_TYPE_IDS,
-        )
-    ).annotate(
-        published=Subquery(
-            DocEvent.objects.filter(
-                doc_id=OuterRef("pk"),
-                type="published_rfc",
-            )
-            .order_by("-time")
-            .values("time")[:1]
-        ),
-    )
-    
+    queryset = Document.objects.filter(type_id="rfc")
     api_key_endpoint = "ietf.api.views_rpc"
     lookup_field = "rfc_number"
     serializer_class = RfcAmendMetadataSerializer

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -280,6 +280,16 @@ class RfcViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
     lookup_field = "rfc_number"
     serializer_class = EditableRfcSerializer
 
+    def perform_update(self, serializer):
+        DocEvent.objects.create(
+            doc=serializer.instance,
+            rev=serializer.instance.rev,
+            by=Person.objects.get(name="(System)"),
+            type="sync_from_rfc_editor",
+            desc="Metadata sync from RFC Editor",
+        )
+        super().perform_update(serializer)
+
     @action(detail=False, serializer_class=OriginalStreamSerializer)
     def rfc_original_stream(self, request):
         rfcs = self.get_queryset().annotate(

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -33,7 +33,7 @@ from ietf.api.serializers_rpc import (
     RfcWithAuthorsSerializer,
     DraftWithAuthorsSerializer,
     NotificationAckSerializer, RfcPubSerializer, RfcFileSerializer,
-    EditableRfcSerializer, RfcAmendMetadataSerializer,
+    EditableRfcSerializer,
 )
 from ietf.doc.api import PrefetchRelatedDocument
 from ietf.doc.models import Document, DocHistory, RfcAuthor, SUBSERIES_DOC_TYPE_IDS, \
@@ -278,7 +278,7 @@ class RfcViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):
     queryset = Document.objects.filter(type_id="rfc")
     api_key_endpoint = "ietf.api.views_rpc"
     lookup_field = "rfc_number"
-    serializer_class = RfcAmendMetadataSerializer
+    serializer_class = EditableRfcSerializer
 
     @action(detail=False, serializer_class=OriginalStreamSerializer)
     def rfc_original_stream(self, request):

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -27,6 +27,7 @@ class RfcAuthorSerializer(serializers.ModelSerializer):
         source="person.get_absolute_url",
         required=False,
         help_text="URL for person link (relative to datatracker base URL)",
+        read_only=True,
     )
 
     class Meta:

--- a/ietf/doc/utils.py
+++ b/ietf/doc/utils.py
@@ -740,14 +740,26 @@ def update_rfcauthors(
             new_author.document = rfc
             new_author.order = order + 1
             new_author.save()
-            changes.append(f'Added "{new_author.titlepage_name}" as author')
+            if new_author.person_id is not None:
+                person_desc = f"Person {new_author.person_id}"
+            else:
+                person_desc = "no Person linked"
+            changes.append(
+                f'Added "{new_author.titlepage_name}" ({person_desc}) as author'
+            )
     # Any authors left in original_authors are no longer in the list, so remove them
     for removed_author in original_authors:
         # Skip actual removal of old authors if we are converting from the
         # DocumentAuthor models - the original_authors were just stand-ins anyway.
         if not converting_from_docauthors:
             removed_author.delete()
-        changes.append(f'Removed "{removed_author.titlepage_name}" as author')
+        if removed_author.person_id is not None:
+            person_desc = f"Person {removed_author.person_id}"
+        else:
+            person_desc = "no Person linked"
+        changes.append(
+            f'Removed "{removed_author.titlepage_name}" ({person_desc}) as author'
+        )
     # Create DocEvents, but leave it up to caller to save
     if by is None:
         by = Person.objects.get(name="(System)")


### PR DESCRIPTION
Expands the `purple_rfc_update()` and `purple_rfc_partial_update()` APIs to allow updates beyond author lists. Adds some tests.