### PR TITLE
fix: finish dropping email as RfcAuthor field

### DIFF
--- a/ietf/doc/admin.py
+++ b/ietf/doc/admin.py
@@ -241,7 +241,9 @@ class StoredObjectAdmin(admin.ModelAdmin):
 admin.site.register(StoredObject, StoredObjectAdmin)
 
 class RfcAuthorAdmin(admin.ModelAdmin):
+    # the email field in the list_display/readonly_fields works through a @property
     list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'country', 'order']
-    search_fields = ['document__name', 'titlepage_name', 'person__name', 'email', 'affiliation', 'country']
+    search_fields = ['document__name', 'titlepage_name', 'person__name', 'affiliation', 'country']
     raw_id_fields = ["document", "person"]
+    readonly_fields = ["email"]
 admin.site.register(RfcAuthor, RfcAuthorAdmin)

--- a/ietf/doc/admin.py
+++ b/ietf/doc/admin.py
@@ -243,7 +243,7 @@ admin.site.register(StoredObject, StoredObjectAdmin)
 class RfcAuthorAdmin(admin.ModelAdmin):
     # the email field in the list_display/readonly_fields works through a @property
     list_display = ['id', 'document', 'titlepage_name', 'person', 'email', 'affiliation', 'country', 'order']
-    search_fields = ['document__name', 'titlepage_name', 'person__name', 'affiliation', 'country']
+    search_fields = ['document__name', 'titlepage_name', 'person__name', 'person__email__address', 'affiliation', 'country']
     raw_id_fields = ["document", "person"]
     readonly_fields = ["email"]
 admin.site.register(RfcAuthor, RfcAuthorAdmin)

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -466,11 +466,12 @@ class DocumentInfo(models.Model):
 
     def author_list(self):
         """List of author emails"""
-        author_qs = (
-            self.rfcauthor_set
-            if self.type_id == "rfc" and self.rfcauthor_set.exists()
-            else self.documentauthor_set
-        ).select_related("email").order_by("order")
+        if self.type_id == "rfc" and self.rfcauthor_set.exists():
+            author_qs = self.rfcauthor_set.select_related("person").order_by("order")
+        else:
+            author_qs = self.documentauthor_set.select_related("email").order_by(
+                "order"
+            )
         best_addresses = []
         for author in author_qs:
             if author.email:
@@ -953,6 +954,11 @@ class RfcAuthor(models.Model):
     @property
     def email(self) -> Email | None:
         return self.person.email() if self.person else None
+    
+    def format_for_titlepage(self):
+        if self.is_editor:
+            return f"{self.titlepage_name}, Ed."
+        return self.titlepage_name
 
 
 class DocumentAuthorInfo(models.Model):

--- a/ietf/doc/resources.py
+++ b/ietf/doc/resources.py
@@ -897,7 +897,7 @@ from ietf.person.resources import EmailResource, PersonResource
 class RfcAuthorResource(ModelResource):
     document         = ToOneField(DocumentResource, 'document')
     person           = ToOneField(PersonResource, 'person', null=True)
-    email            = ToOneField(EmailResource, 'email', null=True)
+    email            = ToOneField(EmailResource, 'email', null=True, readonly=True)
     class Meta:
         queryset = RfcAuthor.objects.all()
         serializer = api.Serializer()


### PR DESCRIPTION
`RfcAuthor.email` is still available as a property, so this preserves its display as useful for debugging. 