### PR TITLE
feat: rfc-index generation

### DIFF
--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -101,6 +101,17 @@ for storagename in ARTIFACT_STORAGE_NAMES:
         ),
     }
 
+# For dev on rfc-index generation, create a red_bucket/ directory in the project root
+# and uncomment these settings. Generated files will appear in this directory. To
+# generate an accurate index, put up-to-date copies of unusable-rfc-numbers.json,
+# april-first-rfc-numbers.json, and publication-std-levels.json in this directory
+# before generating the index.
+#
+# STORAGES["red_bucket"] = {
+#     "BACKEND": "django.core.files.storage.FileSystemStorage",
+#     "OPTIONS": {"location": "red_bucket"},
+# }
+
 APP_API_TOKENS = {
     "ietf.api.red_api" : ["devtoken", "redtoken"],  # Not a real secret
     "ietf.api.views_rpc" : ["devtoken"],  # Not a real secret

--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -300,6 +300,7 @@ class RfcPubSerializer(serializers.ModelSerializer):
             "obsoletes",
             "updates",
             "subseries",
+            "keywords",
         ]
 
     def validate(self, data):
@@ -540,6 +541,7 @@ class EditableRfcSerializer(serializers.ModelSerializer):
             "pages",
             "std_level",
             "subseries",
+            "keywords",
         ]
 
     def create(self, validated_data):

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -4,13 +4,11 @@
 from django.db.models import (
     BooleanField,
     Count,
-    JSONField,
     OuterRef,
     Prefetch,
     Q,
     QuerySet,
     Subquery,
-    Value,
 )
 from django.db.models.functions import TruncDate
 from django_filters import rest_framework as filters

--- a/ietf/doc/api.py
+++ b/ietf/doc/api.py
@@ -160,10 +160,6 @@ def augment_rfc_queryset(queryset: QuerySet[Document]):
                 output_field=BooleanField(),
             )
         )
-        .annotate(
-            # TODO implement this fake field for real
-            keywords=Value(["keyword"], output_field=JSONField()),
-        )
     )
 
 

--- a/ietf/doc/factories.py
+++ b/ietf/doc/factories.py
@@ -311,6 +311,12 @@ class NewRevisionDocEventFactory(DocEventFactory):
     def desc(self):
          return 'New version available %s-%s'%(self.doc.name,self.rev)
 
+class PublishedRfcDocEventFactory(DocEventFactory):
+    class Meta:
+        model = DocEvent
+    type = "published_rfc"
+    doc = factory.SubFactory(WgRfcFactory)
+
 class StateDocEventFactory(DocEventFactory):
     class Meta:
         model = StateDocEvent

--- a/ietf/doc/feeds.py
+++ b/ietf/doc/feeds.py
@@ -263,9 +263,11 @@ class RfcFeed(Feed):
                 )
         extra.update({"media_contents": media_contents})
 
-        extra.update({"doi": "10.17487/%s" % item.name.upper()})
         extra.update(
-            {"doiuri": "http://dx.doi.org/10.17487/%s" % item.name.upper()}
+            {
+                "doi": item.doi,
+                "doiuri": f"http://dx.doi.org/{item.doi}",
+            }
         )
 
         # R104 Publisher (Mandatory - but we need a string from them first)

--- a/ietf/doc/feeds.py
+++ b/ietf/doc/feeds.py
@@ -1,5 +1,4 @@
-# Copyright The IETF Trust 2007-2020, All Rights Reserved
-# -*- coding: utf-8 -*-
+# Copyright The IETF Trust 2007-2026, All Rights Reserved
 
 import debug  # pyflakes:ignore
 
@@ -266,7 +265,7 @@ class RfcFeed(Feed):
         extra.update(
             {
                 "doi": item.doi,
-                "doiuri": f"http://dx.doi.org/{item.doi}",
+                "doiuri": f"https://doi.org/{item.doi}",
             }
         )
 

--- a/ietf/doc/migrations/0033_dochistory_keywords_document_keywords.py
+++ b/ietf/doc/migrations/0033_dochistory_keywords_document_keywords.py
@@ -1,0 +1,31 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations, models
+import ietf.doc.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("doc", "0032_remove_rfcauthor_email"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="dochistory",
+            name="keywords",
+            field=models.JSONField(
+                default=list,
+                max_length=1000,
+                validators=[ietf.doc.models.validate_doc_keywords],
+            ),
+        ),
+        migrations.AddField(
+            model_name="document",
+            name="keywords",
+            field=models.JSONField(
+                default=list,
+                max_length=1000,
+                validators=[ietf.doc.models.validate_doc_keywords],
+            ),
+        ),
+    ]

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -13,6 +13,7 @@ import rfc2html
 from io import BufferedReader
 from pathlib import Path
 
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from lxml import etree
 from typing import Optional, Protocol, TYPE_CHECKING, Union
@@ -109,6 +110,17 @@ IESG_CHARTER_ACTIVE_STATES = ("intrev", "extrev", "iesgrev")
 IESG_STATCHG_CONFLREV_ACTIVE_STATES = ("iesgeval", "defer")
 IESG_SUBSTATE_TAGS = ('ad-f-up', 'need-rev', 'extpty')
 
+
+def validate_doc_keywords(value):
+    if (
+        not isinstance(value, list | tuple | set) 
+        or not all(isinstance(elt, str) for elt in value)
+    ):
+        raise ValidationError(
+            f"Value must be an array of strings"
+        )
+
+
 class DocumentInfo(models.Model):
     """Any kind of document.  Draft, RFC, Charter, IPR Statement, Liaison Statement"""
     time = models.DateTimeField(default=timezone.now) # should probably have auto_now=True
@@ -142,6 +154,11 @@ class DocumentInfo(models.Model):
     uploaded_filename = models.TextField(blank=True)
     note = models.TextField(blank=True)
     rfc_number = models.PositiveIntegerField(blank=True, null=True)  # only valid for type="rfc"
+    keywords = models.JSONField(
+        default=list,
+        max_length=1000,
+        validators=[validate_doc_keywords],
+    )
 
     def file_extension(self):
         if not hasattr(self, '_cached_extension'):

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -116,9 +116,7 @@ def validate_doc_keywords(value):
         not isinstance(value, list | tuple | set) 
         or not all(isinstance(elt, str) for elt in value)
     ):
-        raise ValidationError(
-            f"Value must be an array of strings"
-        )
+        raise ValidationError("Value must be an array of strings")
 
 
 class DocumentInfo(models.Model):

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -158,6 +158,12 @@ class DocumentInfo(models.Model):
         validators=[validate_doc_keywords],
     )
 
+    @property
+    def doi(self) -> str | None:
+        if self.type_id == "rfc" and self.rfc_number is not None:
+            return f"{settings.IETF_DOI_PREFIX}/RFC{self.rfc_number:04d}"
+        return None
+
     def file_extension(self):
         if not hasattr(self, '_cached_extension'):
             if self.uploaded_filename:

--- a/ietf/doc/serializers.py
+++ b/ietf/doc/serializers.py
@@ -291,9 +291,9 @@ class RfcMetadataSerializer(serializers.ModelSerializer):
     @extend_schema_field(DocIdentifierSerializer(many=True))
     def get_identifiers(self, doc: Document):
         identifiers = []
-        if doc.rfc_number:
+        if doc.doi:
             identifiers.append(
-                DocIdentifier(type="doi", value=f"10.17487/RFC{doc.rfc_number:04d}")
+                DocIdentifier(type="doi", value=doc.doi)
             )
         return DocIdentifierSerializer(instance=identifiers, many=True).data
 

--- a/ietf/doc/views_doc.py
+++ b/ietf/doc/views_doc.py
@@ -1285,9 +1285,7 @@ def document_bibtex(request, name, rev=None):
                     break
 
     elif doc.type_id == "rfc":
-        # This needs to be replaced with a lookup, as the mapping may change
-        # over time.
-        doi = f"10.17487/RFC{doc.rfc_number:04d}"
+        doi = doc.doi
 
     if doc.is_dochistory():
         latest_event = doc.latest_event(type='new_revision', rev=rev)

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1576,3 +1576,5 @@ if SERVER_MODE != 'production':
 
 
 YOUTUBE_DOMAINS = ['www.youtube.com', 'youtube.com', 'youtu.be', 'm.youtube.com', 'youtube-nocookie.com', 'www.youtube-nocookie.com']
+
+IETF_DOI_PREFIX = "10.17487"

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -838,6 +838,12 @@ MATERIALS_TYPES_SERVED_BY_WORKER = [
     "slides",
 ]
 
+# Other storages
+# todo make this real
+STORAGES["red_bucket"] = {
+    "BACKEND": "django.core.files.storage.FileSystemStorage",
+    "OPTIONS": {"location": "red_bucket"},
+}
 
 # Override this in settings_local.py if needed
 # *_PATH variables ends with a slash/ .

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -839,9 +839,8 @@ MATERIALS_TYPES_SERVED_BY_WORKER = [
 ]
 
 # Other storages
-# todo make this real
 STORAGES["red_bucket"] = {
-    "BACKEND": "django.core.files.storage.FileSystemStorage",
+    "BACKEND": "django.core.files.storage.InMemoryStorage",
     "OPTIONS": {"location": "red_bucket"},
 }
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -938,9 +938,10 @@ RFC_EDITOR_GROUP_NOTIFICATION_EMAIL = "webmaster@rfc-editor.org"
 RFC_EDITOR_QUEUE_URL = "https://www.rfc-editor.org/queue2.xml"
 RFC_EDITOR_INDEX_URL = "https://www.rfc-editor.org/rfc/rfc-index.xml"
 RFC_EDITOR_ERRATA_JSON_URL = "https://www.rfc-editor.org/errata.json"
-RFC_EDITOR_ERRATA_URL = "https://www.rfc-editor.org/errata_search.php?rfc={rfc_number}"
 RFC_EDITOR_INLINE_ERRATA_URL = "https://www.rfc-editor.org/rfc/inline-errata/rfc{rfc_number}.html"
+RFC_EDITOR_ERRATA_BASE_URL = "https://www.rfc-editor.org/errata/"
 RFC_EDITOR_INFO_BASE_URL = "https://www.rfc-editor.org/info/"
+
 
 # NomCom Tool settings
 ROLODEX_URL = ""

--- a/ietf/settings_test.py
+++ b/ietf/settings_test.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import tempfile
 from ietf.settings import *                                          # pyflakes:ignore
-from ietf.settings import ORIG_AUTH_PASSWORD_VALIDATORS
+from ietf.settings import ORIG_AUTH_PASSWORD_VALIDATORS, STORAGES
 import debug                            # pyflakes:ignore
 debug.debug = True
 

--- a/ietf/settings_test.py
+++ b/ietf/settings_test.py
@@ -114,3 +114,9 @@ try:
     AUTH_PASSWORD_VALIDATORS = ORIG_AUTH_PASSWORD_VALIDATORS
 except NameError:
     pass
+
+# Use InMemoryStorage for red bucket storage
+STORAGES["red_bucket"] = {
+    "BACKEND": "django.core.files.storage.InMemoryStorage",
+    "OPTIONS": {"location": "red_bucket"},
+}

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -6,6 +6,9 @@ from io import StringIO, BytesIO
 from itertools import chain
 from operator import attrgetter, itemgetter
 from textwrap import fill
+from urllib.parse import urljoin
+
+from django.conf import settings
 from lxml import etree
 
 from django.core.files.storage import storages
@@ -32,7 +35,7 @@ def format_rfc_number(n):
 
 
 def errata_url(rfc: Document):
-    return f"https://www.rfc-editor.org/errata/rfc{rfc.rfc_number}"
+    return urljoin(settings.RFC_EDITOR_ERRATA_BASE_URL + "/", f"rfc{rfc.rfc_number}")
 
 
 @dataclass

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -359,20 +359,16 @@ def add_rfc_xml_index_entries(rfc_index):
         ElementTree.SubElement(entry, "stream").text = (
             "INDEPENDENT" if rfc.stream_id == "ise" else rfc.stream.name
         )
-        
+
         # Add area / wg_acronym
         if rfc.stream_id == "ietf":
             if rfc.group.acronym in ["none", "gen"]:
-                ElementTree.SubElement(
-                    entry, "wg_acronym"
-                ).text = "NON WORKING GROUP" 
+                ElementTree.SubElement(entry, "wg_acronym").text = "NON WORKING GROUP"
             else:
                 if rfc.area is not None:
                     ElementTree.SubElement(entry, "area").text = rfc.area.acronym
                 if rfc.group:
-                    ElementTree.SubElement(
-                        entry, "wg_acronym"
-                    ).text = rfc.group.acronym
+                    ElementTree.SubElement(entry, "wg_acronym").text = rfc.group.acronym
 
         if rfc.tags.filter(slug="errata").exists():
             ElementTree.SubElement(entry, "errata-url").text = errata_url(rfc)

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -20,10 +20,20 @@ from ietf.utils.log import log
 
 FORMATS_FOR_INDEX = ["txt", "html", "pdf", "xml", "ps"]
 
+# If True, tries to more closely match the legacy rfc-index.xml format for easier diff
+RFCINDEX_MATCH_LEGACY_XML = False
+
+
+def format_rfc_number(n):
+    if RFCINDEX_MATCH_LEGACY_XML:
+        return format(n, "04")
+    else:
+        return format(n)
+
 
 def rfc_doi(rfc: Document):
     assert rfc.rfc_number is not None
-    return f"10.17487/RFC{rfc.rfc_number:04d}"
+    return f"10.17487/RFC{format_rfc_number(rfc.rfc_number)}"
 
 
 def errata_url(rfc: Document):
@@ -106,7 +116,7 @@ def get_rfc_text_index_entries():
     )
     for rfc in rfcs:
         if isinstance(rfc, UnusableRfcNumber):
-            entries.append(f"{rfc.rfc_number:04d} Not Issued.")
+            entries.append(f"{format_rfc_number(rfc.rfc_number)} Not Issued.")
         else:
             assert isinstance(rfc, Document)
             authors = ", ".join(
@@ -139,7 +149,8 @@ def get_rfc_text_index_entries():
             )
             if len(obsoletes_documents) > 0:
                 obsoletes_names = ", ".join(
-                    f"RFC{doc.rfc_number:04d}" for doc in obsoletes_documents
+                    f"RFC{format_rfc_number(doc.rfc_number)}"
+                    for doc in obsoletes_documents
                 )
                 obsoletes = f" (Obsoletes {obsoletes_names})"
 
@@ -151,7 +162,8 @@ def get_rfc_text_index_entries():
             )
             if len(obsoleted_by_documents) > 0:
                 obsoleted_by_names = ", ".join(
-                    f"RFC{doc.rfc_number:04d}" for doc in obsoleted_by_documents
+                    f"RFC{format_rfc_number(doc.rfc_number)}"
+                    for doc in obsoleted_by_documents
                 )
                 obsoleted_by = f" (Obsoleted by {obsoleted_by_names})"
 
