### PR TITLE
feat: add attendance summary and pie chart to meeting attendees page

### DIFF
--- a/ietf/meeting/tests_views.py
+++ b/ietf/meeting/tests_views.py
@@ -9007,6 +9007,8 @@ class ProceedingsTests(BaseMeetingTestCase):
            - assert onsite checkedin=True appears, not onsite checkedin=False
            - assert remote attended appears, not remote not attended
            - prefer onsite checkedin=True to remote attended when same person has both
+           - summary stats row shows correct counts
+           - chart data JSON is embedded with correct values
         """
 
         m = MeetingFactory(type_id='ietf', date=datetime.date(2023, 11, 4), number="118")
@@ -9027,6 +9029,17 @@ class ProceedingsTests(BaseMeetingTestCase):
         self.assertEqual(2, len(q("#id_attendees tbody tr")))
         text = q('#id_attendees tbody tr').text().replace('\n', ' ')
         self.assertEqual(text, f"A Person {areg.affiliation} {areg.country_code} onsite C Person {creg.affiliation} {creg.country_code} remote")
+
+        # Summary stats row: Onsite / Remote / Total (matches registration.ietf.org)
+        self.assertContains(response, 'Onsite:')
+        self.assertContains(response, 'Remote:')
+        self.assertContains(response, 'Total:')
+        self.assertContains(response, '<strong>1</strong>')   # onsite and remote
+        self.assertContains(response, '<strong>2</strong>')   # total
+
+        # Chart data embedded in page
+        chart_json = json.loads(q('#attendees-chart-data').text())
+        self.assertEqual(chart_json['type'], [['Onsite', 1], ['Remote', 1]])
 
     def test_proceedings_overview(self):
         '''Test proceedings IETF Overview page.

--- a/ietf/static/js/attendees-chart.js
+++ b/ietf/static/js/attendees-chart.js
@@ -1,0 +1,58 @@
+(function () {
+    var raw = document.getElementById('attendees-chart-data');
+    if (!raw) return;
+    var chartData = JSON.parse(raw.textContent);
+    var chart = null;
+    var currentBreakdown = 'type';
+
+    // Override the global transparent background set by highcharts.js so the
+    // export menu and fullscreen view use the page background color.
+    var container = document.getElementById('attendees-pie-chart');
+    var bodyBg = getComputedStyle(document.body).backgroundColor;
+    container.style.setProperty('--highcharts-background-color', bodyBg);
+
+    function renderChart(breakdown) {
+        var seriesData = chartData[breakdown].map(function (item) {
+            return { name: item[0], y: item[1] };
+        });
+        if (chart) chart.destroy();
+        chart = Highcharts.chart(container, {
+            chart: { type: 'pie', height: 400 },
+            title: { text: null },
+            tooltip: { pointFormat: '{point.name}: <b>{point.y}</b> ({point.percentage:.1f}%)' },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        enabled: true,
+                        format: '<b>{point.name}</b><br>{point.y} ({point.percentage:.1f}%)',
+                    },
+                    showInLegend: false,
+                }
+            },
+            series: [{ name: 'Attendees', data: seriesData }],
+        });
+    }
+
+    var modal = document.getElementById('attendees-chart-modal');
+
+    // Render (or re-render) the chart each time the modal becomes fully visible,
+    // so Highcharts can measure the container dimensions correctly.
+    modal.addEventListener('shown.bs.modal', function () {
+        renderChart(currentBreakdown);
+    });
+
+    // Release the chart when the modal closes to avoid stale renders.
+    modal.addEventListener('hidden.bs.modal', function () {
+        if (chart) {
+            chart.destroy();
+            chart = null;
+        }
+    });
+
+    document.querySelectorAll('[name="attendees-breakdown"]').forEach(function (radio) {
+        radio.addEventListener('change', function () {
+            currentBreakdown = this.value;
+            renderChart(currentBreakdown);
+        });
+    });
+})();

--- a/ietf/templates/meeting/proceedings_attendees.html
+++ b/ietf/templates/meeting/proceedings_attendees.html
@@ -3,6 +3,7 @@
 {% load origin markup_tags static %}
 {% block pagehead %}
     <link rel="stylesheet" href="{% static "ietf/css/list.css" %}">
+    {% if chart_data %}<link rel="stylesheet" href="{% static "ietf/css/highcharts.css" %}">{% endif %}
 {% endblock %}
 {% block title %}IETF {{ meeting.number }} proceedings{% endblock %}
 {% block content %}
@@ -14,8 +15,52 @@
         </a>
     </h1>
     <h2>Attendee list of IETF {{ meeting.number }} meeting</h2>
-    
+
+    {% if chart_data %}
+    <div class="d-flex align-items-center gap-4 mb-3 flex-wrap">
+        <div class="d-flex gap-4">
+            <div>Onsite: <strong>{{ stats.onsite }}</strong></div>
+            <div>Remote: <strong>{{ stats.remote }}</strong></div>
+            <div>Total: <strong>{{ stats.total }}</strong></div>
+        </div>
+        <button type="button" class="btn btn-primary btn-sm"
+                data-bs-toggle="modal" data-bs-target="#attendees-chart-modal">
+            <i class="bi bi-pie-chart-fill"></i> View chart
+        </button>
+    </div>
+
+    <div class="modal fade" id="attendees-chart-modal" tabindex="-1"
+         aria-labelledby="attendees-chart-modal-label" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 class="modal-title fs-5" id="attendees-chart-modal-label">
+                        IETF {{ meeting.number }} attendees
+                    </h2>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="btn-group mb-3" role="group" aria-label="Chart breakdown">
+                        <input type="radio" class="btn-check" name="attendees-breakdown"
+                               id="breakdown-type" value="type" checked>
+                        <label class="btn btn-outline-secondary btn-sm" for="breakdown-type">Onsite/Remote</label>
+                        <input type="radio" class="btn-check" name="attendees-breakdown"
+                               id="breakdown-countries" value="countries">
+                        <label class="btn btn-outline-secondary btn-sm" for="breakdown-countries">Countries</label>
+                    </div>
+                    <div id="attendees-pie-chart" class="bg-body"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{ chart_data|json_script:"attendees-chart-data" }}
+    {% endif %}{# chart_data #}
+
     {% if template %}
+    <div class="alert alert-info" role="alert">
+        Attendee statistics are not available for this meeting.
+    </div>
       {{template|safe}}
     {% else %}
         <table id="id_attendees" class="table table-sm table-striped tablesorter">
@@ -44,4 +89,67 @@
 {% endblock %}
 {% block js %}
     <script src="{% static "ietf/js/list.js" %}"></script>
+    {% if chart_data %}
+    <script src="{% static "ietf/js/highcharts.js" %}"></script>
+    <script>
+        (function () {
+            var raw = document.getElementById('attendees-chart-data');
+            if (!raw) return;
+            var chartData = JSON.parse(raw.textContent);
+            var chart = null;
+            var currentBreakdown = 'type';
+
+            // Override the global transparent background set by highcharts.js so the
+            // export menu and fullscreen view use the page background color.
+            var container = document.getElementById('attendees-pie-chart');
+            var bodyBg = getComputedStyle(document.body).backgroundColor;
+            container.style.setProperty('--highcharts-background-color', bodyBg);
+
+            function renderChart(breakdown) {
+                var seriesData = chartData[breakdown].map(function (item) {
+                    return { name: item[0], y: item[1] };
+                });
+                if (chart) chart.destroy();
+                chart = Highcharts.chart(container, {
+                    chart: { type: 'pie', height: 400 },
+                    title: { text: null },
+                    tooltip: { pointFormat: '{point.name}: <b>{point.y}</b> ({point.percentage:.1f}%)' },
+                    plotOptions: {
+                        pie: {
+                            dataLabels: {
+                                enabled: true,
+                                format: '<b>{point.name}</b><br>{point.y} ({point.percentage:.1f}%)',
+                            },
+                            showInLegend: false,
+                        }
+                    },
+                    series: [{ name: 'Attendees', data: seriesData }],
+                });
+            }
+
+            var modal = document.getElementById('attendees-chart-modal');
+
+            // Render (or re-render) the chart each time the modal becomes fully visible,
+            // so Highcharts can measure the container dimensions correctly.
+            modal.addEventListener('shown.bs.modal', function () {
+                renderChart(currentBreakdown);
+            });
+
+            // Release the chart when the modal closes to avoid stale renders.
+            modal.addEventListener('hidden.bs.modal', function () {
+                if (chart) {
+                    chart.destroy();
+                    chart = null;
+                }
+            });
+
+            document.querySelectorAll('[name="attendees-breakdown"]').forEach(function (radio) {
+                radio.addEventListener('change', function () {
+                    currentBreakdown = this.value;
+                    renderChart(currentBreakdown);
+                });
+            });
+        })();
+    </script>
+    {% endif %}
 {% endblock %}

--- a/ietf/templates/meeting/proceedings_attendees.html
+++ b/ietf/templates/meeting/proceedings_attendees.html
@@ -91,65 +91,6 @@
     <script src="{% static "ietf/js/list.js" %}"></script>
     {% if chart_data %}
     <script src="{% static "ietf/js/highcharts.js" %}"></script>
-    <script>
-        (function () {
-            var raw = document.getElementById('attendees-chart-data');
-            if (!raw) return;
-            var chartData = JSON.parse(raw.textContent);
-            var chart = null;
-            var currentBreakdown = 'type';
-
-            // Override the global transparent background set by highcharts.js so the
-            // export menu and fullscreen view use the page background color.
-            var container = document.getElementById('attendees-pie-chart');
-            var bodyBg = getComputedStyle(document.body).backgroundColor;
-            container.style.setProperty('--highcharts-background-color', bodyBg);
-
-            function renderChart(breakdown) {
-                var seriesData = chartData[breakdown].map(function (item) {
-                    return { name: item[0], y: item[1] };
-                });
-                if (chart) chart.destroy();
-                chart = Highcharts.chart(container, {
-                    chart: { type: 'pie', height: 400 },
-                    title: { text: null },
-                    tooltip: { pointFormat: '{point.name}: <b>{point.y}</b> ({point.percentage:.1f}%)' },
-                    plotOptions: {
-                        pie: {
-                            dataLabels: {
-                                enabled: true,
-                                format: '<b>{point.name}</b><br>{point.y} ({point.percentage:.1f}%)',
-                            },
-                            showInLegend: false,
-                        }
-                    },
-                    series: [{ name: 'Attendees', data: seriesData }],
-                });
-            }
-
-            var modal = document.getElementById('attendees-chart-modal');
-
-            // Render (or re-render) the chart each time the modal becomes fully visible,
-            // so Highcharts can measure the container dimensions correctly.
-            modal.addEventListener('shown.bs.modal', function () {
-                renderChart(currentBreakdown);
-            });
-
-            // Release the chart when the modal closes to avoid stale renders.
-            modal.addEventListener('hidden.bs.modal', function () {
-                if (chart) {
-                    chart.destroy();
-                    chart = null;
-                }
-            });
-
-            document.querySelectorAll('[name="attendees-breakdown"]').forEach(function (radio) {
-                radio.addEventListener('change', function () {
-                    currentBreakdown = this.value;
-                    renderChart(currentBreakdown);
-                });
-            });
-        })();
-    </script>
+    <script src="{% static "ietf/js/attendees-chart.js" %}"></script>
     {% endif %}
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "ietf/static/images/irtf-logo-white.svg",
         "ietf/static/images/irtf-logo.svg",
         "ietf/static/js/add_session_recordings.js",
+        "ietf/static/js/attendees-chart.js",
         "ietf/static/js/agenda_filter.js",
         "ietf/static/js/agenda_materials.js",
         "ietf/static/js/announcement.js",


### PR DESCRIPTION
For IETF meetings ≥ 118, the attendees proceedings page now shows an Onsite / Remote / Total summary row matching the counts displayed on registration.ietf.org, together with a "View chart" button that opens a Bootstrap modal containing a Highcharts pie chart.