@@ -163,7 +175,8 @@ def get_rfc_text_index_entries():
             )
             if len(updates_documents) > 0:
                 updates_names = ", ".join(
-                    f"RFC{doc.rfc_number:04d}" for doc in updates_documents
+                    f"RFC{format_rfc_number(doc.rfc_number)}"
+                    for doc in updates_documents
                 )
                 updates = f" (Updates {updates_names})"
 
@@ -175,7 +188,8 @@ def get_rfc_text_index_entries():
             )
             if len(updated_by_documents) > 0:
                 updated_by_names = ", ".join(
-                    f"RFC{doc.rfc_number:04d}" for doc in updated_by_documents
+                    f"RFC{format_rfc_number(doc.rfc_number)}"
+                    for doc in updated_by_documents
                 )
                 updated_by = f" (Updated by {updated_by_names})"
 
@@ -183,7 +197,7 @@ def get_rfc_text_index_entries():
 
             # subseries
             subseries = ",".join(
-                f"{container.type.slug}{int(container.name[3:]):04d}"
+                f"{container.type.slug}{format_rfc_number(int(container.name[3:]))}"
                 for container in rfc.part_of()
             ).upper()
             if subseries:
@@ -191,7 +205,7 @@ def get_rfc_text_index_entries():
 
             entry = fill(
                 (
-                    f"{rfc.rfc_number:04d} {rfc.title}. {authors}. {date}. "
+                    f"{format_rfc_number(rfc.rfc_number)} {rfc.title}. {authors}. {date}. "
                     f"(Format: {formats}){doc_relations}{subseries}"
                     f"(Status: {str(rfc.std_level).upper()}) "
                     f"(DOI: {rfc_doi(rfc)})"
@@ -229,11 +243,15 @@ def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
         if len(contained_rfcs) == 0 and not include_all:
             continue
         entry = etree.SubElement(rfc_index, f"{ss_type}-entry")
-        etree.SubElement(entry, "doc-id").text = f"{ss_type.upper()}{ss_number:04d}"
+        etree.SubElement(
+            entry, "doc-id"
+        ).text = f"{ss_type.upper()}{format_rfc_number(ss_number)}"
         if len(contained_rfcs) > 0:
             is_also = etree.SubElement(entry, "is-also")
             for rfc in sorted(contained_rfcs, key=attrgetter("rfc_number")):
-                etree.SubElement(is_also, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
+                etree.SubElement(
+                    is_also, "doc-id"
+                ).text = f"RFC{format_rfc_number(rfc.rfc_number)}"
 
 
 def add_rfc_xml_index_entries(rfc_index):
@@ -260,7 +278,7 @@ def add_rfc_xml_index_entries(rfc_index):
             entry = etree.SubElement(rfc_index, "rfc-not-issued-entry")
             etree.SubElement(
                 entry, "doc-id"
-            ).text = f"RFC{next_unpublished.rfc_number:04d}"
+            ).text = f"RFC{format_rfc_number(next_unpublished.rfc_number)}"
             entries.append(entry)
             next_unpublished = next(unpublished_iter, None)
             continue
@@ -269,7 +287,9 @@ def add_rfc_xml_index_entries(rfc_index):
         next_published = next(published_iter, None)  # prep for next iteration
         entry = etree.SubElement(rfc_index, "rfc-entry")
 
-        etree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
+        etree.SubElement(
+            entry, "doc-id"
+        ).text = f"RFC{format_rfc_number(rfc.rfc_number)}"
         etree.SubElement(entry, "title").text = rfc.title
 
         for author in rfc.rfcauthor_set.all():
@@ -289,7 +309,7 @@ def add_rfc_xml_index_entries(rfc_index):
         fmts = [ff["fmt"] for ff in rfc.formats() if ff["fmt"] in FORMATS_FOR_INDEX]
         for fmt in sorted(fmts, key=format_ordering(rfc.rfc_number)):
             etree.SubElement(format_, "file-format").text = (
-                "ASCII" if fmt == "txt" else fmt.upper()
+                "ASCII" if RFCINDEX_MATCH_LEGACY_XML and fmt == "txt" else fmt.upper()
             )
 
         etree.SubElement(entry, "page-count").text = str(rfc.pages)
@@ -307,7 +327,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(obsoletes_documents) > 0:
             obsoletes = etree.SubElement(entry, "obsoletes")
             for doc in obsoletes_documents:
-                etree.SubElement(obsoletes, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                etree.SubElement(
+                    obsoletes, "doc-id"
+                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
 
         updates_documents = sorted(
             rfc.related_that_doc("updates"),
@@ -316,7 +338,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(updates_documents) > 0:
             updates = etree.SubElement(entry, "updates")
             for doc in updates_documents:
-                etree.SubElement(updates, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                etree.SubElement(
+                    updates, "doc-id"
+                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
 
         obsoleted_by_documents = sorted(
             rfc.related_that("obs"),
@@ -327,7 +351,7 @@ def add_rfc_xml_index_entries(rfc_index):
             for doc in obsoleted_by_documents:
                 etree.SubElement(
                     obsoleted_by, "doc-id"
-                ).text = f"RFC{doc.rfc_number:04d}"
+                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
 
         updated_by_documents = sorted(
             rfc.related_that("updates"),
@@ -336,7 +360,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(updated_by_documents) > 0:
             updated_by = etree.SubElement(entry, "updated-by")
             for doc in updated_by_documents:
-                etree.SubElement(updated_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                etree.SubElement(
+                    updated_by, "doc-id"
+                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
 
         if len(rfc.keywords) > 0:
             keywords = etree.SubElement(entry, "keywords")

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -2,27 +2,33 @@
 import json
 from collections.abc import Container
 from dataclasses import dataclass
-from io import StringIO
+from io import StringIO, BytesIO
 from itertools import chain
 from operator import attrgetter
 from textwrap import fill
 from xml.dom.minidom import parseString
 from xml.etree import ElementTree
 
-from django.conf import settings
 from django.core.files.storage import storages
+from django.db import models
+from django.db.models.functions import Substr, Cast
 from django.template.loader import render_to_string
 from django.utils import timezone
 
 from ietf.doc.models import Document
+from ietf.name.models import StdLevelName
 from ietf.utils.log import log
 
 FORMATS_FOR_INDEX = ["txt", "html", "pdf", "xml", "ps"]
 
 
-def render_doi(rfc: Document):
+def rfc_doi(rfc: Document):
     assert rfc.rfc_number is not None
     return f"10.17487/RFC{rfc.rfc_number:04d}"
+
+
+def errata_url(rfc: Document):
+    return f"https://www.rfc-editor.org/errata/rfc{rfc.rfc_number}"
 
 
 @dataclass
@@ -65,6 +71,24 @@ def get_april1_rfc_numbers() -> Container[int]:
     return records
 
 
+def get_publication_std_levels() -> Container[int]:
+    FILENAME = "publication-std-levels.json"
+    try:
+        with storages["red_bucket"].open(FILENAME) as urn_file:
+            records = json.load(urn_file)
+    except FileNotFoundError:
+        log(f"Error: unable to open {FILENAME} in red_bucket storage")
+        return []
+    except json.JSONDecodeError:
+        log(f"Error: unable to parse {FILENAME} in red_bucket storage")
+        return []
+    assert all(isinstance(record["number"], int) for record in records)
+    return {
+        record["number"]: StdLevelName.objects.get(slug=record["publication_std_level"])
+        for record in records
+    }
+
+
 def format_ordering(rfc_number):
     if rfc_number < 8650:
         ordering = ["txt", "ps", "pdf", "html", "xml"]
@@ -89,10 +113,11 @@ def get_rfc_text_index_entries():
             authors = ", ".join(
                 author.format_for_titlepage() for author in rfc.rfcauthor_set.all()
             )
+            published_at = rfc.pub_date()
             date = (
-                rfc.pub_date().strftime("1 %B %Y")
+                published_at.strftime("1 %B %Y")
                 if rfc.rfc_number in april1_rfc_numbers
-                else rfc.pub_date().strftime("%B %Y")
+                else published_at.strftime("%B %Y")
             )
 
             # formats
@@ -170,7 +195,7 @@ def get_rfc_text_index_entries():
                     f"{rfc.rfc_number:04d} {rfc.title}. {authors}. {date}. "
                     f"(Format: {formats}){doc_relations}{subseries}"
                     f"(Status: {str(rfc.std_level).upper()}) "
-                    f"(DOI: {render_doi(rfc)})"
+                    f"(DOI: {rfc_doi(rfc)})"
                 ),
                 width=73,
                 subsequent_indent=" " * 5,
@@ -180,188 +205,166 @@ def get_rfc_text_index_entries():
     return entries
 
 
-def add_bcp_xml_index_entries(rfc_index):
-    """Add BCP entries for rfc-index.xml"""
-    entries = []
-
-    highest_bcp_number = (
-        SubseriesMember.objects.filter(type_id="bcp").order_by("-number").first().number
+def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
+    """Add subseries entries for rfc-index.xml"""
+    # subseries docs annotated with numeric number
+    ss_docs = list(
+        Document.objects.filter(
+            type_id=ss_type
+        ).annotate(
+            number=Cast(
+                Substr("name", 4, None),
+                output_field=models.IntegerField(),
+            )
+        ).order_by("-number")
     )
-
-    for bcp_number in range(1, highest_bcp_number):
-        entry = ElementTree.SubElement(rfc_index, "bcp-entry")
-        ElementTree.SubElement(entry, "doc-id").text = f"BCP{bcp_number}"
-
-        subseries_members = SubseriesMember.objects.filter(
-            type_id="bcp", number=bcp_number
-        )
-        if subseries_members:
+    if len(ss_docs) == 0:
+        return  # very much not expected
+    highest_number = ss_docs[0].number
+    for ss_number in range(1, highest_number+1):
+        if ss_docs[-1].number == ss_number:
+            this_ss_doc = ss_docs.pop()
+            contained_rfcs = this_ss_doc.contains()
+        else:
+            contained_rfcs = []
+        if len(contained_rfcs) == 0 and not include_all:
+            continue
+        entry = ElementTree.SubElement(rfc_index, f"{ss_type}-entry")
+        ElementTree.SubElement(entry, "doc-id").text = f"{ss_type.upper()}{ss_number:04d}"
+        if len(contained_rfcs) > 0:
             is_also = ElementTree.SubElement(entry, "is-also")
-
-            for bcp_entry in subseries_members:
+            for rfc in sorted(contained_rfcs, key=attrgetter("rfc_number")):
                 ElementTree.SubElement(
                     is_also, "doc-id"
-                ).text = f"RFC{bcp_entry.rfc_to_be.rfc_number}"
-
-        entries.append(entry)
-
-
-def add_fyi_xml_index_entries(rfc_index):
-    """Add FYI entries for rfc-index.xml"""
-    entries = []
-
-    published_fyis = (
-        SubseriesMember.objects.filter(type_id="fyi").order_by("number").distinct()
-    )
-
-    for fyi in published_fyis:
-        entry = ElementTree.SubElement(rfc_index, "fyi-entry")
-        ElementTree.SubElement(entry, "doc-id").text = f"FYI{fyi.number}"
-        is_also = ElementTree.SubElement(entry, "is-also")
-
-        for fyi_entry in SubseriesMember.objects.filter(
-            type_id="fyi", number=fyi.number
-        ):
-            ElementTree.SubElement(
-                is_also, "doc-id"
-            ).text = f"RFC{fyi_entry.rfc_to_be.rfc_number}"
-
-        entries.append(entry)
-
-
-def add_std_xml_index_entries(rfc_index):
-    """Add std entries for rfc-index.xml"""
-    entries = []
-
-    published_stds = (
-        SubseriesMember.objects.filter(type_id="std").order_by("number").distinct()
-    )
-
-    for std in published_stds:
-        entry = ElementTree.SubElement(rfc_index, "std-entry")
-        ElementTree.SubElement(entry, "doc-id").text = f"STD{std.number}"
-        is_also = ElementTree.SubElement(entry, "is-also")
-
-        for std_entry in SubseriesMember.objects.filter(
-            type_id="std", number=std.number
-        ):
-            ElementTree.SubElement(
-                is_also, "doc-id"
-            ).text = f"RFC{std_entry.rfc_to_be.rfc_number}"
-
-        entries.append(entry)
+                ).text = f"RFC{rfc.rfc_number:04d}"
 
 
 def add_rfc_not_be_xml_index_entries(rfc_index):
     """Add unusable RFC entries for rfc-index.xml"""
     entries = []
 
-    for record in UnusableRfcNumber.objects.order_by("number"):
+    for record in sorted(get_unusable_rfc_numbers(), key=attrgetter("rfc_number")):
         entry = ElementTree.SubElement(rfc_index, "rfc-not-issued-entry")
-        ElementTree.SubElement(entry, "doc-id").text = f"RFC{record.number}"
+        ElementTree.SubElement(entry, "doc-id").text = f"RFC{record.rfc_number:04d}"
         entries.append(entry)
 
 
 def add_rfc_xml_index_entries(rfc_index):
     """Add RFC entries for rfc-index.xml"""
     entries = []
+    april1_rfc_numbers = get_april1_rfc_numbers()
+    publication_statuses = get_publication_std_levels()
+    
+    published_rfcs = Document.objects.filter(
+        type_id="rfc"
+    ).order_by("rfc_number")
 
-    published_rfcs = RfcToBe.objects.filter(published_at__isnull=False).order_by(
-        "rfc_number"
-    )
     for rfc in published_rfcs:
         entry = ElementTree.SubElement(rfc_index, "rfc-entry")
 
-        ElementTree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number}"
+        ElementTree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
         ElementTree.SubElement(entry, "title").text = rfc.title
 
-        for author in rfc.authors.all():
+        for author in rfc.rfcauthor_set.all():
             author_element = ElementTree.SubElement(entry, "author")
             ElementTree.SubElement(author_element, "name").text = author.titlepage_name
             if author.is_editor:
                 ElementTree.SubElement(author_element, "title").text = "Editor"
 
         date = ElementTree.SubElement(entry, "date")
-        ElementTree.SubElement(date, "month").text = rfc.published_at.strftime("%B")
-        if rfc.is_april_first_rfc:
-            ElementTree.SubElement(date, "day").text = str(rfc.published_at.day)
-        ElementTree.SubElement(date, "year").text = str(rfc.published_at.year)
+        published_at = rfc.pub_date()
+        ElementTree.SubElement(date, "month").text = published_at.strftime("%B")
+        if rfc.rfc_number in april1_rfc_numbers:
+            ElementTree.SubElement(date, "day").text = str(published_at.day)
+        ElementTree.SubElement(date, "year").text = str(published_at.year)
 
-        format = ElementTree.SubElement(entry, "format")
-        for file_format in rfc.published_formats.filter(
-            slug__in=FORMATS_FOR_INDEX
-        ).values_list("slug", flat=True):
-            ElementTree.SubElement(format, "file-format").text = file_format.upper()
+        format_ = ElementTree.SubElement(entry, "format")
+        fmts = [ff["fmt"] for ff in rfc.formats() if ff["fmt"] in FORMATS_FOR_INDEX]
+        for fmt in sorted(fmts, key=format_ordering(rfc.rfc_number)):
+            ElementTree.SubElement(
+                format_, "file-format"
+            ).text = "ASCII" if fmt == "txt" else fmt.upper()
 
         ElementTree.SubElement(entry, "page-count").text = str(rfc.pages)
 
-        if rfc.obsoletes:
+        part_of_documents = rfc.part_of()
+        if len(part_of_documents) > 0:
+            is_also = ElementTree.SubElement(entry, "is-also")
+            for doc in part_of_documents:
+                ElementTree.SubElement(is_also, "doc-id").text = doc.name.upper()
+        
+        obsoletes_documents = sorted(
+            rfc.related_that_doc("obs"),
+            key=attrgetter("rfc_number"),
+        )
+        if len(obsoletes_documents) > 0:
             obsoletes = ElementTree.SubElement(entry, "obsoletes")
-            for rfc_number in rfc.obsoletes.values_list(
-                "rfc_number", flat=True
-            ).order_by("rfc_number"):
-                ElementTree.SubElement(obsoletes, "doc-id").text = f"RFC{rfc_number}"
+            for doc in obsoletes_documents:
+                ElementTree.SubElement(obsoletes, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
-        if rfc.updates:
+        updates_documents = sorted(
+            rfc.related_that_doc("updates"),
+            key=attrgetter("rfc_number"),
+        )
+        if len(updates_documents) > 0:
             updates = ElementTree.SubElement(entry, "updates")
-            for rfc_number in rfc.updates.values_list("rfc_number", flat=True).order_by(
-                "rfc_number"
-            ):
-                ElementTree.SubElement(updates, "doc-id").text = f"RFC{rfc_number}"
+            for doc in updates_documents:
+                ElementTree.SubElement(updates, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
-        if rfc.obsoleted_by:
+        obsoleted_by_documents = sorted(
+            rfc.related_that("obs"),
+            key=attrgetter("rfc_number"),
+        )
+        if len(obsoleted_by_documents) > 0:
             obsoleted_by = ElementTree.SubElement(entry, "obsoleted-by")
-            for rfc_number in rfc.obsoleted_by.values_list(
-                "rfc_number", flat=True
-            ).order_by("rfc_number"):
-                ElementTree.SubElement(obsoleted_by, "doc-id").text = f"RFC{rfc_number}"
+            for doc in obsoleted_by_documents:
+                ElementTree.SubElement(obsoleted_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
-        if rfc.updated_by:
+        updated_by_documents = sorted(
+            rfc.related_that("updates"),
+            key=attrgetter("rfc_number"),
+        )
+        if len(updated_by_documents) > 0:
             updated_by = ElementTree.SubElement(entry, "updated-by")
-            for rfc_number in rfc.updated_by.values_list(
-                "rfc_number", flat=True
-            ).order_by("rfc_number"):
-                ElementTree.SubElement(updated_by, "doc-id").text = f"RFC{rfc_number}"
+            for doc in updated_by_documents:
+                ElementTree.SubElement(updated_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
-        if rfc.keywords.strip():
-            keywords = ElementTree.SubElement(entry, "keywords")
-            for keyword in rfc.keywords.strip().split(","):
-                ElementTree.SubElement(keywords, "kw").text = keyword.strip()
+        # todo implement keywords
+        # if rfc.keywords.strip():
+        #     keywords = ElementTree.SubElement(entry, "keywords")
+        #     for keyword in rfc.keywords.strip().split(","):
+        #         ElementTree.SubElement(keywords, "kw").text = keyword.strip()
 
         if rfc.abstract:
-            abstract = ElementTree.SubElement(entry, "abstract")
-            ElementTree.SubElement(abstract, "p").text = rfc.abstract
+            abstract_ = ElementTree.SubElement(entry, "abstract")
+            ElementTree.SubElement(abstract_, "p").text = rfc.abstract
 
-        if rfc.draft:
-            ElementTree.SubElement(entry, "draft").text = str(rfc.draft)
+        draft = rfc.came_from_draft()
+        if draft is not None:
+            ElementTree.SubElement(entry, "draft").text = draft.name
 
-        ElementTree.SubElement(entry, "current-status").text = str(
-            rfc.std_level
-        ).upper()
-        ElementTree.SubElement(entry, "publication-status").text = str(
-            rfc.publication_std_level
-        ).upper()
-        ElementTree.SubElement(entry, "stream").text = str(rfc.stream)
+        ElementTree.SubElement(entry, "current-status").text = rfc.std_level.name.upper()
+        ElementTree.SubElement(entry, "publication-status").text = publication_statuses[rfc.rfc_number].name.upper()
+        ElementTree.SubElement(entry, "stream").text = rfc.stream.name
 
-        if rfc.area:
-            ElementTree.SubElement(entry, "area").text = str(rfc.area)
+        if rfc.area is not None:
+            ElementTree.SubElement(entry, "area").text = rfc.area.acronym
 
-        if rfc.group:
-            ElementTree.SubElement(entry, "wg_acronym").text = str(rfc.group)
+        if rfc.group and rfc.group.type_id == "wg":
+            ElementTree.SubElement(entry, "wg_acronym").text = rfc.group.acronym
 
-        ElementTree.SubElement(
-            entry, "errata-url"
-        ).text = f"{settings.ERRATA_URL}/rfc{rfc.rfc_number}"
+        if rfc.tags.filter(slug="errata").exists():
+            ElementTree.SubElement(
+                entry, "errata-url"
+            ).text = errata_url(rfc)
         ElementTree.SubElement(
             entry, "doi"
-        ).text = f"{settings.DOI_PREFIX}/RFC{rfc.rfc_number:04d}"
+        ).text = rfc_doi(rfc)
         entries.append(entry)
 
 
 def create_rfc_txt_index():
-    """
-    Create text index of published documents
-    """
+    """Create text index of published documents"""
     DATE_FMT = "%m/%d/%Y"
     created_on = timezone.now().strftime(DATE_FMT)
     log("Creating rfc-index.txt")
@@ -377,15 +380,13 @@ def create_rfc_txt_index():
     # Django 4.2's FileSystemStorage does not support allow_overwrite. We can drop
     # the delete() when we move to a Storage class that supports it.
     red_bucket.delete(filename)
-    red_bucket.save("rfc-index.txt", StringIO(index))
-    log("Created rfc-index.txt in red_bucket storage")
+    red_bucket.save(filename, StringIO(index))
+    log(f"Created {filename} in red_bucket storage")
 
 
-def createRfcXmlIndex():
-    """
-    Create XML index of published documents
-    """
-    logger.info("Creating rfc-index.xml")
+def create_rfc_xml_index():
+    """Create XML index of published documents"""
+    log("Creating rfc-index.xml")
     rfc_index = ElementTree.Element(
         "rfc-index",
         attrib={
@@ -399,14 +400,19 @@ def createRfcXmlIndex():
     )
 
     # add data
-    add_bcp_xml_index_entries(rfc_index)
-    add_fyi_xml_index_entries(rfc_index)
+    add_subseries_xml_index_entries(rfc_index, "bcp", include_all=True)
+    add_subseries_xml_index_entries(rfc_index, "fyi")
     add_rfc_not_be_xml_index_entries(rfc_index)
     add_rfc_xml_index_entries(rfc_index)
-    add_std_xml_index_entries(rfc_index)
+    add_subseries_xml_index_entries(rfc_index, "std")
 
     # make it pretty
     rough_index = parseString(ElementTree.tostring(rfc_index, encoding="UTF-8"))
     pretty_index = rough_index.toprettyxml(indent=" " * 4, encoding="UTF-8")
-    print(pretty_index.decode())  # TODO: Write to a blob store
-    logger.info("Created rfc-index.xml")
+    red_bucket = storages["red_bucket"]
+    filename = "rfc-index.xml"
+    # Django 4.2's FileSystemStorage does not support allow_overwrite. We can drop
+    # the delete() when we move to a Storage class that supports it.
+    red_bucket.delete(filename)
+    red_bucket.save(filename, BytesIO(pretty_index))
+    log(f"Created {filename} in red_bucket storage")

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -4,7 +4,7 @@ from collections.abc import Container
 from dataclasses import dataclass
 from io import StringIO, BytesIO
 from itertools import chain
-from operator import attrgetter
+from operator import attrgetter, itemgetter
 from textwrap import fill
 from xml.dom.minidom import parseString
 from xml.etree import ElementTree
@@ -52,7 +52,7 @@ def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
     assert all(isinstance(record["comment"], str) for record in records)
     return [
         UnusableRfcNumber(rfc_number=record["number"], comment=record["comment"])
-        for record in records
+        for record in sorted(records, key=itemgetter("number"))
     ]
 
 
@@ -241,16 +241,6 @@ def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
                 ).text = f"RFC{rfc.rfc_number:04d}"
 
 
-def add_rfc_not_be_xml_index_entries(rfc_index):
-    """Add unusable RFC entries for rfc-index.xml"""
-    entries = []
-
-    for record in sorted(get_unusable_rfc_numbers(), key=attrgetter("rfc_number")):
-        entry = ElementTree.SubElement(rfc_index, "rfc-not-issued-entry")
-        ElementTree.SubElement(entry, "doc-id").text = f"RFC{record.rfc_number:04d}"
-        entries.append(entry)
-
-
 def add_rfc_xml_index_entries(rfc_index):
     """Add RFC entries for rfc-index.xml"""
     entries = []
@@ -259,7 +249,29 @@ def add_rfc_xml_index_entries(rfc_index):
 
     published_rfcs = Document.objects.filter(type_id="rfc").order_by("rfc_number")
 
-    for rfc in published_rfcs:
+    # Iterators for unpublished and published, both sorted by number
+    unpublished_iter = iter(get_unusable_rfc_numbers())
+    published_iter = iter(published_rfcs)
+
+    # Prime the next_* values
+    next_unpublished = next(unpublished_iter, None)
+    next_published = next(published_iter, None)
+
+    while next_published is not None or next_unpublished is not None:
+        if next_unpublished is not None and (
+            next_published is None
+            or next_unpublished.rfc_number < next_published.rfc_number
+        ):
+            entry = ElementTree.SubElement(rfc_index, "rfc-not-issued-entry")
+            ElementTree.SubElement(
+                entry, "doc-id"
+            ).text = f"RFC{next_unpublished.rfc_number:04d}"
+            entries.append(entry)
+            next_unpublished = next(unpublished_iter, None)
+            continue
+
+        rfc = next_published  # hang on to this
+        next_published = next(published_iter, None)  # prep for next iteration
         entry = ElementTree.SubElement(rfc_index, "rfc-entry")
 
         ElementTree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
@@ -415,7 +427,6 @@ def create_rfc_xml_index():
     # add data
     add_subseries_xml_index_entries(rfc_index, "bcp", include_all=True)
     add_subseries_xml_index_entries(rfc_index, "fyi")
-    add_rfc_not_be_xml_index_entries(rfc_index)
     add_rfc_xml_index_entries(rfc_index)
     add_subseries_xml_index_entries(rfc_index, "std")
 

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -33,7 +33,7 @@ def format_rfc_number(n):
 
 def rfc_doi(rfc: Document):
     assert rfc.rfc_number is not None
-    return f"10.17487/RFC{format_rfc_number(rfc.rfc_number)}"
+    return f"10.17487/RFC{rfc.rfc_number:04d}"
 
 
 def errata_url(rfc: Document):

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -31,11 +31,6 @@ def format_rfc_number(n):
         return format(n)
 
 
-def rfc_doi(rfc: Document):
-    assert rfc.rfc_number is not None
-    return f"10.17487/RFC{rfc.rfc_number:04d}"
-
-
 def errata_url(rfc: Document):
     return f"https://www.rfc-editor.org/errata/rfc{rfc.rfc_number}"
 
@@ -208,7 +203,7 @@ def get_rfc_text_index_entries():
                     f"{format_rfc_number(rfc.rfc_number)} {rfc.title}. {authors}. {date}. "
                     f"(Format: {formats}){doc_relations}{subseries}"
                     f"(Status: {str(rfc.std_level).upper()}) "
-                    f"(DOI: {rfc_doi(rfc)})"
+                    f"(DOI: {rfc.doi})"
                 ),
                 width=73,
                 subsequent_indent=" " * 5,
@@ -378,7 +373,7 @@ def add_rfc_xml_index_entries(rfc_index):
 
         if rfc.tags.filter(slug="errata").exists():
             etree.SubElement(entry, "errata-url").text = errata_url(rfc)
-        etree.SubElement(entry, "doi").text = rfc_doi(rfc)
+        etree.SubElement(entry, "doi").text = rfc.doi
         entries.append(entry)
 
 

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -1,5 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 import json
+from collections import defaultdict
 from collections.abc import Container
 from dataclasses import dataclass
 from io import StringIO, BytesIO
@@ -50,7 +51,14 @@ def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
         with storages["red_bucket"].open(FILENAME) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
-        log(f"Error: unable to open {FILENAME} in red_bucket storage")
+        if settings.SERVER_MODE == "production":
+            log(f"Error: unable to open {FILENAME} in red_bucket storage")
+            raise
+        elif settings.SERVER_MODE == "development":
+            log(
+                f"Unable to open {FILENAME} in red_bucket storage. This is okay in dev "
+                "but generated rfc-index will not agree with RFC Editor values."
+            )
         return []
     except json.JSONDecodeError:
         log(f"Error: unable to parse {FILENAME} in red_bucket storage")
@@ -69,7 +77,14 @@ def get_april1_rfc_numbers() -> Container[int]:
         with storages["red_bucket"].open(FILENAME) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
-        log(f"Error: unable to open {FILENAME} in red_bucket storage")
+        if settings.SERVER_MODE == "production":
+            log(f"Error: unable to open {FILENAME} in red_bucket storage")
+            raise
+        elif settings.SERVER_MODE == "development":
+            log(
+                f"Unable to open {FILENAME} in red_bucket storage. This is okay in dev "
+                "but generated rfc-index will not agree with RFC Editor values."
+            )
         return []
     except json.JSONDecodeError:
         log(f"Error: unable to parse {FILENAME} in red_bucket storage")
@@ -78,22 +93,34 @@ def get_april1_rfc_numbers() -> Container[int]:
     return records
 
 
-def get_publication_std_levels() -> Container[int]:
+def get_publication_std_levels() -> dict[int, StdLevelName]:
     FILENAME = "publication-std-levels.json"
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
-        log(f"Error: unable to open {FILENAME} in red_bucket storage")
-        return []
+        if settings.SERVER_MODE == "production":
+            log(f"Error: unable to open {FILENAME} in red_bucket storage")
+            raise
+        elif settings.SERVER_MODE == "development":
+            log(
+                f"Unable to open {FILENAME} in red_bucket storage. This is okay in dev "
+                "but generated rfc-index will not agree with RFC Editor values."
+            )
+        values = {}
     except json.JSONDecodeError:
         log(f"Error: unable to parse {FILENAME} in red_bucket storage")
-        return []
-    assert all(isinstance(record["number"], int) for record in records)
-    return {
-        record["number"]: StdLevelName.objects.get(slug=record["publication_std_level"])
-        for record in records
-    }
+        values = {}
+    else:
+        assert all(isinstance(record["number"], int) for record in records)
+        values = {
+            record["number"]: StdLevelName.objects.get(
+                slug=record["publication_std_level"]
+            )
+            for record in records
+        }
+    unknown_std_level = StdLevelName.objects.get(slug="unkn")
+    return defaultdict(lambda: unknown_std_level, values)
 
 
 def format_ordering(rfc_number):

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -6,8 +6,7 @@ from io import StringIO, BytesIO
 from itertools import chain
 from operator import attrgetter, itemgetter
 from textwrap import fill
-from xml.dom.minidom import parseString
-from xml.etree import ElementTree
+from lxml import etree
 
 from django.core.files.storage import storages
 from django.db import models
@@ -229,16 +228,12 @@ def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
             contained_rfcs = []
         if len(contained_rfcs) == 0 and not include_all:
             continue
-        entry = ElementTree.SubElement(rfc_index, f"{ss_type}-entry")
-        ElementTree.SubElement(
-            entry, "doc-id"
-        ).text = f"{ss_type.upper()}{ss_number:04d}"
+        entry = etree.SubElement(rfc_index, f"{ss_type}-entry")
+        etree.SubElement(entry, "doc-id").text = f"{ss_type.upper()}{ss_number:04d}"
         if len(contained_rfcs) > 0:
-            is_also = ElementTree.SubElement(entry, "is-also")
+            is_also = etree.SubElement(entry, "is-also")
             for rfc in sorted(contained_rfcs, key=attrgetter("rfc_number")):
-                ElementTree.SubElement(
-                    is_also, "doc-id"
-                ).text = f"RFC{rfc.rfc_number:04d}"
+                etree.SubElement(is_also, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
 
 
 def add_rfc_xml_index_entries(rfc_index):
@@ -262,8 +257,8 @@ def add_rfc_xml_index_entries(rfc_index):
             next_published is None
             or next_unpublished.rfc_number < next_published.rfc_number
         ):
-            entry = ElementTree.SubElement(rfc_index, "rfc-not-issued-entry")
-            ElementTree.SubElement(
+            entry = etree.SubElement(rfc_index, "rfc-not-issued-entry")
+            etree.SubElement(
                 entry, "doc-id"
             ).text = f"RFC{next_unpublished.rfc_number:04d}"
             entries.append(entry)
@@ -272,69 +267,65 @@ def add_rfc_xml_index_entries(rfc_index):
 
         rfc = next_published  # hang on to this
         next_published = next(published_iter, None)  # prep for next iteration
-        entry = ElementTree.SubElement(rfc_index, "rfc-entry")
+        entry = etree.SubElement(rfc_index, "rfc-entry")
 
-        ElementTree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
-        ElementTree.SubElement(entry, "title").text = rfc.title
+        etree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number:04d}"
+        etree.SubElement(entry, "title").text = rfc.title
 
         for author in rfc.rfcauthor_set.all():
-            author_element = ElementTree.SubElement(entry, "author")
-            ElementTree.SubElement(author_element, "name").text = author.titlepage_name
+            author_element = etree.SubElement(entry, "author")
+            etree.SubElement(author_element, "name").text = author.titlepage_name
             if author.is_editor:
-                ElementTree.SubElement(author_element, "title").text = "Editor"
+                etree.SubElement(author_element, "title").text = "Editor"
 
-        date = ElementTree.SubElement(entry, "date")
+        date = etree.SubElement(entry, "date")
         published_at = rfc.pub_date()
-        ElementTree.SubElement(date, "month").text = published_at.strftime("%B")
+        etree.SubElement(date, "month").text = published_at.strftime("%B")
         if rfc.rfc_number in april1_rfc_numbers:
-            ElementTree.SubElement(date, "day").text = str(published_at.day)
-        ElementTree.SubElement(date, "year").text = str(published_at.year)
+            etree.SubElement(date, "day").text = str(published_at.day)
+        etree.SubElement(date, "year").text = str(published_at.year)
 
-        format_ = ElementTree.SubElement(entry, "format")
+        format_ = etree.SubElement(entry, "format")
         fmts = [ff["fmt"] for ff in rfc.formats() if ff["fmt"] in FORMATS_FOR_INDEX]
         for fmt in sorted(fmts, key=format_ordering(rfc.rfc_number)):
-            ElementTree.SubElement(format_, "file-format").text = (
+            etree.SubElement(format_, "file-format").text = (
                 "ASCII" if fmt == "txt" else fmt.upper()
             )
 
-        ElementTree.SubElement(entry, "page-count").text = str(rfc.pages)
+        etree.SubElement(entry, "page-count").text = str(rfc.pages)
 
         part_of_documents = rfc.part_of()
         if len(part_of_documents) > 0:
-            is_also = ElementTree.SubElement(entry, "is-also")
+            is_also = etree.SubElement(entry, "is-also")
             for doc in part_of_documents:
-                ElementTree.SubElement(is_also, "doc-id").text = doc.name.upper()
+                etree.SubElement(is_also, "doc-id").text = doc.name.upper()
 
         obsoletes_documents = sorted(
             rfc.related_that_doc("obs"),
             key=attrgetter("rfc_number"),
         )
         if len(obsoletes_documents) > 0:
-            obsoletes = ElementTree.SubElement(entry, "obsoletes")
+            obsoletes = etree.SubElement(entry, "obsoletes")
             for doc in obsoletes_documents:
-                ElementTree.SubElement(
-                    obsoletes, "doc-id"
-                ).text = f"RFC{doc.rfc_number:04d}"
+                etree.SubElement(obsoletes, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
         updates_documents = sorted(
             rfc.related_that_doc("updates"),
             key=attrgetter("rfc_number"),
         )
         if len(updates_documents) > 0:
-            updates = ElementTree.SubElement(entry, "updates")
+            updates = etree.SubElement(entry, "updates")
             for doc in updates_documents:
-                ElementTree.SubElement(
-                    updates, "doc-id"
-                ).text = f"RFC{doc.rfc_number:04d}"
+                etree.SubElement(updates, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
         obsoleted_by_documents = sorted(
             rfc.related_that("obs"),
             key=attrgetter("rfc_number"),
         )
         if len(obsoleted_by_documents) > 0:
-            obsoleted_by = ElementTree.SubElement(entry, "obsoleted-by")
+            obsoleted_by = etree.SubElement(entry, "obsoleted-by")
             for doc in obsoleted_by_documents:
-                ElementTree.SubElement(
+                etree.SubElement(
                     obsoleted_by, "doc-id"
                 ).text = f"RFC{doc.rfc_number:04d}"
 
@@ -343,48 +334,44 @@ def add_rfc_xml_index_entries(rfc_index):
             key=attrgetter("rfc_number"),
         )
         if len(updated_by_documents) > 0:
-            updated_by = ElementTree.SubElement(entry, "updated-by")
+            updated_by = etree.SubElement(entry, "updated-by")
             for doc in updated_by_documents:
-                ElementTree.SubElement(
-                    updated_by, "doc-id"
-                ).text = f"RFC{doc.rfc_number:04d}"
+                etree.SubElement(updated_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
         if len(rfc.keywords) > 0:
-            keywords = ElementTree.SubElement(entry, "keywords")
+            keywords = etree.SubElement(entry, "keywords")
             for keyword in rfc.keywords:
-                ElementTree.SubElement(keywords, "kw").text = keyword.strip()
+                etree.SubElement(keywords, "kw").text = keyword.strip()
 
         if rfc.abstract:
-            abstract_ = ElementTree.SubElement(entry, "abstract")
-            ElementTree.SubElement(abstract_, "p").text = rfc.abstract
+            abstract_ = etree.SubElement(entry, "abstract")
+            etree.SubElement(abstract_, "p").text = rfc.abstract
 
         draft = rfc.came_from_draft()
         if draft is not None:
-            ElementTree.SubElement(entry, "draft").text = f"{draft.name}-{draft.rev}"
+            etree.SubElement(entry, "draft").text = f"{draft.name}-{draft.rev}"
 
-        ElementTree.SubElement(
-            entry, "current-status"
-        ).text = rfc.std_level.name.upper()
-        ElementTree.SubElement(entry, "publication-status").text = publication_statuses[
+        etree.SubElement(entry, "current-status").text = rfc.std_level.name.upper()
+        etree.SubElement(entry, "publication-status").text = publication_statuses[
             rfc.rfc_number
         ].name.upper()
-        ElementTree.SubElement(entry, "stream").text = (
+        etree.SubElement(entry, "stream").text = (
             "INDEPENDENT" if rfc.stream_id == "ise" else rfc.stream.name
         )
 
         # Add area / wg_acronym
         if rfc.stream_id == "ietf":
             if rfc.group.acronym in ["none", "gen"]:
-                ElementTree.SubElement(entry, "wg_acronym").text = "NON WORKING GROUP"
+                etree.SubElement(entry, "wg_acronym").text = "NON WORKING GROUP"
             else:
                 if rfc.area is not None:
-                    ElementTree.SubElement(entry, "area").text = rfc.area.acronym
+                    etree.SubElement(entry, "area").text = rfc.area.acronym
                 if rfc.group:
-                    ElementTree.SubElement(entry, "wg_acronym").text = rfc.group.acronym
+                    etree.SubElement(entry, "wg_acronym").text = rfc.group.acronym
 
         if rfc.tags.filter(slug="errata").exists():
-            ElementTree.SubElement(entry, "errata-url").text = errata_url(rfc)
-        ElementTree.SubElement(entry, "doi").text = rfc_doi(rfc)
+            etree.SubElement(entry, "errata-url").text = errata_url(rfc)
+        etree.SubElement(entry, "doi").text = rfc_doi(rfc)
         entries.append(entry)
 
 
@@ -411,13 +398,18 @@ def create_rfc_txt_index():
 
 def create_rfc_xml_index():
     """Create XML index of published documents"""
+    XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
+    XSI = "{" + XSI_NAMESPACE + "}"
+
     log("Creating rfc-index.xml")
-    rfc_index = ElementTree.Element(
+    rfc_index = etree.Element(
         "rfc-index",
+        nsmap={
+            None: "https://www.rfc-editor.org/rfc-index",
+            "xsi": XSI_NAMESPACE,
+        },
         attrib={
-            "xmlns": "https://www.rfc-editor.org/rfc-index",
-            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-            "xsi:schemaLocation": (
+            XSI + "schemaLocation": (
                 "https://www.rfc-editor.org/rfc-index "
                 "https://www.rfc-editor.org/rfc-index.xsd"
             ),
@@ -431,8 +423,12 @@ def create_rfc_xml_index():
     add_subseries_xml_index_entries(rfc_index, "std")
 
     # make it pretty
-    rough_index = parseString(ElementTree.tostring(rfc_index, encoding="UTF-8"))
-    pretty_index = rough_index.toprettyxml(indent=" " * 4, encoding="UTF-8")
+    pretty_index = etree.tostring(
+        rfc_index,
+        encoding="utf-8",
+        xml_declaration=True,
+        pretty_print=4,
+    )
     red_bucket = storages["red_bucket"]
     filename = "rfc-index.xml"
     # Django 4.2's FileSystemStorage does not support allow_overwrite. We can drop

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -314,6 +314,20 @@ def add_rfc_xml_index_entries(rfc_index):
 
         etree.SubElement(entry, "page-count").text = str(rfc.pages)
 
+        if len(rfc.keywords) > 0:
+            keywords = etree.SubElement(entry, "keywords")
+            for keyword in rfc.keywords:
+                etree.SubElement(keywords, "kw").text = keyword.strip()
+
+        if rfc.abstract:
+            abstract = etree.SubElement(entry, "abstract")
+            for paragraph in rfc.abstract.split("\n\n"):
+                etree.SubElement(abstract, "p").text = paragraph.strip()
+
+        draft = rfc.came_from_draft()
+        if draft is not None:
+            etree.SubElement(entry, "draft").text = f"{draft.name}-{draft.rev}"
+
         part_of_documents = rfc.part_of()
         if len(part_of_documents) > 0:
             is_also = etree.SubElement(entry, "is-also")
@@ -331,17 +345,6 @@ def add_rfc_xml_index_entries(rfc_index):
                     obsoletes, "doc-id"
                 ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
 
-        updates_documents = sorted(
-            rfc.related_that_doc("updates"),
-            key=attrgetter("rfc_number"),
-        )
-        if len(updates_documents) > 0:
-            updates = etree.SubElement(entry, "updates")
-            for doc in updates_documents:
-                etree.SubElement(
-                    updates, "doc-id"
-                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
-
         obsoleted_by_documents = sorted(
             rfc.related_that("obs"),
             key=attrgetter("rfc_number"),
@@ -351,6 +354,17 @@ def add_rfc_xml_index_entries(rfc_index):
             for doc in obsoleted_by_documents:
                 etree.SubElement(
                     obsoleted_by, "doc-id"
+                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
+
+        updates_documents = sorted(
+            rfc.related_that_doc("updates"),
+            key=attrgetter("rfc_number"),
+        )
+        if len(updates_documents) > 0:
+            updates = etree.SubElement(entry, "updates")
+            for doc in updates_documents:
+                etree.SubElement(
+                    updates, "doc-id"
                 ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
 
         updated_by_documents = sorted(
@@ -363,20 +377,6 @@ def add_rfc_xml_index_entries(rfc_index):
                 etree.SubElement(
                     updated_by, "doc-id"
                 ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
-
-        if len(rfc.keywords) > 0:
-            keywords = etree.SubElement(entry, "keywords")
-            for keyword in rfc.keywords:
-                etree.SubElement(keywords, "kw").text = keyword.strip()
-
-        if rfc.abstract:
-            abstract = etree.SubElement(entry, "abstract")
-            for paragraph in rfc.abstract.split("\n\n"):
-                etree.SubElement(abstract, "p").text = paragraph.strip()
-
-        draft = rfc.came_from_draft()
-        if draft is not None:
-            etree.SubElement(entry, "draft").text = f"{draft.name}-{draft.rev}"
 
         etree.SubElement(entry, "current-status").text = rfc.std_level.name.upper()
         etree.SubElement(entry, "publication-status").text = publication_statuses[

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -373,8 +373,9 @@ def add_rfc_xml_index_entries(rfc_index):
         format_ = etree.SubElement(entry, "format")
         fmts = [ff["fmt"] for ff in rfc.formats() if ff["fmt"] in FORMATS_FOR_INDEX]
         for fmt in sorted(fmts, key=format_ordering(rfc.rfc_number)):
+            match_legacy = getattr(settings, "RFCINDEX_MATCH_LEGACY_XML", False)
             etree.SubElement(format_, "file-format").text = (
-                "ASCII" if RFCINDEX_MATCH_LEGACY_XML and fmt == "txt" else fmt.upper()
+                "ASCII" if match_legacy and fmt == "txt" else fmt.upper()
             )
 
         etree.SubElement(entry, "page-count").text = str(rfc.pages)

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from io import StringIO, BytesIO
 from itertools import chain
 from operator import attrgetter, itemgetter
+from pathlib import Path
 from textwrap import fill
 from urllib.parse import urljoin
 
@@ -43,6 +44,16 @@ def errata_url(rfc: Document):
 class UnusableRfcNumber:
     rfc_number: int
     comment: str
+
+
+def save_to_red_bucket(filename: str, content: BytesIO | StringIO):
+    red_bucket = storages["red_bucket"]
+    bucket_path = str(Path(getattr(settings, "RFCINDEX_PATH_IN_BUCKET", "")) / filename)
+    if getattr(settings, "RFCINDEX_DELETE_THEN_WRITE", True):
+        # Django 4.2's FileSystemStorage does not support allow_overwrite.
+        red_bucket.delete(bucket_path)
+    red_bucket.save(bucket_path, content)
+    log(f"Saved {bucket_path} in red_bucket storage")
 
 
 def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
@@ -419,13 +430,7 @@ def create_rfc_txt_index():
             "rfcs": get_rfc_text_index_entries(),
         },
     )
-    red_bucket = storages["red_bucket"]
-    filename = "rfc-index.txt"
-    # Django 4.2's FileSystemStorage does not support allow_overwrite. We can drop
-    # the delete() when we move to a Storage class that supports it.
-    red_bucket.delete(filename)
-    red_bucket.save(filename, StringIO(index))
-    log(f"Created {filename} in red_bucket storage")
+    save_to_red_bucket("rfc-index.txt", StringIO(index))
 
 
 def create_rfc_xml_index():
@@ -461,10 +466,4 @@ def create_rfc_xml_index():
         xml_declaration=True,
         pretty_print=4,
     )
-    red_bucket = storages["red_bucket"]
-    filename = "rfc-index.xml"
-    # Django 4.2's FileSystemStorage does not support allow_overwrite. We can drop
-    # the delete() when we move to a Storage class that supports it.
-    red_bucket.delete(filename)
-    red_bucket.save(filename, BytesIO(pretty_index))
-    log(f"Created {filename} in red_bucket storage")
+    save_to_red_bucket("rfc-index.xml", BytesIO(pretty_index))

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -254,6 +254,25 @@ def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
                 ).text = f"RFC{format_rfc_number(rfc.rfc_number)}"
 
 
+def add_related_xml_index_entries(root: etree.Element, rfc: Document, tag: str):
+    relation_getter = {
+        "obsoletes": lambda doc: doc.related_that_doc("obs"),
+        "obsoleted-by": lambda doc: doc.related_that("obs"),
+        "updates": lambda doc: doc.related_that_doc("updates"),
+        "updated-by": lambda doc: doc.related_that("updates"),
+    }
+    related_docs = sorted(
+        relation_getter[tag](rfc),
+        key=attrgetter("rfc_number"),
+    )
+    if len(related_docs) > 0:
+        element = etree.SubElement(root, tag)
+        for doc in related_docs:
+            etree.SubElement(
+                element, "doc-id"
+            ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
+
+
 def add_rfc_xml_index_entries(rfc_index):
     """Add RFC entries for rfc-index.xml"""
     entries = []
@@ -334,49 +353,10 @@ def add_rfc_xml_index_entries(rfc_index):
             for doc in part_of_documents:
                 etree.SubElement(is_also, "doc-id").text = doc.name.upper()
 
-        obsoletes_documents = sorted(
-            rfc.related_that_doc("obs"),
-            key=attrgetter("rfc_number"),
-        )
-        if len(obsoletes_documents) > 0:
-            obsoletes = etree.SubElement(entry, "obsoletes")
-            for doc in obsoletes_documents:
-                etree.SubElement(
-                    obsoletes, "doc-id"
-                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
-
-        obsoleted_by_documents = sorted(
-            rfc.related_that("obs"),
-            key=attrgetter("rfc_number"),
-        )
-        if len(obsoleted_by_documents) > 0:
-            obsoleted_by = etree.SubElement(entry, "obsoleted-by")
-            for doc in obsoleted_by_documents:
-                etree.SubElement(
-                    obsoleted_by, "doc-id"
-                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
-
-        updates_documents = sorted(
-            rfc.related_that_doc("updates"),
-            key=attrgetter("rfc_number"),
-        )
-        if len(updates_documents) > 0:
-            updates = etree.SubElement(entry, "updates")
-            for doc in updates_documents:
-                etree.SubElement(
-                    updates, "doc-id"
-                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
-
-        updated_by_documents = sorted(
-            rfc.related_that("updates"),
-            key=attrgetter("rfc_number"),
-        )
-        if len(updated_by_documents) > 0:
-            updated_by = etree.SubElement(entry, "updated-by")
-            for doc in updated_by_documents:
-                etree.SubElement(
-                    updated_by, "doc-id"
-                ).text = f"RFC{format_rfc_number(doc.rfc_number)}"
+        add_related_xml_index_entries(entry, rfc, "obsoletes")
+        add_related_xml_index_entries(entry, rfc, "obsoleted-by")
+        add_related_xml_index_entries(entry, rfc, "updates")
+        add_related_xml_index_entries(entry, rfc, "updated-by")
 
         etree.SubElement(entry, "current-status").text = rfc.std_level.name.upper()
         etree.SubElement(entry, "publication-status").text = publication_statuses[

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -348,7 +348,7 @@ def add_rfc_xml_index_entries(rfc_index):
 
         draft = rfc.came_from_draft()
         if draft is not None:
-            ElementTree.SubElement(entry, "draft").text = draft.name
+            ElementTree.SubElement(entry, "draft").text = f"{draft.name}-{draft.rev}"
 
         ElementTree.SubElement(
             entry, "current-status"

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -388,7 +388,7 @@ def add_rfc_xml_index_entries(rfc_index):
 
         # Add area / wg_acronym
         if rfc.stream_id == "ietf":
-            if rfc.group.acronym in ["none", "gen"]:
+            if rfc.group.type_id in ["individ", "area"]:
                 etree.SubElement(entry, "wg_acronym").text = "NON WORKING GROUP"
             else:
                 if rfc.area is not None:

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -344,8 +344,9 @@ def add_rfc_xml_index_entries(rfc_index):
                 etree.SubElement(keywords, "kw").text = keyword.strip()
 
         if rfc.abstract:
-            abstract_ = etree.SubElement(entry, "abstract")
-            etree.SubElement(abstract_, "p").text = rfc.abstract
+            abstract = etree.SubElement(entry, "abstract")
+            for paragraph in rfc.abstract.split("\n\n"):
+                etree.SubElement(abstract, "p").text = paragraph.strip()
 
         draft = rfc.came_from_draft()
         if draft is not None:

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -209,19 +209,19 @@ def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
     """Add subseries entries for rfc-index.xml"""
     # subseries docs annotated with numeric number
     ss_docs = list(
-        Document.objects.filter(
-            type_id=ss_type
-        ).annotate(
+        Document.objects.filter(type_id=ss_type)
+        .annotate(
             number=Cast(
                 Substr("name", 4, None),
                 output_field=models.IntegerField(),
             )
-        ).order_by("-number")
+        )
+        .order_by("-number")
     )
     if len(ss_docs) == 0:
         return  # very much not expected
     highest_number = ss_docs[0].number
-    for ss_number in range(1, highest_number+1):
+    for ss_number in range(1, highest_number + 1):
         if ss_docs[-1].number == ss_number:
             this_ss_doc = ss_docs.pop()
             contained_rfcs = this_ss_doc.contains()
@@ -230,7 +230,9 @@ def add_subseries_xml_index_entries(rfc_index, ss_type, include_all=False):
         if len(contained_rfcs) == 0 and not include_all:
             continue
         entry = ElementTree.SubElement(rfc_index, f"{ss_type}-entry")
-        ElementTree.SubElement(entry, "doc-id").text = f"{ss_type.upper()}{ss_number:04d}"
+        ElementTree.SubElement(
+            entry, "doc-id"
+        ).text = f"{ss_type.upper()}{ss_number:04d}"
         if len(contained_rfcs) > 0:
             is_also = ElementTree.SubElement(entry, "is-also")
             for rfc in sorted(contained_rfcs, key=attrgetter("rfc_number")):
@@ -254,10 +256,8 @@ def add_rfc_xml_index_entries(rfc_index):
     entries = []
     april1_rfc_numbers = get_april1_rfc_numbers()
     publication_statuses = get_publication_std_levels()
-    
-    published_rfcs = Document.objects.filter(
-        type_id="rfc"
-    ).order_by("rfc_number")
+
+    published_rfcs = Document.objects.filter(type_id="rfc").order_by("rfc_number")
 
     for rfc in published_rfcs:
         entry = ElementTree.SubElement(rfc_index, "rfc-entry")
@@ -281,9 +281,9 @@ def add_rfc_xml_index_entries(rfc_index):
         format_ = ElementTree.SubElement(entry, "format")
         fmts = [ff["fmt"] for ff in rfc.formats() if ff["fmt"] in FORMATS_FOR_INDEX]
         for fmt in sorted(fmts, key=format_ordering(rfc.rfc_number)):
-            ElementTree.SubElement(
-                format_, "file-format"
-            ).text = "ASCII" if fmt == "txt" else fmt.upper()
+            ElementTree.SubElement(format_, "file-format").text = (
+                "ASCII" if fmt == "txt" else fmt.upper()
+            )
 
         ElementTree.SubElement(entry, "page-count").text = str(rfc.pages)
 
@@ -292,7 +292,7 @@ def add_rfc_xml_index_entries(rfc_index):
             is_also = ElementTree.SubElement(entry, "is-also")
             for doc in part_of_documents:
                 ElementTree.SubElement(is_also, "doc-id").text = doc.name.upper()
-        
+
         obsoletes_documents = sorted(
             rfc.related_that_doc("obs"),
             key=attrgetter("rfc_number"),
@@ -300,7 +300,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(obsoletes_documents) > 0:
             obsoletes = ElementTree.SubElement(entry, "obsoletes")
             for doc in obsoletes_documents:
-                ElementTree.SubElement(obsoletes, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                ElementTree.SubElement(
+                    obsoletes, "doc-id"
+                ).text = f"RFC{doc.rfc_number:04d}"
 
         updates_documents = sorted(
             rfc.related_that_doc("updates"),
@@ -309,7 +311,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(updates_documents) > 0:
             updates = ElementTree.SubElement(entry, "updates")
             for doc in updates_documents:
-                ElementTree.SubElement(updates, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                ElementTree.SubElement(
+                    updates, "doc-id"
+                ).text = f"RFC{doc.rfc_number:04d}"
 
         obsoleted_by_documents = sorted(
             rfc.related_that("obs"),
@@ -318,7 +322,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(obsoleted_by_documents) > 0:
             obsoleted_by = ElementTree.SubElement(entry, "obsoleted-by")
             for doc in obsoleted_by_documents:
-                ElementTree.SubElement(obsoleted_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                ElementTree.SubElement(
+                    obsoleted_by, "doc-id"
+                ).text = f"RFC{doc.rfc_number:04d}"
 
         updated_by_documents = sorted(
             rfc.related_that("updates"),
@@ -327,7 +333,9 @@ def add_rfc_xml_index_entries(rfc_index):
         if len(updated_by_documents) > 0:
             updated_by = ElementTree.SubElement(entry, "updated-by")
             for doc in updated_by_documents:
-                ElementTree.SubElement(updated_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
+                ElementTree.SubElement(
+                    updated_by, "doc-id"
+                ).text = f"RFC{doc.rfc_number:04d}"
 
         if len(rfc.keywords) > 0:
             keywords = ElementTree.SubElement(entry, "keywords")
@@ -342,23 +350,33 @@ def add_rfc_xml_index_entries(rfc_index):
         if draft is not None:
             ElementTree.SubElement(entry, "draft").text = draft.name
 
-        ElementTree.SubElement(entry, "current-status").text = rfc.std_level.name.upper()
-        ElementTree.SubElement(entry, "publication-status").text = publication_statuses[rfc.rfc_number].name.upper()
-        ElementTree.SubElement(entry, "stream").text = rfc.stream.name
-
-        if rfc.area is not None:
-            ElementTree.SubElement(entry, "area").text = rfc.area.acronym
-
-        if rfc.group and rfc.group.type_id == "wg":
-            ElementTree.SubElement(entry, "wg_acronym").text = rfc.group.acronym
+        ElementTree.SubElement(
+            entry, "current-status"
+        ).text = rfc.std_level.name.upper()
+        ElementTree.SubElement(entry, "publication-status").text = publication_statuses[
+            rfc.rfc_number
+        ].name.upper()
+        ElementTree.SubElement(entry, "stream").text = (
+            "INDEPENDENT" if rfc.stream_id == "ise" else rfc.stream.name
+        )
+        
+        # Add area / wg_acronym
+        if rfc.stream_id == "ietf":
+            if rfc.group.acronym in ["none", "gen"]:
+                ElementTree.SubElement(
+                    entry, "wg_acronym"
+                ).text = "NON WORKING GROUP" 
+            else:
+                if rfc.area is not None:
+                    ElementTree.SubElement(entry, "area").text = rfc.area.acronym
+                if rfc.group:
+                    ElementTree.SubElement(
+                        entry, "wg_acronym"
+                    ).text = rfc.group.acronym
 
         if rfc.tags.filter(slug="errata").exists():
-            ElementTree.SubElement(
-                entry, "errata-url"
-            ).text = errata_url(rfc)
-        ElementTree.SubElement(
-            entry, "doi"
-        ).text = rfc_doi(rfc)
+            ElementTree.SubElement(entry, "errata-url").text = errata_url(rfc)
+        ElementTree.SubElement(entry, "doi").text = rfc_doi(rfc)
         entries.append(entry)
 
 

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -329,11 +329,10 @@ def add_rfc_xml_index_entries(rfc_index):
             for doc in updated_by_documents:
                 ElementTree.SubElement(updated_by, "doc-id").text = f"RFC{doc.rfc_number:04d}"
 
-        # todo implement keywords
-        # if rfc.keywords.strip():
-        #     keywords = ElementTree.SubElement(entry, "keywords")
-        #     for keyword in rfc.keywords.strip().split(","):
-        #         ElementTree.SubElement(keywords, "kw").text = keyword.strip()
+        if len(rfc.keywords) > 0:
+            keywords = ElementTree.SubElement(entry, "keywords")
+            for keyword in rfc.keywords:
+                ElementTree.SubElement(keywords, "kw").text = keyword.strip()
 
         if rfc.abstract:
             abstract_ = ElementTree.SubElement(entry, "abstract")

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -48,7 +48,7 @@ class UnusableRfcNumber:
 
 def save_to_red_bucket(filename: str, content: BytesIO | StringIO):
     red_bucket = storages["red_bucket"]
-    bucket_path = str(Path(getattr(settings, "RFCINDEX_PATH_IN_BUCKET", "")) / filename)
+    bucket_path = str(Path(getattr(settings, "RFCINDEX_OUTPUT_PATH", "")) / filename)
     if getattr(settings, "RFCINDEX_DELETE_THEN_WRITE", True):
         # Django 4.2's FileSystemStorage does not support allow_overwrite.
         red_bucket.delete(bucket_path)
@@ -57,7 +57,8 @@ def save_to_red_bucket(filename: str, content: BytesIO | StringIO):
 
 
 def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
-    FILENAME = "unusable-rfc-numbers.json"
+    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) 
+    FILENAME = str(bucket_path / "unusable-rfc-numbers.json")
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:
             records = json.load(urn_file)
@@ -83,7 +84,8 @@ def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
 
 
 def get_april1_rfc_numbers() -> Container[int]:
-    FILENAME = "april-first-rfc-numbers.json"
+    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) 
+    FILENAME = str(bucket_path / "april-first-rfc-numbers.json")
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:
             records = json.load(urn_file)
@@ -105,7 +107,8 @@ def get_april1_rfc_numbers() -> Container[int]:
 
 
 def get_publication_std_levels() -> dict[int, StdLevelName]:
-    FILENAME = "publication-std-levels.json"
+    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) 
+    FILENAME = str(bucket_path / "publication-std-levels.json")
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:
             records = json.load(urn_file)

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -26,6 +26,7 @@ from ietf.utils.log import log
 FORMATS_FOR_INDEX = ["txt", "html", "pdf", "xml", "ps"]
 
 # If True, tries to more closely match the legacy rfc-index.xml format for easier diff
+# Must be False for tests to pass!
 RFCINDEX_MATCH_LEGACY_XML = False
 
 
@@ -57,7 +58,7 @@ def save_to_red_bucket(filename: str, content: BytesIO | StringIO):
 
 
 def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
-    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) 
+    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", ""))
     FILENAME = str(bucket_path / "unusable-rfc-numbers.json")
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:
@@ -84,7 +85,7 @@ def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
 
 
 def get_april1_rfc_numbers() -> Container[int]:
-    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) 
+    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", ""))
     FILENAME = str(bucket_path / "april-first-rfc-numbers.json")
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:
@@ -107,7 +108,7 @@ def get_april1_rfc_numbers() -> Container[int]:
 
 
 def get_publication_std_levels() -> dict[int, StdLevelName]:
-    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) 
+    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", ""))
     FILENAME = str(bucket_path / "publication-std-levels.json")
     try:
         with storages["red_bucket"].open(FILENAME) as urn_file:

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -1,0 +1,412 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+import json
+from collections.abc import Container
+from dataclasses import dataclass
+from io import StringIO
+from itertools import chain
+from operator import attrgetter
+from textwrap import fill
+from xml.dom.minidom import parseString
+from xml.etree import ElementTree
+
+from django.conf import settings
+from django.core.files.storage import storages
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+from ietf.doc.models import Document
+from ietf.utils.log import log
+
+FORMATS_FOR_INDEX = ["txt", "html", "pdf", "xml", "ps"]
+
+
+def render_doi(rfc: Document):
+    assert rfc.rfc_number is not None
+    return f"10.17487/RFC{rfc.rfc_number:04d}"
+
+
+@dataclass
+class UnusableRfcNumber:
+    rfc_number: int
+    comment: str
+
+
+def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
+    FILENAME = "unusable-rfc-numbers.json"
+    try:
+        with storages["red_bucket"].open(FILENAME) as urn_file:
+            records = json.load(urn_file)
+    except FileNotFoundError:
+        log(f"Error: unable to open {FILENAME} in red_bucket storage")
+        return []
+    except json.JSONDecodeError:
+        log(f"Error: unable to parse {FILENAME} in red_bucket storage")
+        return []
+    assert all(isinstance(record["number"], int) for record in records)
+    assert all(isinstance(record["comment"], str) for record in records)
+    return [
+        UnusableRfcNumber(rfc_number=record["number"], comment=record["comment"])
+        for record in records
+    ]
+
+
+def get_april1_rfc_numbers() -> Container[int]:
+    FILENAME = "april-first-rfc-numbers.json"
+    try:
+        with storages["red_bucket"].open(FILENAME) as urn_file:
+            records = json.load(urn_file)
+    except FileNotFoundError:
+        log(f"Error: unable to open {FILENAME} in red_bucket storage")
+        return []
+    except json.JSONDecodeError:
+        log(f"Error: unable to parse {FILENAME} in red_bucket storage")
+        return []
+    assert all(isinstance(record, int) for record in records)
+    return records
+
+
+def format_ordering(rfc_number):
+    if rfc_number < 8650:
+        ordering = ["txt", "ps", "pdf", "html", "xml"]
+    else:
+        ordering = ["html", "txt", "ps", "pdf", "xml"]
+    return ordering.index  # return the method
+
+
+def get_rfc_text_index_entries():
+    """Returns RFC entries for rfc-index.txt"""
+    entries = []
+    april1_rfc_numbers = get_april1_rfc_numbers()
+    published_rfcs = Document.objects.filter(type_id="rfc").order_by("rfc_number")
+    rfcs = sorted(
+        chain(published_rfcs, get_unusable_rfc_numbers()), key=attrgetter("rfc_number")
+    )
+    for rfc in rfcs:
+        if isinstance(rfc, UnusableRfcNumber):
+            entries.append(f"{rfc.rfc_number:04d} Not Issued.")
+        else:
+            assert isinstance(rfc, Document)
+            authors = ", ".join(
+                author.format_for_titlepage() for author in rfc.rfcauthor_set.all()
+            )
+            date = (
+                rfc.pub_date().strftime("1 %B %Y")
+                if rfc.rfc_number in april1_rfc_numbers
+                else rfc.pub_date().strftime("%B %Y")
+            )
+
+            # formats
+            formats = ", ".join(
+                sorted(
+                    [
+                        format["fmt"]
+                        for format in rfc.formats()
+                        if format["fmt"] in FORMATS_FOR_INDEX
+                    ],
+                    key=format_ordering(rfc.rfc_number),
+                )
+            ).upper()
+
+            # obsoletes
+            obsoletes = ""
+            obsoletes_documents = sorted(
+                rfc.related_that_doc("obs"),
+                key=attrgetter("rfc_number"),
+            )
+            if len(obsoletes_documents) > 0:
+                obsoletes_names = ", ".join(
+                    f"RFC{doc.rfc_number:04d}" for doc in obsoletes_documents
+                )
+                obsoletes = f" (Obsoletes {obsoletes_names})"
+
+            # obsoleted by
+            obsoleted_by = ""
+            obsoleted_by_documents = sorted(
+                rfc.related_that("obs"),
+                key=attrgetter("rfc_number"),
+            )
+            if len(obsoleted_by_documents) > 0:
+                obsoleted_by_names = ", ".join(
+                    f"RFC{doc.rfc_number:04d}" for doc in obsoleted_by_documents
+                )
+                obsoleted_by = f" (Obsoleted by {obsoleted_by_names})"
+
+            # updates
+            updates = ""
+            updates_documents = sorted(
+                rfc.related_that_doc("updates"),
+                key=attrgetter("rfc_number"),
+            )
+            if len(updates_documents) > 0:
+                updates_names = ", ".join(
+                    f"RFC{doc.rfc_number:04d}" for doc in updates_documents
+                )
+                updates = f" (Updates {updates_names})"
+
+            # updated by
+            updated_by = ""
+            updated_by_documents = sorted(
+                rfc.related_that("updates"),
+                key=attrgetter("rfc_number"),
+            )
+            if len(updated_by_documents) > 0:
+                updated_by_names = ", ".join(
+                    f"RFC{doc.rfc_number:04d}" for doc in updated_by_documents
+                )
+                updated_by = f" (Updated by {updated_by_names})"
+
+            doc_relations = f"{obsoletes}{obsoleted_by}{updates}{updated_by} "
+
+            # subseries
+            subseries = ",".join(
+                f"{container.type.slug}{int(container.name[3:]):04d}"
+                for container in rfc.part_of()
+            ).upper()
+            if subseries:
+                subseries = f"(Also {subseries}) "
+
+            entry = fill(
+                (
+                    f"{rfc.rfc_number:04d} {rfc.title}. {authors}. {date}. "
+                    f"(Format: {formats}){doc_relations}{subseries}"
+                    f"(Status: {str(rfc.std_level).upper()}) "
+                    f"(DOI: {render_doi(rfc)})"
+                ),
+                width=73,
+                subsequent_indent=" " * 5,
+            )
+            entries.append(entry)
+
+    return entries
+
+
+def add_bcp_xml_index_entries(rfc_index):
+    """Add BCP entries for rfc-index.xml"""
+    entries = []
+
+    highest_bcp_number = (
+        SubseriesMember.objects.filter(type_id="bcp").order_by("-number").first().number
+    )
+
+    for bcp_number in range(1, highest_bcp_number):
+        entry = ElementTree.SubElement(rfc_index, "bcp-entry")
+        ElementTree.SubElement(entry, "doc-id").text = f"BCP{bcp_number}"
+
+        subseries_members = SubseriesMember.objects.filter(
+            type_id="bcp", number=bcp_number
+        )
+        if subseries_members:
+            is_also = ElementTree.SubElement(entry, "is-also")
+
+            for bcp_entry in subseries_members:
+                ElementTree.SubElement(
+                    is_also, "doc-id"
+                ).text = f"RFC{bcp_entry.rfc_to_be.rfc_number}"
+
+        entries.append(entry)
+
+
+def add_fyi_xml_index_entries(rfc_index):
+    """Add FYI entries for rfc-index.xml"""
+    entries = []
+
+    published_fyis = (
+        SubseriesMember.objects.filter(type_id="fyi").order_by("number").distinct()
+    )
+
+    for fyi in published_fyis:
+        entry = ElementTree.SubElement(rfc_index, "fyi-entry")
+        ElementTree.SubElement(entry, "doc-id").text = f"FYI{fyi.number}"
+        is_also = ElementTree.SubElement(entry, "is-also")
+
+        for fyi_entry in SubseriesMember.objects.filter(
+            type_id="fyi", number=fyi.number
+        ):
+            ElementTree.SubElement(
+                is_also, "doc-id"
+            ).text = f"RFC{fyi_entry.rfc_to_be.rfc_number}"
+
+        entries.append(entry)
+
+
+def add_std_xml_index_entries(rfc_index):
+    """Add std entries for rfc-index.xml"""
+    entries = []
+
+    published_stds = (
+        SubseriesMember.objects.filter(type_id="std").order_by("number").distinct()
+    )
+
+    for std in published_stds:
+        entry = ElementTree.SubElement(rfc_index, "std-entry")
+        ElementTree.SubElement(entry, "doc-id").text = f"STD{std.number}"
+        is_also = ElementTree.SubElement(entry, "is-also")
+
+        for std_entry in SubseriesMember.objects.filter(
+            type_id="std", number=std.number
+        ):
+            ElementTree.SubElement(
+                is_also, "doc-id"
+            ).text = f"RFC{std_entry.rfc_to_be.rfc_number}"
+
+        entries.append(entry)
+
+
+def add_rfc_not_be_xml_index_entries(rfc_index):
+    """Add unusable RFC entries for rfc-index.xml"""
+    entries = []
+
+    for record in UnusableRfcNumber.objects.order_by("number"):
+        entry = ElementTree.SubElement(rfc_index, "rfc-not-issued-entry")
+        ElementTree.SubElement(entry, "doc-id").text = f"RFC{record.number}"
+        entries.append(entry)
+
+
+def add_rfc_xml_index_entries(rfc_index):
+    """Add RFC entries for rfc-index.xml"""
+    entries = []
+
+    published_rfcs = RfcToBe.objects.filter(published_at__isnull=False).order_by(
+        "rfc_number"
+    )
+    for rfc in published_rfcs:
+        entry = ElementTree.SubElement(rfc_index, "rfc-entry")
+
+        ElementTree.SubElement(entry, "doc-id").text = f"RFC{rfc.rfc_number}"
+        ElementTree.SubElement(entry, "title").text = rfc.title
+
+        for author in rfc.authors.all():
+            author_element = ElementTree.SubElement(entry, "author")
+            ElementTree.SubElement(author_element, "name").text = author.titlepage_name
+            if author.is_editor:
+                ElementTree.SubElement(author_element, "title").text = "Editor"
+
+        date = ElementTree.SubElement(entry, "date")
+        ElementTree.SubElement(date, "month").text = rfc.published_at.strftime("%B")
+        if rfc.is_april_first_rfc:
+            ElementTree.SubElement(date, "day").text = str(rfc.published_at.day)
+        ElementTree.SubElement(date, "year").text = str(rfc.published_at.year)
+
+        format = ElementTree.SubElement(entry, "format")
+        for file_format in rfc.published_formats.filter(
+            slug__in=FORMATS_FOR_INDEX
+        ).values_list("slug", flat=True):
+            ElementTree.SubElement(format, "file-format").text = file_format.upper()
+
+        ElementTree.SubElement(entry, "page-count").text = str(rfc.pages)
+
+        if rfc.obsoletes:
+            obsoletes = ElementTree.SubElement(entry, "obsoletes")
+            for rfc_number in rfc.obsoletes.values_list(
+                "rfc_number", flat=True
+            ).order_by("rfc_number"):
+                ElementTree.SubElement(obsoletes, "doc-id").text = f"RFC{rfc_number}"
+
+        if rfc.updates:
+            updates = ElementTree.SubElement(entry, "updates")
+            for rfc_number in rfc.updates.values_list("rfc_number", flat=True).order_by(
+                "rfc_number"
+            ):
+                ElementTree.SubElement(updates, "doc-id").text = f"RFC{rfc_number}"
+
+        if rfc.obsoleted_by:
+            obsoleted_by = ElementTree.SubElement(entry, "obsoleted-by")
+            for rfc_number in rfc.obsoleted_by.values_list(
+                "rfc_number", flat=True
+            ).order_by("rfc_number"):
+                ElementTree.SubElement(obsoleted_by, "doc-id").text = f"RFC{rfc_number}"
+
+        if rfc.updated_by:
+            updated_by = ElementTree.SubElement(entry, "updated-by")
+            for rfc_number in rfc.updated_by.values_list(
+                "rfc_number", flat=True
+            ).order_by("rfc_number"):
+                ElementTree.SubElement(updated_by, "doc-id").text = f"RFC{rfc_number}"
+
+        if rfc.keywords.strip():
+            keywords = ElementTree.SubElement(entry, "keywords")
+            for keyword in rfc.keywords.strip().split(","):
+                ElementTree.SubElement(keywords, "kw").text = keyword.strip()
+
+        if rfc.abstract:
+            abstract = ElementTree.SubElement(entry, "abstract")
+            ElementTree.SubElement(abstract, "p").text = rfc.abstract
+
+        if rfc.draft:
+            ElementTree.SubElement(entry, "draft").text = str(rfc.draft)
+
+        ElementTree.SubElement(entry, "current-status").text = str(
+            rfc.std_level
+        ).upper()
+        ElementTree.SubElement(entry, "publication-status").text = str(
+            rfc.publication_std_level
+        ).upper()
+        ElementTree.SubElement(entry, "stream").text = str(rfc.stream)
+
+        if rfc.area:
+            ElementTree.SubElement(entry, "area").text = str(rfc.area)
+
+        if rfc.group:
+            ElementTree.SubElement(entry, "wg_acronym").text = str(rfc.group)
+
+        ElementTree.SubElement(
+            entry, "errata-url"
+        ).text = f"{settings.ERRATA_URL}/rfc{rfc.rfc_number}"
+        ElementTree.SubElement(
+            entry, "doi"
+        ).text = f"{settings.DOI_PREFIX}/RFC{rfc.rfc_number:04d}"
+        entries.append(entry)
+
+
+def create_rfc_txt_index():
+    """
+    Create text index of published documents
+    """
+    DATE_FMT = "%m/%d/%Y"
+    created_on = timezone.now().strftime(DATE_FMT)
+    log("Creating rfc-index.txt")
+    index = render_to_string(
+        "sync/rfc-index.txt",
+        {
+            "created_on": created_on,
+            "rfcs": get_rfc_text_index_entries(),
+        },
+    )
+    red_bucket = storages["red_bucket"]
+    filename = "rfc-index.txt"
+    # Django 4.2's FileSystemStorage does not support allow_overwrite. We can drop
+    # the delete() when we move to a Storage class that supports it.
+    red_bucket.delete(filename)
+    red_bucket.save("rfc-index.txt", StringIO(index))
+    log("Created rfc-index.txt in red_bucket storage")
+
+
+def createRfcXmlIndex():
+    """
+    Create XML index of published documents
+    """
+    logger.info("Creating rfc-index.xml")
+    rfc_index = ElementTree.Element(
+        "rfc-index",
+        attrib={
+            "xmlns": "https://www.rfc-editor.org/rfc-index",
+            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            "xsi:schemaLocation": (
+                "https://www.rfc-editor.org/rfc-index "
+                "https://www.rfc-editor.org/rfc-index.xsd"
+            ),
+        },
+    )
+
+    # add data
+    add_bcp_xml_index_entries(rfc_index)
+    add_fyi_xml_index_entries(rfc_index)
+    add_rfc_not_be_xml_index_entries(rfc_index)
+    add_rfc_xml_index_entries(rfc_index)
+    add_std_xml_index_entries(rfc_index)
+
+    # make it pretty
+    rough_index = parseString(ElementTree.tostring(rfc_index, encoding="UTF-8"))
+    pretty_index = rough_index.toprettyxml(indent=" " * 4, encoding="UTF-8")
+    print(pretty_index.decode())  # TODO: Write to a blob store
+    logger.info("Created rfc-index.xml")

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -41,12 +41,6 @@ def errata_url(rfc: Document):
     return urljoin(settings.RFC_EDITOR_ERRATA_BASE_URL + "/", f"rfc{rfc.rfc_number}")
 
 
-@dataclass
-class UnusableRfcNumber:
-    rfc_number: int
-    comment: str
-
-
 def save_to_red_bucket(filename: str, content: BytesIO | StringIO):
     red_bucket = storages["red_bucket"]
     bucket_path = str(Path(getattr(settings, "RFCINDEX_OUTPUT_PATH", "")) / filename)
@@ -57,24 +51,30 @@ def save_to_red_bucket(filename: str, content: BytesIO | StringIO):
     log(f"Saved {bucket_path} in red_bucket storage")
 
 
+@dataclass
+class UnusableRfcNumber:
+    rfc_number: int
+    comment: str
+
+
 def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
-    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", ""))
-    FILENAME = str(bucket_path / "unusable-rfc-numbers.json")
+    FILENAME = "unusable-rfc-numbers.json"
+    bucket_path = str(Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) / FILENAME)
     try:
-        with storages["red_bucket"].open(FILENAME) as urn_file:
+        with storages["red_bucket"].open(bucket_path) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
         if settings.SERVER_MODE == "production":
-            log(f"Error: unable to open {FILENAME} in red_bucket storage")
+            log(f"Error: unable to open {bucket_path} in red_bucket storage")
             raise
         elif settings.SERVER_MODE == "development":
             log(
-                f"Unable to open {FILENAME} in red_bucket storage. This is okay in dev "
+                f"Unable to open {bucket_path} in red_bucket storage. This is okay in dev "
                 "but generated rfc-index will not agree with RFC Editor values."
             )
         return []
     except json.JSONDecodeError:
-        log(f"Error: unable to parse {FILENAME} in red_bucket storage")
+        log(f"Error: unable to parse {bucket_path} in red_bucket storage")
         return []
     assert all(isinstance(record["number"], int) for record in records)
     assert all(isinstance(record["comment"], str) for record in records)
@@ -85,47 +85,46 @@ def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
 
 
 def get_april1_rfc_numbers() -> Container[int]:
-    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", ""))
-    FILENAME = str(bucket_path / "april-first-rfc-numbers.json")
+    FILENAME = "april-first-rfc-numbers.json"
+    bucket_path = str(Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) / FILENAME)
     try:
-        with storages["red_bucket"].open(FILENAME) as urn_file:
+        with storages["red_bucket"].open(bucket_path) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
         if settings.SERVER_MODE == "production":
-            log(f"Error: unable to open {FILENAME} in red_bucket storage")
+            log(f"Error: unable to open {bucket_path} in red_bucket storage")
             raise
         elif settings.SERVER_MODE == "development":
             log(
-                f"Unable to open {FILENAME} in red_bucket storage. This is okay in dev "
+                f"Unable to open {bucket_path} in red_bucket storage. This is okay in dev "
                 "but generated rfc-index will not agree with RFC Editor values."
             )
         return []
     except json.JSONDecodeError:
-        log(f"Error: unable to parse {FILENAME} in red_bucket storage")
+        log(f"Error: unable to parse {bucket_path} in red_bucket storage")
         return []
     assert all(isinstance(record, int) for record in records)
     return records
 
 
 def get_publication_std_levels() -> dict[int, StdLevelName]:
-    bucket_path = Path(getattr(settings, "RFCINDEX_INPUT_PATH", ""))
-    FILENAME = str(bucket_path / "publication-std-levels.json")
+    FILENAME = "publication-std-levels.json"
+    bucket_path = str(Path(getattr(settings, "RFCINDEX_INPUT_PATH", "")) / FILENAME)
+    values: dict[int, StdLevelName] = {}
     try:
-        with storages["red_bucket"].open(FILENAME) as urn_file:
+        with storages["red_bucket"].open(bucket_path) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
         if settings.SERVER_MODE == "production":
-            log(f"Error: unable to open {FILENAME} in red_bucket storage")
+            log(f"Error: unable to open {bucket_path} in red_bucket storage")
             raise
         elif settings.SERVER_MODE == "development":
             log(
-                f"Unable to open {FILENAME} in red_bucket storage. This is okay in dev "
+                f"Unable to open {bucket_path} in red_bucket storage. This is okay in dev "
                 "but generated rfc-index will not agree with RFC Editor values."
             )
-        values = {}
     except json.JSONDecodeError:
-        log(f"Error: unable to parse {FILENAME} in red_bucket storage")
-        values = {}
+        log(f"Error: unable to parse {bucket_path} in red_bucket storage")
     else:
         assert all(isinstance(record["number"], int) for record in records)
         values = {
@@ -134,6 +133,7 @@ def get_publication_std_levels() -> dict[int, StdLevelName]:
             )
             for record in records
         }
+    # defaultdict to return "unknown" for any missing values
     unknown_std_level = StdLevelName.objects.get(slug="unkn")
     return defaultdict(lambda: unknown_std_level, values)
 

--- a/ietf/sync/rfcindex.py
+++ b/ietf/sync/rfcindex.py
@@ -25,13 +25,14 @@ from ietf.utils.log import log
 
 FORMATS_FOR_INDEX = ["txt", "html", "pdf", "xml", "ps"]
 
-# If True, tries to more closely match the legacy rfc-index.xml format for easier diff
-# Must be False for tests to pass!
-RFCINDEX_MATCH_LEGACY_XML = False
-
 
 def format_rfc_number(n):
-    if RFCINDEX_MATCH_LEGACY_XML:
+    """Format an RFC number (or subseries doc number)
+    
+    Set settings.RFCINDEX_MATCH_LEGACY_XML=True for the legacy (leading-zero) format.
+    That is for debugging only - tests will fail.
+    """
+    if getattr(settings, "RFCINDEX_MATCH_LEGACY_XML", False):
         return format(n, "04")
     else:
         return format(n)
@@ -64,18 +65,19 @@ def get_unusable_rfc_numbers() -> list[UnusableRfcNumber]:
         with storages["red_bucket"].open(bucket_path) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
-        if settings.SERVER_MODE == "production":
-            log(f"Error: unable to open {bucket_path} in red_bucket storage")
-            raise
-        elif settings.SERVER_MODE == "development":
+        if settings.SERVER_MODE == "development":
             log(
                 f"Unable to open {bucket_path} in red_bucket storage. This is okay in dev "
                 "but generated rfc-index will not agree with RFC Editor values."
-            )
-        return []
+            )  # pragma: no cover
+            return []  # pragma: no cover
+        log(f"Error: unable to open {bucket_path} in red_bucket storage")
+        raise
     except json.JSONDecodeError:
         log(f"Error: unable to parse {bucket_path} in red_bucket storage")
-        return []
+        if settings.SERVER_MODE == "development":
+            return []  # pragma: no cover  
+        raise
     assert all(isinstance(record["number"], int) for record in records)
     assert all(isinstance(record["comment"], str) for record in records)
     return [
@@ -91,18 +93,19 @@ def get_april1_rfc_numbers() -> Container[int]:
         with storages["red_bucket"].open(bucket_path) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
-        if settings.SERVER_MODE == "production":
-            log(f"Error: unable to open {bucket_path} in red_bucket storage")
-            raise
-        elif settings.SERVER_MODE == "development":
+        if settings.SERVER_MODE == "development":
             log(
                 f"Unable to open {bucket_path} in red_bucket storage. This is okay in dev "
                 "but generated rfc-index will not agree with RFC Editor values."
-            )
-        return []
+            )  # pragma: no cover
+            return []  # pragma: no cover
+        log(f"Error: unable to open {bucket_path} in red_bucket storage")
+        raise
     except json.JSONDecodeError:
         log(f"Error: unable to parse {bucket_path} in red_bucket storage")
-        return []
+        if settings.SERVER_MODE == "development":
+            return []  # pragma: no cover
+        raise
     assert all(isinstance(record, int) for record in records)
     return records
 
@@ -115,16 +118,19 @@ def get_publication_std_levels() -> dict[int, StdLevelName]:
         with storages["red_bucket"].open(bucket_path) as urn_file:
             records = json.load(urn_file)
     except FileNotFoundError:
-        if settings.SERVER_MODE == "production":
-            log(f"Error: unable to open {bucket_path} in red_bucket storage")
-            raise
-        elif settings.SERVER_MODE == "development":
+        if settings.SERVER_MODE == "development":
             log(
                 f"Unable to open {bucket_path} in red_bucket storage. This is okay in dev "
                 "but generated rfc-index will not agree with RFC Editor values."
-            )
+            )  # pragma: no cover
+            # intentionally fall through instead of return here
+        else:
+            log(f"Error: unable to open {bucket_path} in red_bucket storage")
+            raise
     except json.JSONDecodeError:
         log(f"Error: unable to parse {bucket_path} in red_bucket storage")
+        if settings.SERVER_MODE != "development":
+            raise
     else:
         assert all(isinstance(record["number"], int) for record in records)
         values = {

--- a/ietf/sync/tests_rfcindex.py
+++ b/ietf/sync/tests_rfcindex.py
@@ -1,0 +1,161 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+import json
+from io import StringIO
+from unittest import mock
+
+from django.core.files.storage import storages
+from django.test.utils import override_settings
+from lxml import etree
+
+from ietf.doc.factories import PublishedRfcDocEventFactory, IndividualRfcFactory
+from ietf.sync.rfcindex import create_rfc_txt_index, create_rfc_xml_index
+from ietf.utils.test_utils import TestCase
+
+
+class RfcIndexTests(TestCase):
+    """Tests of rfc-index generation
+
+    Tests are very limited and should cover more cases.
+
+    Be careful when calling create_rfc_txt_index() or create_rfc_xml_index(). These
+    will save to a storage by default, which can introduce cross-talk between tests.
+    Best to patch that method with a mock.
+    """
+
+    def setUp(self):
+        super().setUp()
+        red_bucket = storages["red_bucket"]
+
+        # Create an unused RFC number
+        red_bucket.save(
+            "input/unusable-rfc-numbers.json",
+            StringIO(json.dumps([{"number": 123, "comment": ""}])),
+        )
+
+        # actual April 1 RFC
+        self.april_fools_rfc = PublishedRfcDocEventFactory(
+            time="2020-04-01T12:00:00Z",
+            doc=IndividualRfcFactory(stream_id="ise", std_level_id="inf"),
+        ).doc
+        # Set up a JSON file to flag the April 1 RFC
+        red_bucket.save(
+            "input/april-first-rfc-numbers.json",
+            StringIO(json.dumps([self.april_fools_rfc.rfc_number])),
+        )
+
+        # non-April Fools RFC that happens to have been published on April 1
+        self.rfc = PublishedRfcDocEventFactory(
+            time="2021-04-01T12:00:00Z", doc__std_level_id="std"
+        ).doc
+        # Set up a publication-std-levels.json file to indicate the publication
+        # standard of self.rfc as different from its current value
+        red_bucket.save(
+            "input/publication-std-levels.json",
+            StringIO(
+                json.dumps(
+                    [{"number": self.rfc.rfc_number, "publication_std_level": "ps"}]
+                )
+            ),
+        )
+
+    def tearDown(self):
+        red_bucket = storages["red_bucket"]
+        red_bucket.delete("input/unusable-rfc-numbers.json")
+        red_bucket.delete("input/april-first-rfc-numbers.json")
+        red_bucket.delete("input/publication-std-levels.json")
+        super().tearDown()
+
+    @override_settings(RFCINDEX_INPUT_PATH="input/")
+    @mock.patch("ietf.sync.rfcindex.save_to_red_bucket")
+    def test_create_rfc_txt_index(self, mock_save):
+        create_rfc_txt_index()
+        self.assertEqual(mock_save.call_count, 1)
+        self.assertEqual(mock_save.call_args[0][0], "rfc-index.txt")
+        contents = mock_save.call_args[0][1].read()
+        self.assertIn(
+            "123 Not Issued.",
+            contents,
+        )
+        # No zero prefix!
+        self.assertNotIn(
+            "0123 Not Issued.",
+            contents,
+        )
+        self.assertIn(
+            f"{self.april_fools_rfc.rfc_number} {self.april_fools_rfc.title}",
+            contents,
+        )
+        self.assertIn("1 April 2020", contents)  # from the April 1 RFC
+        self.assertIn(
+            f"{self.rfc.rfc_number} {self.rfc.title}",
+            contents,
+        )
+        self.assertIn("April 2021", contents)  # from the non-April 1 RFC
+        self.assertNotIn("1 April 2021", contents)
+
+    @override_settings(RFCINDEX_INPUT_PATH="input/")
+    @mock.patch("ietf.sync.rfcindex.save_to_red_bucket")
+    def test_create_rfc_xml_index(self, mock_save):
+        create_rfc_xml_index()
+        self.assertEqual(mock_save.call_count, 1)
+        self.assertEqual(mock_save.call_args[0][0], "rfc-index.xml")
+        contents = mock_save.call_args[0][1].read()
+        ns = "{https://www.rfc-editor.org/rfc-index}"  # NOT an f-string
+        index = etree.fromstring(contents)
+
+        # We can aspire to validating the schema - currently does not conform because
+        # XSD expects 4-digit RFC numbers (etc).
+        #
+        # xmlschema = etree.XMLSchema(etree.fromstring(
+        #     Path(__file__).with_name("rfc-index.xsd").read_bytes())
+        # )
+        # xmlschema.assertValid(index)
+
+        children = list(index)  # elements as list
+        # Should be one rfc-not-issued-entry
+        self.assertEqual(len(children), 3)
+        self.assertEqual(
+            [
+                c.find(f"{ns}doc-id").text
+                for c in children
+                if c.tag == f"{ns}rfc-not-issued-entry"
+            ],
+            ["RFC123"],
+        )
+        # Should be two rfc-entries
+        rfc_entries = {
+            c.find(f"{ns}doc-id").text: c for c in children if c.tag == f"{ns}rfc-entry"
+        }
+
+        # Check the April Fool's entry
+        april_fools_entry = rfc_entries[self.april_fools_rfc.name.upper()]
+        self.assertEqual(
+            april_fools_entry.find(f"{ns}title").text,
+            self.april_fools_rfc.title,
+        )
+        self.assertEqual(
+            [(c.tag, c.text) for c in april_fools_entry.find(f"{ns}date")],
+            [(f"{ns}month", "April"), (f"{ns}day", "1"), (f"{ns}year", "2020")],
+        )
+        self.assertEqual(
+            april_fools_entry.find(f"{ns}current-status").text,
+            "INFORMATIONAL",
+        )
+        self.assertEqual(
+            april_fools_entry.find(f"{ns}publication-status").text,
+            "UNKNOWN",
+        )
+
+        # Check the Regular entry
+        rfc_entry = rfc_entries[self.rfc.name.upper()]
+        self.assertEqual(rfc_entry.find(f"{ns}title").text, self.rfc.title)
+        self.assertEqual(
+            rfc_entry.find(f"{ns}current-status").text, "INTERNET STANDARD"
+        )
+        self.assertEqual(
+            rfc_entry.find(f"{ns}publication-status").text, "PROPOSED STANDARD"
+        )
+        self.assertEqual(
+            [(c.tag, c.text) for c in rfc_entry.find(f"{ns}date")],
+            [(f"{ns}month", "April"), (f"{ns}year", "2021")],
+        )

--- a/ietf/sync/tests_rfcindex.py
+++ b/ietf/sync/tests_rfcindex.py
@@ -1,6 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 import json
-from io import StringIO
+from io import BytesIO, StringIO
 from unittest import mock
 
 from django.core.files.storage import storages
@@ -8,14 +8,24 @@ from django.test.utils import override_settings
 from lxml import etree
 
 from ietf.doc.factories import PublishedRfcDocEventFactory, IndividualRfcFactory
-from ietf.sync.rfcindex import create_rfc_txt_index, create_rfc_xml_index
+from ietf.name.models import DocTagName
+from ietf.sync.rfcindex import (
+    create_rfc_txt_index,
+    create_rfc_xml_index,
+    format_rfc_number,
+    save_to_red_bucket, get_unusable_rfc_numbers, get_april1_rfc_numbers,
+    get_publication_std_levels,
+)
 from ietf.utils.test_utils import TestCase
 
 
 class RfcIndexTests(TestCase):
     """Tests of rfc-index generation
 
-    Tests are very limited and should cover more cases.
+    Tests are limited and should cover more cases. Needs:
+      * test of subseries docs
+      * test of related docs (obsoletes/updates + reverse directions)
+      * more thorough validation of index contents
 
     Be careful when calling create_rfc_txt_index() or create_rfc_xml_index(). These
     will save to a storage by default, which can introduce cross-talk between tests.
@@ -35,7 +45,12 @@ class RfcIndexTests(TestCase):
         # actual April 1 RFC
         self.april_fools_rfc = PublishedRfcDocEventFactory(
             time="2020-04-01T12:00:00Z",
-            doc=IndividualRfcFactory(stream_id="ise", std_level_id="inf"),
+            doc=IndividualRfcFactory(
+                name="rfc4560",
+                rfc_number=4560,
+                stream_id="ise",
+                std_level_id="inf",
+            ),
         ).doc
         # Set up a JSON file to flag the April 1 RFC
         red_bucket.save(
@@ -45,8 +60,13 @@ class RfcIndexTests(TestCase):
 
         # non-April Fools RFC that happens to have been published on April 1
         self.rfc = PublishedRfcDocEventFactory(
-            time="2021-04-01T12:00:00Z", doc__std_level_id="std"
+            time="2021-04-01T12:00:00Z",
+            doc__name="rfc10000",
+            doc__rfc_number=10000,
+            doc__std_level_id="std",
         ).doc
+        self.rfc.tags.add(DocTagName.objects.get(slug="errata"))
+
         # Set up a publication-std-levels.json file to indicate the publication
         # standard of self.rfc as different from its current value
         red_bucket.save(
@@ -159,3 +179,52 @@ class RfcIndexTests(TestCase):
             [(c.tag, c.text) for c in rfc_entry.find(f"{ns}date")],
             [(f"{ns}month", "April"), (f"{ns}year", "2021")],
         )
+
+
+class HelperTests(TestCase):
+    def test_format_rfc_number(self):
+        self.assertEqual(format_rfc_number(10), "10")
+        with override_settings(RFCINDEX_MATCH_LEGACY_XML=True):
+            self.assertEqual(format_rfc_number(10), "0010")
+
+    def test_save_to_red_bucket(self):
+        red_bucket = storages["red_bucket"]
+        with override_settings(RFCINDEX_DELETE_THEN_WRITE=False):
+            save_to_red_bucket("test", StringIO("contents"))
+        with red_bucket.open("test", "r") as f:
+            self.assertEqual(f.read(), "contents")
+        with override_settings(RFCINDEX_DELETE_THEN_WRITE=True):
+            save_to_red_bucket("test", BytesIO(b"new contents"))
+        with red_bucket.open("test", "r") as f:
+            self.assertEqual(f.read(), "new contents")
+        red_bucket.delete("test")  # clean up like a good child
+
+    def test_get_unusable_rfc_numbers_raises(self):
+        """get_unusable_rfc_numbers should bail on errors"""
+        with self.assertRaises(FileNotFoundError):
+            get_unusable_rfc_numbers()
+        red_bucket = storages["red_bucket"]
+        red_bucket.save("unusable-rfc-numbers.json", StringIO("not json"))
+        with self.assertRaises(json.JSONDecodeError):
+            get_unusable_rfc_numbers()
+        red_bucket.delete("unusable-rfc-numbers.json")
+
+    def test_get_april1_rfc_numbers_raises(self):
+        """get_april1_rfc_numbers should bail on errors"""
+        with self.assertRaises(FileNotFoundError):
+            get_april1_rfc_numbers()
+        red_bucket = storages["red_bucket"]
+        red_bucket.save("april-first-rfc-numbers.json", StringIO("not json"))
+        with self.assertRaises(json.JSONDecodeError):
+            get_april1_rfc_numbers()
+        red_bucket.delete("april-first-rfc-numbers.json")
+
+    def test_get_publication_std_levels_raises(self):
+        """get_publication_std_levels should bail on errors"""
+        with self.assertRaises(FileNotFoundError):
+            get_publication_std_levels()
+        red_bucket = storages["red_bucket"]
+        red_bucket.save("publication-std-levels.json", StringIO("not json"))
+        with self.assertRaises(json.JSONDecodeError):
+            get_publication_std_levels()
+        red_bucket.delete("publication-std-levels.json")

--- a/ietf/templates/sync/rfc-index.txt
+++ b/ietf/templates/sync/rfc-index.txt
@@ -1,0 +1,69 @@
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+                             RFC INDEX
+                           -------------
+
+(CREATED ON: {{created_on}}.)
+
+This file contains citations for all RFCs in numeric order.
+
+RFC citations appear in this format:
+
+  ####  Title of RFC.  Author 1, Author 2, Author 3.  Issue date.
+        (Format: ASCII) (Obsoletes xxx) (Obsoleted by xxx) (Updates xxx)
+        (Updated by xxx) (Also FYI ####) (Status: ssssss) (DOI: ddd)
+
+or
+
+  ####  Not Issued.
+
+For example:
+
+  1129 Internet Time Synchronization: The Network Time Protocol. D.L.
+       Mills. October 1989. (Format: TXT, PS, PDF, HTML) (Also RFC1119)
+       (Status: INFORMATIONAL) (DOI: 10.17487/RFC1129)
+
+Key to citations:
+
+#### is the RFC number.
+
+Following the RFC number are the title, the author(s), and the
+publication date of the RFC.  Each of these is terminated by a period.
+
+Following the number are the title (terminated with a period), the
+author, or list of authors (terminated with a period), and the date
+(terminated with a period).
+
+The format follows in parentheses. One or more of the following formats
+are listed:  text (TXT), PostScript (PS), Portable Document Format
+(PDF), HTML, XML.
+
+Obsoletes xxxx refers to other RFCs that this one replaces;
+Obsoleted by xxxx refers to RFCs that have replaced this one.
+Updates xxxx refers to other RFCs that this one merely updates (but
+does not replace); Updated by xxxx refers to RFCs that have updated
+(but not replaced) this one.  Generally, only immediately succeeding
+and/or preceding RFCs are indicated, not the entire history of each
+related earlier or later RFC in a related series.
+
+The (Also FYI ##) or (Also STD ##) or (Also BCP ##) phrase gives the
+equivalent FYI, STD, or BCP number if the RFC is also in those
+document sub-series.  The Status field gives the document's
+current status (see RFC 2026).  The (DOI ddd) field gives the
+Digital Object Identifier.
+
+RFCs may be obtained in a number of ways, using HTTP, FTP, or email.
+See the RFC Editor Web page http://www.rfc-editor.org
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+                                RFC INDEX
+                                ---------
+
+
+
+{% for rfc in rfcs %}{{rfc|safe}}
+
+{% endfor %}

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -417,6 +417,32 @@ for storagename in ARTIFACT_STORAGE_NAMES:
         ),
     }
 
+# Configure storage for the red bucket - assume it uses the same credentials as
+# other blobs
+_red_bucket_name = os.environ.get("DATATRACKER_BLOB_STORE_RED_BUCKET_NAME", "").strip()
+if _red_bucket_name == "":
+    raise RuntimeError("DATATRACKER_BLOB_STORE_RED_BUCKET_NAME must be set")
+
+STORAGES["red_bucket"] = {
+    "BACKEND": "storages.backends.s3.S3Storage",
+    "OPTIONS": dict(
+        endpoint_url=_blob_store_endpoint_url,
+        access_key=_blob_store_access_key,
+        secret_key=_blob_store_secret_key,
+        security_token=None,
+        client_config=botocore.config.Config(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+            signature_version="s3v4",
+            connect_timeout=_blob_store_connect_timeout,
+            read_timeout=_blob_store_read_timeout,
+            retries={"total_max_attempts": _blob_store_max_attempts},
+        ),
+        verify=False,
+        bucket_name=_red_bucket_name,
+    ),
+}
+
 # Configure the blobdb app for artifact storage
 _blobdb_replication_enabled = (
     os.environ.get("DATATRACKER_BLOBDB_REPLICATION_ENABLED", "true").lower() == "true"

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -442,6 +442,10 @@ STORAGES["red_bucket"] = {
         bucket_name=_red_bucket_name,
     ),
 }
+RFCINDEX_DELETE_THEN_WRITE = False  # S3Storage allows file_overwrite by default
+RFCINDEX_PATH_IN_BUCKET = os.environ.get(
+    "DATATRACKER_RFCINDEX_PATH_IN_BUCKET", "other/"
+)
 
 # Configure the blobdb app for artifact storage
 _blobdb_replication_enabled = (

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -443,8 +443,11 @@ STORAGES["red_bucket"] = {
     ),
 }
 RFCINDEX_DELETE_THEN_WRITE = False  # S3Storage allows file_overwrite by default
-RFCINDEX_PATH_IN_BUCKET = os.environ.get(
-    "DATATRACKER_RFCINDEX_PATH_IN_BUCKET", "other/"
+RFCINDEX_OUTPUT_PATH = os.environ.get(
+    "DATATRACKER_RFCINDEX_OUTPUT_PATH", "other/"
+)
+RFCINDEX_INPUT_PATH = os.environ.get(
+    "DATATRACKR_RFCINDEX_INPUT_PATH", ""
 )
 
 # Configure the blobdb app for artifact storage


### PR DESCRIPTION
This is based on @kesara's index code from purple.

Generates rfc-index.xml. Relies on three files existing in the "red bucket": 
* `unusable-rfc-numbers.json`
    - list of `{"number": 123, "comment": "comment or empty string"}`
* `april-first-rfc-numbers.json`
    - list of integers
* `publication-std-levels.json`
    - list of `{"number": 123, "publication_std_level": "some slug"}`
These should be generated by purple and deposited in the "red" bucket. A directory prefix within the bucket can be set via `settings.RFCINDEX_INPUT_PATH`, which defaults to `""`.

Indexes are written to the same bucket using `RFCINDEX_OUTPUT_PATH` (also defaults to `""`)

Expects to share the same credentials as for the blobdb replication storages.

Adds support for `Document.keywords` and adds API support to allow these to be set from purple.

Does not yet have triggering a / task wrapper.

For development, defaults to using an `InMemoryStorage`, which does not leave traces on the filesystem. Without the JSON files, the RFC index will be wrong: there will be no unusable RFC numbers listed, no RFCs will be treated as April 1, and all publication-status values will be UNKNOWN. This situation will raise an exception in production. In development, a log entry will be emitted as a reminder. The tests fill in their own JSON data. Comments in `settings_local.py` suggest a way to create a persistent `FileSystemStorage` which is useful for development.


### Todo
- [x] Tests
- [x] Real `Storage` configuration for `red_bucket`
- [x] Extract settings from `rfcindex.py` into the settings module