### PR TITLE
feat: update typesense search index on rfc pub/update

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2025, All Rights Reserved
+# Copyright The IETF Trust 2025-2026, All Rights Reserved
 import datetime
 from pathlib import Path
 from typing import Literal, Optional
@@ -20,6 +20,7 @@ from ietf.doc.models import (
     RfcAuthor,
 )
 from ietf.doc.serializers import RfcAuthorSerializer
+from ietf.doc.tasks import update_rfc_searchindex_task
 from ietf.doc.utils import (
     default_consensus,
     prettify_std_name,
@@ -682,6 +683,8 @@ class EditableRfcSerializer(serializers.ModelSerializer):
                 stale_subseries_relations.delete()
             if len(rfc_events) > 0:
                 rfc.save_with_history(rfc_events)
+
+        update_rfc_searchindex_task.delay(rfc.rfc_number)
         return rfc
 
 

--- a/ietf/api/tests_serializers_rpc.py
+++ b/ietf/api/tests_serializers_rpc.py
@@ -1,4 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+from unittest import mock
+
 from django.utils import timezone
 
 from ietf.utils.test_utils import TestCase
@@ -32,7 +34,8 @@ class EditableRfcSerializerTests(TestCase):
         with self.assertRaises(RuntimeError, msg="serializer does not allow create()"):
             serializer.save()
 
-    def test_update(self):
+    @mock.patch("ietf.api.serializers_rpc.update_rfc_searchindex_task")
+    def test_update(self, mock_update_searchindex_task):
         rfc = WgRfcFactory(pages=10)
         serializer = EditableRfcSerializer(
             instance=rfc,
@@ -56,6 +59,11 @@ class EditableRfcSerializerTests(TestCase):
         )
         self.assertTrue(serializer.is_valid())
         result = serializer.save()
+        self.assertTrue(mock_update_searchindex_task.delay.called)
+        self.assertEqual(
+            mock_update_searchindex_task.delay.call_args,
+            mock.call(rfc.rfc_number),
+        )
         result.refresh_from_db()
         self.assertEqual(result.title, "Yadda yadda yadda")
         self.assertEqual(
@@ -84,7 +92,8 @@ class EditableRfcSerializerTests(TestCase):
             [Document.objects.get(name="fyi999")],
         )
 
-    def test_partial_update(self):
+    @mock.patch("ietf.api.serializers_rpc.update_rfc_searchindex_task")
+    def test_partial_update(self, mock_update_searchindex_task):
         # We could test other permutations of fields, but authors is a partial update
         # we know we are going to use, so verifying that one in particular.
         rfc = WgRfcFactory(pages=10, abstract="do or do not", title="padawan")
@@ -104,6 +113,11 @@ class EditableRfcSerializerTests(TestCase):
         )
         self.assertTrue(serializer.is_valid())
         result = serializer.save()
+        self.assertTrue(mock_update_searchindex_task.delay.called)
+        self.assertEqual(
+            mock_update_searchindex_task.delay.call_args,
+            mock.call(rfc.rfc_number),
+        )
         result.refresh_from_db()
         self.assertEqual(rfc.title, "padawan")
         self.assertEqual(

--- a/ietf/api/tests_views_rpc.py
+++ b/ietf/api/tests_views_rpc.py
@@ -196,7 +196,8 @@ class RpcApiTests(APITestCase):
         self.assertEqual(mock_kwargs["rfc_number_list"], expected_rfc_number_list)
 
     @override_settings(APP_API_TOKENS={"ietf.api.views_rpc": ["valid-token"]})
-    def test_upload_rfc_files(self):
+    @mock.patch("ietf.api.views_rpc.update_rfc_searchindex_task")
+    def test_upload_rfc_files(self, mock_update_searchindex_task):
         def _valid_post_data():
             """Generate a valid post data dict
 
@@ -217,14 +218,7 @@ class RpcApiTests(APITestCase):
             }
 
         url = urlreverse("ietf.api.purple_api.upload_rfc_files")
-        unused_rfc_number = (
-            Document.objects.filter(rfc_number__isnull=False).aggregate(
-                unused_rfc_number=Max("rfc_number") + 1
-            )["unused_rfc_number"]
-            or 10000
-        )
-
-        rfc = WgRfcFactory(rfc_number=unused_rfc_number)
+        rfc = WgRfcFactory()
         assert isinstance(rfc, Document), "WgRfcFactory should generate a Document"
         with TemporaryDirectory() as rfc_dir:
             settings.RFC_PATH = rfc_dir  # affects overridden settings
@@ -236,15 +230,17 @@ class RpcApiTests(APITestCase):
             # no api key
             r = self.client.post(url, _valid_post_data(), format="multipart")
             self.assertEqual(r.status_code, 403)
+            self.assertFalse(mock_update_searchindex_task.delay.called)
 
             # invalid RFC
             r = self.client.post(
                 url,
-                _valid_post_data() | {"rfc": unused_rfc_number + 1},
+                _valid_post_data() | {"rfc": rfc.rfc_number + 10},
                 format="multipart",
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 400)
+            self.assertFalse(mock_update_searchindex_task.delay.called)
 
             # empty files
             r = self.client.post(
@@ -263,6 +259,7 @@ class RpcApiTests(APITestCase):
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 400)
+            self.assertFalse(mock_update_searchindex_task.delay.called)
 
             # bad file type
             r = self.client.post(
@@ -276,9 +273,10 @@ class RpcApiTests(APITestCase):
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 400)
+            self.assertFalse(mock_update_searchindex_task.delay.called)
 
             # Put a file in the way. Post should fail because replace = False
-            file_in_the_way = (rfc_path / f"rfc{unused_rfc_number}.txt")
+            file_in_the_way = (rfc_path / f"{rfc.name}.txt")
             file_in_the_way.touch()
             r = self.client.post(
                 url,
@@ -287,11 +285,12 @@ class RpcApiTests(APITestCase):
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 409)  # conflict
+            self.assertFalse(mock_update_searchindex_task.delay.called)
             file_in_the_way.unlink()
             
             # Put a blob in the way. Post should fail because replace = False
             blob_in_the_way = Blob.objects.create(
-                bucket="rfc", name=f"txt/rfc{unused_rfc_number}.txt", content=b""
+                bucket="rfc", name=f"txt/{rfc.name}.txt", content=b""
             )
             r = self.client.post(
                 url,
@@ -300,6 +299,7 @@ class RpcApiTests(APITestCase):
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 409)  # conflict
+            self.assertFalse(mock_update_searchindex_task.delay.called)
             blob_in_the_way.delete()
 
             # valid post
@@ -310,8 +310,13 @@ class RpcApiTests(APITestCase):
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 200)
+            self.assertTrue(mock_update_searchindex_task.delay.called)
+            self.assertEqual(
+                mock_update_searchindex_task.delay.call_args,
+                mock.call(rfc.rfc_number),
+            )
             for extension in ["xml", "txt", "html", "pdf", "json"]:
-                filename = f"rfc{unused_rfc_number}.{extension}"
+                filename = f"{rfc.name}.{extension}"
                 self.assertEqual(
                     (rfc_path / filename)
                     .read_text(),
@@ -328,7 +333,7 @@ class RpcApiTests(APITestCase):
                     f"{extension} blob should contain the expected content",
                 )
             # special case for notprepped
-            notprepped_fn = f"rfc{unused_rfc_number}.notprepped.xml"
+            notprepped_fn = f"{rfc.name}.notprepped.xml"
             self.assertEqual(
                 (
                     rfc_path / "prerelease" / notprepped_fn
@@ -347,6 +352,7 @@ class RpcApiTests(APITestCase):
             )
 
             # re-post with replace = False should now fail
+            mock_update_searchindex_task.reset_mock()
             r = self.client.post(
                 url,
                 _valid_post_data(),
@@ -354,7 +360,8 @@ class RpcApiTests(APITestCase):
                 headers={"X-Api-Key": "valid-token"},
             )
             self.assertEqual(r.status_code, 409)  # conflict
-            
+            self.assertFalse(mock_update_searchindex_task.delay.called)
+
             # re-post with replace = True should succeed
             r = self.client.post(
                 url,
@@ -362,7 +369,12 @@ class RpcApiTests(APITestCase):
                 format="multipart",
                 headers={"X-Api-Key": "valid-token"},
             )
-            self.assertEqual(r.status_code, 200)  # conflict
+            self.assertEqual(r.status_code, 200)
+            self.assertTrue(mock_update_searchindex_task.delay.called)
+            self.assertEqual(
+                mock_update_searchindex_task.delay.call_args,
+                mock.call(rfc.rfc_number),
+            )
 
     @override_settings(APP_API_TOKENS={"ietf.api.views_rpc": ["valid-token"]})
     @mock.patch("ietf.api.views_rpc.create_rfc_index_task")

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -38,7 +38,7 @@ from ietf.api.serializers_rpc import (
 from ietf.doc.models import Document, DocHistory, RfcAuthor, DocEvent
 from ietf.doc.serializers import RfcAuthorSerializer
 from ietf.doc.storage_utils import remove_from_storage, store_file, exists_in_storage
-from ietf.doc.tasks import signal_update_rfc_metadata_task
+from ietf.doc.tasks import signal_update_rfc_metadata_task, update_rfc_searchindex_task
 from ietf.person.models import Email, Person
 from ietf.sync.tasks import create_rfc_index_task
 
@@ -516,6 +516,7 @@ class RfcPubFilesView(APIView):
                     destination.parent.mkdir()
                 shutil.move(ftm, destination)
 
+        update_rfc_searchindex_task.delay(rfc.rfc_number)
         return Response(NotificationAckSerializer().data)
 
 

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -1285,11 +1285,8 @@ class Document(StorableMixin, DocumentInfo):
         s = s.first()
         return s
 
-    def pub_date(self):
-        """Get the publication date for this document
-
-        This is the rfc publication date for RFCs, and the new-revision date for other documents.
-        """
+    def pub_datetime(self):
+        """Get the publication datetime of this document"""
         if self.type_id == "rfc":
             # As of Sept 2022, in ietf.sync.rfceditor.update_docs_from_rfc_index() `published_rfc` events are
             # created with a timestamp whose date *in the PST8PDT timezone* is the official publication date
@@ -1297,7 +1294,15 @@ class Document(StorableMixin, DocumentInfo):
             event = self.latest_event(type='published_rfc')
         else:
             event = self.latest_event(type='new_revision')
-        return event.time.astimezone(RPC_TZINFO).date() if event else None
+        return event.time.astimezone(RPC_TZINFO) if event else None
+
+    def pub_date(self):
+        """Get the publication date for this document
+
+        This is the rfc publication date for RFCs, and the new-revision date for other documents.
+        """
+        pub_datetime = self.pub_datetime()
+        return None if pub_datetime is None else pub_datetime.date()
 
     def is_dochistory(self):
         return False

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -77,17 +77,19 @@ def expire_last_calls_task():
         try:
             expire_last_call(doc)
         except Exception:
-            log.log(f"ERROR: Failed to expire last call for {doc.file_tag()} (id={doc.pk})")
+            log.log(
+                f"ERROR: Failed to expire last call for {doc.file_tag()} (id={doc.pk})"
+            )
         else:
             log.log(f"Expired last call for {doc.file_tag()} (id={doc.pk})")
 
 
-@shared_task            
+@shared_task
 def generate_idnits2_rfc_status_task():
     outpath = Path(settings.DERIVED_DIR) / "idnits2-rfc-status"
     blob = generate_idnits2_rfc_status()
     try:
-        outpath.write_text(blob, encoding="utf8") # TODO-BLOBSTORE
+        outpath.write_text(blob, encoding="utf8")  # TODO-BLOBSTORE
     except Exception as e:
         log.log(f"failed to write idnits2-rfc-status: {e}")
 
@@ -97,7 +99,7 @@ def generate_idnits2_rfcs_obsoleted_task():
     outpath = Path(settings.DERIVED_DIR) / "idnits2-rfcs-obsoleted"
     blob = generate_idnits2_rfcs_obsoleted()
     try:
-        outpath.write_text(blob, encoding="utf8") # TODO-BLOBSTORE
+        outpath.write_text(blob, encoding="utf8")  # TODO-BLOBSTORE
     except Exception as e:
         log.log(f"failed to write idnits2-rfcs-obsoleted: {e}")
 
@@ -105,7 +107,7 @@ def generate_idnits2_rfcs_obsoleted_task():
 @shared_task
 def generate_draft_bibxml_files_task(days=7, process_all=False):
     """Generate bibxml files for recently updated docs
-    
+
     If process_all is False (the default), processes only docs with new revisions
     in the last specified number of days.
     """
@@ -117,7 +119,9 @@ def generate_draft_bibxml_files_task(days=7, process_all=False):
         doc__type_id="draft",
     ).order_by("time")
     if not process_all:
-        doc_events = doc_events.filter(time__gte=timezone.now() - datetime.timedelta(days=days))
+        doc_events = doc_events.filter(
+            time__gte=timezone.now() - datetime.timedelta(days=days)
+        )
     for event in doc_events:
         try:
             update_or_create_draft_bibxml_file(event.doc, event.rev)
@@ -131,6 +135,7 @@ def investigate_fragment_task(name_fragment: str):
         "name_fragment": name_fragment,
         "results": investigate_fragment(name_fragment),
     }
+
 
 @shared_task
 def rebuild_reference_relations_task(doc_names: list[str]):
@@ -156,6 +161,7 @@ def rebuild_reference_relations_task(doc_names: list[str]):
 @shared_task
 def fixup_bofreq_timestamps_task():  # pragma: nocover
     fixup_bofreq_timestamps()
+
 
 @shared_task
 def signal_update_rfc_metadata_task(rfc_number_list=()):

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -3,6 +3,7 @@
 # Celery task definitions
 #
 import datetime
+
 import debug  # pyflakes:ignore
 
 from celery import shared_task
@@ -11,7 +12,7 @@ from pathlib import Path
 from django.conf import settings
 from django.utils import timezone
 
-from ietf.utils import log
+from ietf.utils import log, searchindex
 from ietf.utils.timezone import datetime_today
 
 from .expire import (
@@ -166,3 +167,26 @@ def fixup_bofreq_timestamps_task():  # pragma: nocover
 @shared_task
 def signal_update_rfc_metadata_task(rfc_number_list=()):
     signal_update_rfc_metadata(rfc_number_list)
+
+
+@shared_task(bind=True)
+def update_rfc_searchindex_task(self, rfc_number: int):
+    """Update the search index for one RFC"""
+    if not searchindex.enabled():
+        log.log("Search indexing is not enabled, skipping")
+
+    rfc = Document.objects.filter(type_id="rfc", rfc_number=rfc_number).first()
+    if rfc is None:
+        log.log(
+            f"ERROR: Document for rfc{rfc_number} not found, not updating search index"
+        )
+        return
+    try:
+        searchindex.update_or_create_rfc_entry(rfc)
+    except Exception as err:
+        log.log(f"Search index update for {rfc.name} failed ({err})")
+        if isinstance(err, searchindex.RETRYABLE_ERROR_CLASSES):
+            self.retry(
+                countdown=getattr(settings, "SEARCHINDEX_TASK_RETRY_DELAY", 10),
+                max_retries=getattr(settings, "SEARCHINDEX_TASK_MAX_RETRIES", 12),
+            )

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -174,6 +174,7 @@ def update_rfc_searchindex_task(self, rfc_number: int):
     """Update the search index for one RFC"""
     if not searchindex.enabled():
         log.log("Search indexing is not enabled, skipping")
+        return
 
     rfc = Document.objects.filter(type_id="rfc", rfc_number=rfc_number).first()
     if rfc is None:

--- a/ietf/doc/tasks.py
+++ b/ietf/doc/tasks.py
@@ -186,7 +186,8 @@ def update_rfc_searchindex_task(self, rfc_number: int):
     except Exception as err:
         log.log(f"Search index update for {rfc.name} failed ({err})")
         if isinstance(err, searchindex.RETRYABLE_ERROR_CLASSES):
+            searchindex_settings = searchindex.get_settings()
             self.retry(
-                countdown=getattr(settings, "SEARCHINDEX_TASK_RETRY_DELAY", 10),
-                max_retries=getattr(settings, "SEARCHINDEX_TASK_MAX_RETRIES", 12),
+                countdown=searchindex_settings["TASK_RETRY_DELAY"],
+                max_retries=searchindex_settings["TASK_MAX_RETRIES"],
             )

--- a/ietf/doc/tests_tasks.py
+++ b/ietf/doc/tests_tasks.py
@@ -1,6 +1,5 @@
 # Copyright The IETF Trust 2024-2026, All Rights Reserved
 
-import debug    # pyflakes:ignore
 import datetime
 from unittest import mock
 
@@ -24,7 +23,8 @@ from .tasks import (
     generate_idnits2_rfcs_obsoleted_task,
     generate_idnits2_rfc_status_task,
     investigate_fragment_task,
-    notify_expirations_task, update_rfc_searchindex_task,
+    notify_expirations_task,
+    update_rfc_searchindex_task,
 )
 
 
@@ -91,7 +91,7 @@ class TaskTests(TestCase):
         self.assertEqual(mock_expire.call_args_list[0], mock.call(docs[0]))
         self.assertEqual(mock_expire.call_args_list[1], mock.call(docs[1]))
         self.assertEqual(mock_expire.call_args_list[2], mock.call(docs[2]))
-    
+
         # Check that it runs even if exceptions occur
         mock_get_expired.reset_mock()
         mock_expire.reset_mock()
@@ -117,7 +117,9 @@ class TaskTests(TestCase):
 
     @mock.patch("ietf.doc.tasks.searchindex.update_or_create_rfc_entry")
     @mock.patch("ietf.doc.tasks.searchindex.enabled")
-    def test_update_rfc_searchindex_task(self, mock_searchindex_enabled, mock_create_entry):
+    def test_update_rfc_searchindex_task(
+        self, mock_searchindex_enabled, mock_create_entry
+    ):
         mock_searchindex_enabled.return_value = False
 
         self.assertFalse(Document.objects.filter(rfc_number=5073).exists())
@@ -126,7 +128,7 @@ class TaskTests(TestCase):
         self.assertFalse(mock_create_entry.called)
         update_rfc_searchindex_task(rfc_number=rfc.rfc_number)
         self.assertFalse(mock_create_entry.called)
-        
+
         mock_searchindex_enabled.return_value = True
         update_rfc_searchindex_task(rfc_number=5073)
         self.assertFalse(mock_create_entry.called)
@@ -141,10 +143,12 @@ class TaskTests(TestCase):
             mock_create_entry.side_effect = typesense_exceptions.Timeout
             with self.assertRaises(Retry):
                 update_rfc_searchindex_task(rfc_number=rfc.rfc_number)
-            
+
 
 class Idnits2SupportTests(TestCase):
-    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['DERIVED_DIR']
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + [
+        "DERIVED_DIR"
+    ]
 
     @mock.patch("ietf.doc.tasks.generate_idnits2_rfcs_obsoleted")
     def test_generate_idnits2_rfcs_obsoleted_task(self, mock_generate):
@@ -182,7 +186,9 @@ class BIBXMLSupportTests(TestCase):
         )
         # a couple that should always be ignored
         NewRevisionDocEventFactory(
-            time=now - datetime.timedelta(days=6), rev="09", doc__type_id="rfc"  # not a draft
+            time=now - datetime.timedelta(days=6),
+            rev="09",
+            doc__type_id="rfc",  # not a draft
         )
         NewRevisionDocEventFactory(
             type="changed_document",  # not a "new_revision" type
@@ -195,7 +201,9 @@ class BIBXMLSupportTests(TestCase):
 
     @mock.patch("ietf.doc.tasks.ensure_draft_bibxml_path_exists")
     @mock.patch("ietf.doc.tasks.update_or_create_draft_bibxml_file")
-    def test_generate_bibxml_files_for_all_drafts_task(self, mock_create, mock_ensure_path):
+    def test_generate_bibxml_files_for_all_drafts_task(
+        self, mock_create, mock_ensure_path
+    ):
         generate_draft_bibxml_files_task(process_all=True)
         self.assertTrue(mock_ensure_path.called)
         self.assertCountEqual(
@@ -224,12 +232,15 @@ class BIBXMLSupportTests(TestCase):
 
     @mock.patch("ietf.doc.tasks.ensure_draft_bibxml_path_exists")
     @mock.patch("ietf.doc.tasks.update_or_create_draft_bibxml_file")
-    def test_generate_bibxml_files_for_recent_drafts_task(self, mock_create, mock_ensure_path):
+    def test_generate_bibxml_files_for_recent_drafts_task(
+        self, mock_create, mock_ensure_path
+    ):
         # default args - look back 7 days
         generate_draft_bibxml_files_task()
         self.assertTrue(mock_ensure_path.called)
         self.assertCountEqual(
-            mock_create.call_args_list, [mock.call(self.young_event.doc, self.young_event.rev)]
+            mock_create.call_args_list,
+            [mock.call(self.young_event.doc, self.young_event.rev)],
         )
         mock_create.reset_mock()
         mock_ensure_path.reset_mock()
@@ -254,7 +265,9 @@ class BIBXMLSupportTests(TestCase):
 
     @mock.patch("ietf.doc.tasks.ensure_draft_bibxml_path_exists")
     @mock.patch("ietf.doc.tasks.update_or_create_draft_bibxml_file")
-    def test_generate_bibxml_files_for_recent_drafts_task_with_bad_value(self, mock_create, mock_ensure_path):
+    def test_generate_bibxml_files_for_recent_drafts_task_with_bad_value(
+        self, mock_create, mock_ensure_path
+    ):
         with self.assertRaises(ValueError):
             generate_draft_bibxml_files_task(days=0)
         self.assertFalse(mock_create.called)

--- a/ietf/doc/tests_tasks.py
+++ b/ietf/doc/tests_tasks.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2024, All Rights Reserved
+# Copyright The IETF Trust 2024-2026, All Rights Reserved
 
 import debug    # pyflakes:ignore
 import datetime
@@ -6,13 +6,16 @@ from unittest import mock
 
 from pathlib import Path
 
+from celery.exceptions import Retry
 from django.conf import settings
+from django.test.utils import override_settings
 from django.utils import timezone
+from typesense import exceptions as typesense_exceptions
 
 from ietf.utils.test_utils import TestCase
 from ietf.utils.timezone import datetime_today
 
-from .factories import DocumentFactory, NewRevisionDocEventFactory
+from .factories import DocumentFactory, NewRevisionDocEventFactory, WgRfcFactory
 from .models import Document, NewRevisionDocEvent
 from .tasks import (
     expire_ids_task,
@@ -21,8 +24,9 @@ from .tasks import (
     generate_idnits2_rfcs_obsoleted_task,
     generate_idnits2_rfc_status_task,
     investigate_fragment_task,
-    notify_expirations_task,
+    notify_expirations_task, update_rfc_searchindex_task,
 )
+
 
 class TaskTests(TestCase):
     @mock.patch("ietf.doc.tasks.in_draft_expire_freeze")
@@ -111,6 +115,33 @@ class TaskTests(TestCase):
             retval, {"name_fragment": "some fragment", "results": investigation_results}
         )
 
+    @mock.patch("ietf.doc.tasks.searchindex.update_or_create_rfc_entry")
+    @mock.patch("ietf.doc.tasks.searchindex.enabled")
+    def test_update_rfc_searchindex_task(self, mock_searchindex_enabled, mock_create_entry):
+        mock_searchindex_enabled.return_value = False
+
+        self.assertFalse(Document.objects.filter(rfc_number=5073).exists())
+        rfc = WgRfcFactory()
+        update_rfc_searchindex_task(rfc_number=5073)
+        self.assertFalse(mock_create_entry.called)
+        update_rfc_searchindex_task(rfc_number=rfc.rfc_number)
+        self.assertFalse(mock_create_entry.called)
+        
+        mock_searchindex_enabled.return_value = True
+        update_rfc_searchindex_task(rfc_number=5073)
+        self.assertFalse(mock_create_entry.called)
+        update_rfc_searchindex_task(rfc_number=rfc.rfc_number)
+        self.assertTrue(mock_create_entry.called)
+
+        with override_settings(SEARCHINDEX_CONFIG={"TASK_MAX_RETRIES": 0}):
+            # Try a non-retryable error (there are others)
+            mock_create_entry.side_effect = typesense_exceptions.RequestMalformed
+            update_rfc_searchindex_task(rfc_number=rfc.rfc_number)  # no retry
+            # Now what should be a retryable error
+            mock_create_entry.side_effect = typesense_exceptions.Timeout
+            with self.assertRaises(Retry):
+                update_rfc_searchindex_task(rfc_number=rfc.rfc_number)
+            
 
 class Idnits2SupportTests(TestCase):
     settings_temp_path_overrides = TestCase.settings_temp_path_overrides + ['DERIVED_DIR']

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -2,8 +2,6 @@
 """Search indexing utilities"""
 
 import re
-import typing
-from collections.abc import Collection
 from math import floor
 
 import httpx  # just for exceptions
@@ -26,15 +24,7 @@ RETRYABLE_ERROR_CLASSES = (
 )
 
 
-class SettingsDict(typing.TypedDict):
-    TYPESENSE_API_URL: str
-    TYPESENSE_API_KEY: str
-    TYPESENSE_COLLECTION_NAME: str
-    TASK_RETRY_DELAY: int | float
-    TASK_MAX_RETRIES: int
-
-
-DEFAULT_SETTINGS: SettingsDict = {
+DEFAULT_SETTINGS = {
     "TYPESENSE_API_URL": "",
     "TYPESENSE_API_KEY": "",
     "TYPESENSE_COLLECTION_NAME": "docs",
@@ -43,70 +33,13 @@ DEFAULT_SETTINGS: SettingsDict = {
 }
 
 
-def get_settings() -> SettingsDict:
+def get_settings():
     return DEFAULT_SETTINGS | getattr(settings, "SEARCHINDEX_CONFIG", {})
 
 
 def enabled():
     _settings = get_settings()
     return _settings["TYPESENSE_API_URL"] != ""
-
-
-type DocsSchemaTypeT = typing.Literal["draft", "rfc"]
-
-SlugNameDict = typing.TypedDict("SlugNameDict", {"slug": str, "name": str})
-
-
-class GroupDict(typing.TypedDict):
-    acronym: str
-    name: str
-    full: str
-
-
-class SubseriesDict(typing.TypedDict):
-    acronym: str  # type of subseries
-    number: int  # number of the subseries doc
-    total: int  # total number of docs in the subseries
-
-
-class AuthorDict(typing.TypedDict):
-    name: str
-    affiliation: str
-
-
-class FlagsDict(typing.TypedDict):
-    hiddenDefault: bool  # should doc be hidden in search by default?
-    obsoleted: bool  # obsoleted by another doc?
-    updated: bool  # updated by another doc?
-
-
-class DocsSchemaDict(typing.TypedDict):
-    """TypedDict equivalent to the Typesense "docs" schema"""
-
-    rfcNumber: int | None  # integer RFC number, omit for drafts
-    rfc: str | None  # string RFC number, omit for drafts
-    ref: str | None  # RFC number for drafts corresponding to draft, else omitted
-    filename: str  # filename of the document, without extension
-    title: str  # title of the draft / rfc
-    abstract: str  # abstract of the draft / rfc
-    keywords: Collection[str]  # search keywords, possibly empty
-    type: DocsSchemaTypeT  # type of the document (draft/rfc)
-    state: Collection[str] | None  # state(s) of the document (full name)
-    status: SlugNameDict | None  # standard level name (slug and name)
-    subseries: SubseriesDict | None
-    date: int  # date as a unix timestamp
-    expires: int | None  # expiration date as a unix timestamp
-    publicationDate: int | None  # publication date as a unix timestamp
-    group: GroupDict | None  # working group
-    area: GroupDict | None
-    stream: SlugNameDict | None
-    authors: list[AuthorDict] | None
-    adName: str | None  # area director name
-    flags: FlagsDict
-    obsoletedBy: list[str]  # RFC numbers (as strs) obsoleting this doc
-    updatedBy: list[str]  # RFC numbers (as strs) updating this doc
-    content: str | None  # sanitized content
-    ranking: int  # ranking when no explicit sorting (RFC number or rev)
 
 
 def _sanitize_text(content):
@@ -159,10 +92,9 @@ def update_or_create_rfc_entry(rfc: Document):
             log(f"Unable to retrieve {stored_txt} from storage")
 
     ts_id = f"doc-{rfc.pk}"
-    ts_document: DocsSchemaDict = {
+    ts_document = {
         "rfcNumber": rfc.rfc_number,
         "rfc": str(rfc.rfc_number),
-        "ref": None,
         "filename": rfc.name,
         "title": rfc.title,
         "abstract": _sanitize_text(rfc.abstract),
@@ -170,47 +102,13 @@ def update_or_create_rfc_entry(rfc: Document):
         "type": "rfc",
         "state": [state.name for state in rfc.states.all()],
         "status": {"slug": rfc.std_level.slug, "name": rfc.std_level.name},
-        "subseries": (
-            None
-            if subseries is None
-            else SubseriesDict(
-                acronym=subseries.type.slug,
-                number=int(subseries.name[len(subseries.type.slug) :]),
-                total=len(subseries.contains()),
-            )
-        ),
         "date": floor(rfc.time.timestamp()),
-        "expires": None,
         "publicationDate": floor(rfc.pub_datetime().timestamp()),
-        "group": (
-            None
-            if rfc.group is None  # exclude "none" (individual group)?
-            else GroupDict(
-                acronym=rfc.group.acronym,
-                name=rfc.group.name,
-                full=f"{rfc.group.acronym} - {rfc.group.name}",
-            )
-        ),
-        "area": (
-            GroupDict(
-                acronym=rfc.group.parent.acronym,
-                name=rfc.group.parent.name,
-                full=f"{rfc.group.parent.acronym} - {rfc.group.parent.name}",
-            )
-            if (
-                rfc.group.parent is not None
-                and rfc.stream_id not in ["ise", "irtf", "iab"]  # exclude editorial?
-            )
-            else None
-        ),
         "stream": {"slug": rfc.stream.slug, "name": rfc.stream.name},
         "authors": [
-            AuthorDict(
-                name=rfc_author.titlepage_name, affiliation=rfc_author.affiliation
-            )
+            {"name": rfc_author.titlepage_name, "affiliation": rfc_author.affiliation}
             for rfc_author in rfc.rfcauthor_set.all()
         ],
-        "adName": None if rfc.ad is None else rfc.ad.name,
         "flags": {
             "hiddenDefault": False,
             "obsoleted": len(obsoleted_by) > 0,
@@ -218,10 +116,33 @@ def update_or_create_rfc_entry(rfc: Document):
         },
         "obsoletedBy": [str(doc.rfc_number) for doc in obsoleted_by],
         "updatedBy": [str(doc.rfc_number) for doc in updated_by],
-        "content": None if content is None else _sanitize_text(content),
         "ranking": rfc.rfc_number,
     }
-
+    if subseries is not None:
+        ts_document["subseries"] = {
+            "acronym": subseries.type.slug,
+            "number": int(subseries.name[len(subseries.type.slug) :]),
+            "total": len(subseries.contains()),
+        }
+    if rfc.group is not None:
+        ts_document["group"] = {
+            "acronym": rfc.group.acronym,
+            "name": rfc.group.name,
+            "full": f"{rfc.group.acronym} - {rfc.group.name}",
+        }
+    if (
+        rfc.group.parent is not None
+        and rfc.stream_id not in ["ise", "irtf", "iab"]  # exclude editorial?
+    ):
+        ts_document["area"] = {
+            "acronym": rfc.group.parent.acronym,
+            "name": rfc.group.parent.name,
+            "full": f"{rfc.group.parent.acronym} - {rfc.group.parent.name}",
+        }
+    if rfc.ad is not None:
+        ts_document["adName"] = rfc.ad.name
+    if content is not None:
+        ts_document["content"] = _sanitize_text(content)
     _settings = get_settings()
     client = typesense.Client(
         {

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -1,6 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 """Search indexing utilities"""
-
+import re
 import typing
 from collections.abc import Collection
 from math import floor
@@ -16,6 +16,7 @@ COLLECTION = "docs"
 type DocsSchemaTypeT = typing.Literal["draft", "rfc"]
 
 SlugNameDict = typing.TypedDict("SlugNameDict", {"slug": str, "name": str})
+
 
 class GroupDict(typing.TypedDict):
     acronym: str
@@ -42,6 +43,7 @@ class FlagsDict(typing.TypedDict):
 
 class DocsSchemaDict(typing.TypedDict):
     """TypedDict equivalent to the Typesense "docs" schema"""
+
     rfcNumber: int | None  # integer RFC number, omit for drafts
     rfc: str | None  # string RFC number, omit for drafts
     ref: str | None  # RFC number for drafts corresponding to draft, else omitted
@@ -68,10 +70,31 @@ class DocsSchemaDict(typing.TypedDict):
     ranking: int  # ranking when no explicit sorting (RFC number or rev)
 
 
+
+def _sanitize_text(content):
+    """Sanitize content or abstract text for search"""
+    # REs (with approximate names)
+    RE_DOT_OR_BANG_SPACE = r"\. |! "  # -> " " (space)
+    RE_COMMENT_OR_TOC_CRUD = r"<--|-->|--+|\+|\.\.+"  # -> ""
+    RE_BRACKETED_REF = r"\[[a-zA-Z0-9 -]+\]"  # -> ""
+    RE_DOTTED_NUMBERS = r"[0-9]+\.[0-9]+(\.[0-9]+)?"  # -> ""
+    RE_MULTIPLE_WHITESPACE = r"\s+"  # -> " " (space)
+    # Replacement values (for clarity of intent)
+    SPACE = " "
+    EMPTY = ""
+    # Sanitizing begins here, order is significant!
+    content = re.sub(RE_DOT_OR_BANG_SPACE, SPACE, content.strip())
+    content = re.sub(RE_COMMENT_OR_TOC_CRUD, EMPTY, content)
+    content = re.sub(RE_BRACKETED_REF, EMPTY, content)
+    content = re.sub(RE_DOTTED_NUMBERS, EMPTY, content)
+    content = re.sub(RE_MULTIPLE_WHITESPACE, SPACE, content)
+    return content.strip()
+
+
 def update_or_create_rfc_entry(rfc: Document):
     assert rfc.type_id == "rfc"
     assert rfc.rfc_number is not None
-    
+
     keywords: list[str] = rfc.keywords  # help type checking
 
     subseries = rfc.part_of()
@@ -91,7 +114,7 @@ def update_or_create_rfc_entry(rfc: Document):
         "ref": None,
         "filename": rfc.name,
         "title": rfc.title,
-        "abstract": rfc.abstract,
+        "abstract": _sanitize_text(rfc.abstract),
         "keywords": keywords,
         "type": "rfc",
         "state": [state.name for state in rfc.states.all()],
@@ -101,7 +124,7 @@ def update_or_create_rfc_entry(rfc: Document):
             if subseries is None
             else SubseriesDict(
                 acronym=subseries.type.slug,
-                number=int(subseries.name[len(subseries.type.slug):]),
+                number=int(subseries.name[len(subseries.type.slug) :]),
                 total=len(subseries.contains()),
             )
         ),
@@ -130,7 +153,12 @@ def update_or_create_rfc_entry(rfc: Document):
             else None
         ),
         "stream": {"slug": rfc.stream.slug, "name": rfc.stream.name},
-        "authors": [],
+        "authors": [
+            AuthorDict(
+                name=rfc_author.titlepage_name, affiliation=rfc_author.affiliation
+            )
+            for rfc_author in rfc.rfcauthor_set.all()
+        ],
         "adName": None if rfc.ad is None else rfc.ad.name,
         "flags": {
             "hiddenDefault": False,
@@ -142,8 +170,7 @@ def update_or_create_rfc_entry(rfc: Document):
         "content": None,  # tbd
         "ranking": rfc.rfc_number,
     }
-    
-    
+
     client = typesense.Client(
         {"api_key": settings.TYPESENSE_API_KEY, "nodes": [settings.TYPESENSE_API_URL]}
     )

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -1,0 +1,150 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+"""Search indexing utilities"""
+
+import typing
+from collections.abc import Collection
+from math import floor
+
+import typesense
+from django.conf import settings
+
+from ietf.doc.models import Document
+from ietf.utils.log import log
+
+COLLECTION = "docs"
+
+type DocsSchemaTypeT = typing.Literal["draft", "rfc"]
+
+SlugNameDict = typing.TypedDict("SlugNameDict", {"slug": str, "name": str})
+
+class GroupDict(typing.TypedDict):
+    acronym: str
+    name: str
+    full: str
+
+
+class SubseriesDict(typing.TypedDict):
+    acronym: str  # type of subseries
+    number: int  # number of the subseries doc
+    total: int  # total number of docs in the subseries
+
+
+class AuthorDict(typing.TypedDict):
+    name: str
+    affiliation: str
+
+
+class FlagsDict(typing.TypedDict):
+    hiddenDefault: bool  # should doc be hidden in search by default?
+    obsoleted: bool  # obsoleted by another doc?
+    updated: bool  # updated by another doc?
+
+
+class DocsSchemaDict(typing.TypedDict):
+    """TypedDict equivalent to the Typesense "docs" schema"""
+    rfcNumber: int | None  # integer RFC number, omit for drafts
+    rfc: str | None  # string RFC number, omit for drafts
+    ref: str | None  # RFC number for drafts corresponding to draft, else omitted
+    filename: str  # filename of the document, without extension
+    title: str  # title of the draft / rfc
+    abstract: str  # abstract of the draft / rfc
+    keywords: Collection[str]  # search keywords, possibly empty
+    type: DocsSchemaTypeT  # type of the document (draft/rfc)
+    state: Collection[str] | None  # state(s) of the document (full name)
+    status: SlugNameDict | None  # standard level name (slug and name)
+    subseries: SubseriesDict | None
+    date: int  # date as a unix timestamp
+    expires: int | None  # expiration date as a unix timestamp
+    publicationDate: int | None  # publication date as a unix timestamp
+    group: GroupDict | None  # working group
+    area: GroupDict | None
+    stream: SlugNameDict | None
+    authors: list[AuthorDict] | None
+    adName: str | None  # area director name
+    flags: FlagsDict
+    obsoletedBy: list[str]  # RFC numbers (as strs) obsoleting this doc
+    updatedBy: list[str]  # RFC numbers (as strs) updating this doc
+    content: str | None  # sanitized content
+    ranking: int  # ranking when no explicit sorting (RFC number or rev)
+
+
+def update_or_create_rfc_entry(rfc: Document):
+    assert rfc.type_id == "rfc"
+    assert rfc.rfc_number is not None
+    
+    keywords: list[str] = rfc.keywords  # help type checking
+
+    subseries = rfc.part_of()
+    if len(subseries) > 1:
+        log(
+            f"RFC {rfc.rfc_number} is in multiple subseries. "
+            f"Indexing as {subseries[0].name}"
+        )
+    subseries = subseries[0] if len(subseries) > 0 else None
+    obsoleted_by = rfc.relations_that("obs")
+    updated_by = rfc.relations_that("updates")
+
+    ts_id = f"doc-{rfc.pk}"
+    ts_document: DocsSchemaDict = {
+        "rfcNumber": rfc.rfc_number,
+        "rfc": str(rfc.rfc_number),
+        "ref": None,
+        "filename": rfc.name,
+        "title": rfc.title,
+        "abstract": rfc.abstract,
+        "keywords": keywords,
+        "type": "rfc",
+        "state": [state.name for state in rfc.states.all()],
+        "status": {"slug": rfc.std_level.slug, "name": rfc.std_level.name},
+        "subseries": (
+            None
+            if subseries is None
+            else SubseriesDict(
+                acronym=subseries.type.slug,
+                number=int(subseries.name[len(subseries.type.slug):]),
+                total=len(subseries.contains()),
+            )
+        ),
+        "date": floor(rfc.time.timestamp()),
+        "expires": None,
+        "publicationDate": floor(rfc.pub_datetime().timestamp()),
+        "group": (
+            None
+            if rfc.group is None  # exclude "none" (individual group)?
+            else GroupDict(
+                acronym=rfc.group.acronym,
+                name=rfc.group.name,
+                full=f"{rfc.group.acronym} - {rfc.group.name}",
+            )
+        ),
+        "area": (
+            GroupDict(
+                acronym=rfc.group.parent.acronym,
+                name=rfc.group.parent.name,
+                full=f"{rfc.group.parent.acronym} - {rfc.group.parent.name}",
+            )
+            if (
+                rfc.group.parent is not None
+                and rfc.stream_id not in ["ise", "irtf", "iab"]  # exclude editorial?
+            )
+            else None
+        ),
+        "stream": {"slug": rfc.stream.slug, "name": rfc.stream.name},
+        "authors": [],
+        "adName": None if rfc.ad is None else rfc.ad.name,
+        "flags": {
+            "hiddenDefault": False,
+            "obsoleted": len(obsoleted_by) > 0,
+            "updated": len(updated_by) > 0,
+        },
+        "obsoletedBy": [str(doc.rfc_number) for doc in obsoleted_by],
+        "updatedBy": [str(doc.rfc_number) for doc in updated_by],
+        "content": None,  # tbd
+        "ranking": rfc.rfc_number,
+    }
+    
+    
+    client = typesense.Client(
+        {"api_key": settings.TYPESENSE_API_KEY, "nodes": [settings.TYPESENSE_API_URL]}
+    )
+    client.collections[COLLECTION].documents.upsert({"id": ts_id} | ts_document)

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -6,14 +6,29 @@ import typing
 from collections.abc import Collection
 from math import floor
 
+import httpx  # just for exceptions
 import typesense
+import typesense.exceptions
 from django.conf import settings
 
 from ietf.doc.models import Document, StoredObject
 from ietf.doc.storage_utils import retrieve_str
 from ietf.utils.log import log
 
-COLLECTION = "docs"
+# Error classes that might succeed just by retrying a failed attempt.
+# Must be a tuple for use with isinstance()
+RETRYABLE_ERROR_CLASSES = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    typesense.exceptions.Timeout,
+    typesense.exceptions.ServerError,
+    typesense.exceptions.ServiceUnavailable,
+)
+
+
+def enabled():
+    return getattr(settings, "SEARCHINDEX_API_URL", "") != ""
+
 
 type DocsSchemaTypeT = typing.Literal["draft", "rfc"]
 

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -83,13 +83,13 @@ def update_or_create_rfc_entry(rfc: Document):
         .filter(store="rfc", doc_name=rfc.name, name__startswith="txt/")
         .first()
     )
-    content = None
+    content = ""
     if stored_txt is not None:
         # Should be available in the blobdb, but be cautious...
         try:
             content = retrieve_str(kind=stored_txt.store, name=stored_txt.name)
-        except Exception:
-            log(f"Unable to retrieve {stored_txt} from storage")
+        except Exception as err:
+            log(f"Unable to retrieve {stored_txt} from storage: {err}")
 
     ts_id = f"doc-{rfc.pk}"
     ts_document = {
@@ -141,7 +141,7 @@ def update_or_create_rfc_entry(rfc: Document):
         }
     if rfc.ad is not None:
         ts_document["adName"] = rfc.ad.name
-    if content is not None:
+    if content != "":
         ts_document["content"] = _sanitize_text(content)
     _settings = get_settings()
     client = typesense.Client(

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -26,8 +26,22 @@ RETRYABLE_ERROR_CLASSES = (
 )
 
 
+DEFAULT_SETTINGS = {
+    "TYPESENSE_API_URL": "",
+    "TYPESENSE_API_KEY": "",
+    "TYPESENSE_COLLECTION_NAME": "docs",
+    "TASK_RETRY_DELAY": 10,
+    "TASK_MAX_RETRIES": 12,
+}
+
+
+def get_settings():
+    return DEFAULT_SETTINGS | getattr(settings, "SEARCHINDEX_CONFIG")
+
+
 def enabled():
-    return getattr(settings, "SEARCHINDEX_API_URL", "") != ""
+    _settings = get_settings()
+    return _settings["TYPESENSE_API_URL"] != ""
 
 
 type DocsSchemaTypeT = typing.Literal["draft", "rfc"]
@@ -200,7 +214,12 @@ def update_or_create_rfc_entry(rfc: Document):
         "ranking": rfc.rfc_number,
     }
 
+    _settings = get_settings()
     client = typesense.Client(
-        {"api_key": settings.TYPESENSE_API_KEY, "nodes": [settings.TYPESENSE_API_URL]}
+        {
+            "api_key": _settings["TYPESENSE_API_KEY"], 
+            "nodes": [_settings["TYPESENSE_API_URL"]]}
     )
-    client.collections[COLLECTION].documents.upsert({"id": ts_id} | ts_document)
+    client.collections[
+        _settings["TYPESENSE_COLLECTION_NAME"]
+    ].documents.upsert({"id": ts_id} | ts_document)

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -1,5 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 """Search indexing utilities"""
+
 import re
 import typing
 from collections.abc import Collection
@@ -8,7 +9,8 @@ from math import floor
 import typesense
 from django.conf import settings
 
-from ietf.doc.models import Document
+from ietf.doc.models import Document, StoredObject
+from ietf.doc.storage_utils import retrieve_str
 from ietf.utils.log import log
 
 COLLECTION = "docs"
@@ -70,7 +72,6 @@ class DocsSchemaDict(typing.TypedDict):
     ranking: int  # ranking when no explicit sorting (RFC number or rev)
 
 
-
 def _sanitize_text(content):
     """Sanitize content or abstract text for search"""
     # REs (with approximate names)
@@ -106,6 +107,19 @@ def update_or_create_rfc_entry(rfc: Document):
     subseries = subseries[0] if len(subseries) > 0 else None
     obsoleted_by = rfc.relations_that("obs")
     updated_by = rfc.relations_that("updates")
+
+    stored_txt = (
+        StoredObject.objects.exclude_deleted()
+        .filter(store="rfc", doc_name=rfc.name, name__startswith="txt/")
+        .first()
+    )
+    content = None
+    if stored_txt is not None:
+        # Should be available in the blobdb, but be cautious...
+        try:
+            content = retrieve_str(kind=stored_txt.store, name=stored_txt.name)
+        except Exception:
+            log(f"Unable to retrieve {stored_txt} from storage")
 
     ts_id = f"doc-{rfc.pk}"
     ts_document: DocsSchemaDict = {
@@ -167,7 +181,7 @@ def update_or_create_rfc_entry(rfc: Document):
         },
         "obsoletedBy": [str(doc.rfc_number) for doc in obsoleted_by],
         "updatedBy": [str(doc.rfc_number) for doc in updated_by],
-        "content": None,  # tbd
+        "content": None if content is None else _sanitize_text(content),
         "ranking": rfc.rfc_number,
     }
 

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -225,9 +225,10 @@ def update_or_create_rfc_entry(rfc: Document):
     _settings = get_settings()
     client = typesense.Client(
         {
-            "api_key": _settings["TYPESENSE_API_KEY"], 
-            "nodes": [_settings["TYPESENSE_API_URL"]]}
+            "api_key": _settings["TYPESENSE_API_KEY"],
+            "nodes": [_settings["TYPESENSE_API_URL"]],
+        }
     )
-    client.collections[
-        _settings["TYPESENSE_COLLECTION_NAME"]
-    ].documents.upsert({"id": ts_id} | ts_document)
+    client.collections[_settings["TYPESENSE_COLLECTION_NAME"]].documents.upsert(
+        {"id": ts_id} | ts_document
+    )

--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -26,7 +26,15 @@ RETRYABLE_ERROR_CLASSES = (
 )
 
 
-DEFAULT_SETTINGS = {
+class SettingsDict(typing.TypedDict):
+    TYPESENSE_API_URL: str
+    TYPESENSE_API_KEY: str
+    TYPESENSE_COLLECTION_NAME: str
+    TASK_RETRY_DELAY: int | float
+    TASK_MAX_RETRIES: int
+
+
+DEFAULT_SETTINGS: SettingsDict = {
     "TYPESENSE_API_URL": "",
     "TYPESENSE_API_KEY": "",
     "TYPESENSE_COLLECTION_NAME": "docs",
@@ -35,8 +43,8 @@ DEFAULT_SETTINGS = {
 }
 
 
-def get_settings():
-    return DEFAULT_SETTINGS | getattr(settings, "SEARCHINDEX_CONFIG")
+def get_settings() -> SettingsDict:
+    return DEFAULT_SETTINGS | getattr(settings, "SEARCHINDEX_CONFIG", {})
 
 
 def enabled():

--- a/ietf/utils/tests_searchindex.py
+++ b/ietf/utils/tests_searchindex.py
@@ -1,22 +1,48 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 from unittest import mock
+
+from django.conf import settings
 from django.test.utils import override_settings
 
-from .searchindex import _sanitize_text, update_or_create_rfc_entry
+from . import searchindex
 from .test_utils import TestCase
-from ..doc.factories import WgDraftFactory, WgRfcFactory, PublishedRfcDocEventFactory
+from ..blobdb.models import Blob
+from ..doc.factories import (
+    WgDraftFactory,
+    WgRfcFactory,
+    PublishedRfcDocEventFactory,
+    BcpFactory,
+    StdFactory,
+)
 from ..doc.models import Document
 from ..doc.storage_utils import store_str
+from ..person.factories import PersonFactory
 
 
 class SearchindexTests(TestCase):
+    def test_enabled(self):
+        with override_settings():
+            try:
+                del settings.SEARCHINDEX_CONFIG
+            except AttributeError:
+                pass
+            self.assertFalse(searchindex.enabled())
+        with override_settings(
+            SEARCHINDEX_CONFIG={"TYPESENSE_API_KEY": "this-is-not-a-key"}
+        ):
+            self.assertFalse(searchindex.enabled())
+        with override_settings(
+            SEARCHINDEX_CONFIG={"TYPESENSE_API_URL": "http://example.com"}
+        ):
+            self.assertTrue(searchindex.enabled())
+
     def test_sanitize_text(self):
         dirty_text = """
         
         This is text.  It + is <---- full    of \tprobl.....ems! Fix it. 
         """
         sanitized = "This is text It is full of problems Fix it."
-        self.assertEqual(_sanitize_text(dirty_text), sanitized)
+        self.assertEqual(searchindex._sanitize_text(dirty_text), sanitized)
 
     @override_settings(
         SEARCHINDEX_CONFIG={
@@ -30,36 +56,36 @@ class SearchindexTests(TestCase):
         not_rfc = WgDraftFactory()
         assert isinstance(not_rfc, Document)
         with self.assertRaises(AssertionError):
-            update_or_create_rfc_entry(not_rfc)
+            searchindex.update_or_create_rfc_entry(not_rfc)
         self.assertFalse(mock_ts_client_constructor.called)
 
         invalid_rfc = WgRfcFactory(name="rfc1000000", rfc_number=None)
         assert isinstance(invalid_rfc, Document)
         with self.assertRaises(AssertionError):
-            update_or_create_rfc_entry(invalid_rfc)
+            searchindex.update_or_create_rfc_entry(invalid_rfc)
         self.assertFalse(mock_ts_client_constructor.called)
 
         rfc = PublishedRfcDocEventFactory().doc
         assert isinstance(rfc, Document)
-        update_or_create_rfc_entry(rfc)
+        searchindex.update_or_create_rfc_entry(rfc)
         self.assertTrue(mock_ts_client_constructor.called)
         # walk the tree down to the method we expected to be called...
-        mock_upsert = (
-            mock_ts_client_constructor
-            .return_value
-            .collections["frogs"]  # matches value in override_settings above
-            .documents
-            .upsert
-        )
+        mock_upsert = mock_ts_client_constructor.return_value.collections[
+            "frogs"
+        ].documents.upsert  # matches value in override_settings above
         self.assertTrue(mock_upsert.called)
         upserted_dict = mock_upsert.call_args[0][0]
         # Check a few values, not exhaustive
         self.assertEqual(upserted_dict["id"], f"doc-{rfc.pk}")
         self.assertEqual(upserted_dict["rfcNumber"], rfc.rfc_number)
-        self.assertEqual(upserted_dict["abstract"], _sanitize_text(rfc.abstract))
-        self.assertNotIn("content", upserted_dict, None)  # no blob
+        self.assertEqual(
+            upserted_dict["abstract"], searchindex._sanitize_text(rfc.abstract)
+        )
+        self.assertNotIn("adName", upserted_dict)
+        self.assertNotIn("content", upserted_dict)  # no blob
+        self.assertNotIn("subseries", upserted_dict)
 
-        # repeat, this time with contents
+        # repeat, this time with contents, an AD, and subseries docs
         mock_upsert.reset_mock()
         store_str(
             kind="rfc",
@@ -68,11 +94,35 @@ class SearchindexTests(TestCase):
             doc_name=rfc.name,
             doc_rev=rfc.rev,  # expected to be None
         )
-        update_or_create_rfc_entry(rfc)
+        rfc.ad = PersonFactory(name="Alfred D. Rector")
+        # Put it in two Subseries docs to be sure this does not break things
+        # (the typesense schema does not support this for real at the moment)
+        BcpFactory(contains=[rfc], name="bcp1234")
+        StdFactory(contains=[rfc], name="std1234")
+        searchindex.update_or_create_rfc_entry(rfc)
         self.assertTrue(mock_upsert.called)
         upserted_dict = mock_upsert.call_args[0][0]
         # Check a few values, not exhaustive
         self.assertEqual(
             upserted_dict["content"],
-            _sanitize_text("The contents of this RFC"),
+            searchindex._sanitize_text("The contents of this RFC"),
         )
+        self.assertEqual(upserted_dict["adName"], "Alfred D. Rector")
+        self.assertIn("subseries", upserted_dict)
+        ss_dict = upserted_dict["subseries"]
+        # We should get one of the two subseries docs, but neither is more correct
+        # than the other...
+        self.assertTrue(
+            any(
+                ss_dict == {"acronym": ss_type, "number": 1234, "total": 1}
+                for ss_type in ["bcp", "std"]
+            )
+        )
+
+        # Finally, delete the contents blob and make sure things don't blow up 
+        mock_upsert.reset_mock()
+        Blob.objects.get(bucket="rfc", name=f"txt/{rfc.name}.txt").delete()
+        searchindex.update_or_create_rfc_entry(rfc)
+        self.assertTrue(mock_upsert.called)
+        upserted_dict = mock_upsert.call_args[0][0]
+        self.assertNotIn("content", upserted_dict)

--- a/ietf/utils/tests_searchindex.py
+++ b/ietf/utils/tests_searchindex.py
@@ -1,0 +1,78 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+from unittest import mock
+from django.test.utils import override_settings
+
+from .searchindex import _sanitize_text, update_or_create_rfc_entry
+from .test_utils import TestCase
+from ..doc.factories import WgDraftFactory, WgRfcFactory, PublishedRfcDocEventFactory
+from ..doc.models import Document
+from ..doc.storage_utils import store_str
+
+
+class SearchindexTests(TestCase):
+    def test_sanitize_text(self):
+        dirty_text = """
+        
+        This is text.  It + is <---- full    of \tprobl.....ems! Fix it. 
+        """
+        sanitized = "This is text It is full of problems Fix it."
+        self.assertEqual(_sanitize_text(dirty_text), sanitized)
+
+    @override_settings(
+        SEARCHINDEX_CONFIG={
+            "TYPESENSE_API_URL": "http://ts.example.com",
+            "TYPESENSE_API_KEY": "test-api-key",
+            "TYPESENSE_COLLECTION_NAME": "frogs",
+        }
+    )
+    @mock.patch("ietf.utils.searchindex.typesense.Client")
+    def test_update_or_create_rfc_entry(self, mock_ts_client_constructor):
+        not_rfc = WgDraftFactory()
+        assert isinstance(not_rfc, Document)
+        with self.assertRaises(AssertionError):
+            update_or_create_rfc_entry(not_rfc)
+        self.assertFalse(mock_ts_client_constructor.called)
+
+        invalid_rfc = WgRfcFactory(name="rfc1000000", rfc_number=None)
+        assert isinstance(invalid_rfc, Document)
+        with self.assertRaises(AssertionError):
+            update_or_create_rfc_entry(invalid_rfc)
+        self.assertFalse(mock_ts_client_constructor.called)
+
+        rfc = PublishedRfcDocEventFactory().doc
+        assert isinstance(rfc, Document)
+        update_or_create_rfc_entry(rfc)
+        self.assertTrue(mock_ts_client_constructor.called)
+        # walk the tree down to the method we expected to be called...
+        mock_upsert = (
+            mock_ts_client_constructor
+            .return_value
+            .collections["frogs"]  # matches value in override_settings above
+            .documents
+            .upsert
+        )
+        self.assertTrue(mock_upsert.called)
+        upserted_dict = mock_upsert.call_args[0][0]
+        # Check a few values, not exhaustive
+        self.assertEqual(upserted_dict["id"], f"doc-{rfc.pk}")
+        self.assertEqual(upserted_dict["rfcNumber"], rfc.rfc_number)
+        self.assertEqual(upserted_dict["abstract"], _sanitize_text(rfc.abstract))
+        self.assertEqual(upserted_dict["content"], None)  # no blob
+
+        # repeat, this time with contents
+        mock_upsert.reset_mock()
+        store_str(
+            kind="rfc",
+            name=f"txt/{rfc.name}.txt",
+            content="The contents of this RFC",
+            doc_name=rfc.name,
+            doc_rev=rfc.rev,  # expected to be None
+        )
+        update_or_create_rfc_entry(rfc)
+        self.assertTrue(mock_upsert.called)
+        upserted_dict = mock_upsert.call_args[0][0]
+        # Check a few values, not exhaustive
+        self.assertEqual(
+            upserted_dict["content"],
+            _sanitize_text("The contents of this RFC"),
+        )

--- a/ietf/utils/tests_searchindex.py
+++ b/ietf/utils/tests_searchindex.py
@@ -57,7 +57,7 @@ class SearchindexTests(TestCase):
         self.assertEqual(upserted_dict["id"], f"doc-{rfc.pk}")
         self.assertEqual(upserted_dict["rfcNumber"], rfc.rfc_number)
         self.assertEqual(upserted_dict["abstract"], _sanitize_text(rfc.abstract))
-        self.assertEqual(upserted_dict["content"], None)  # no blob
+        self.assertNotIn("content", upserted_dict, None)  # no blob
 
         # repeat, this time with contents
         mock_upsert.reset_mock()

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2007-2024, All Rights Reserved
+# Copyright The IETF Trust 2007-2026, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 from base64 import b64decode
@@ -468,11 +468,12 @@ PASSWORD_POLICY_ENFORCE_AT_LOGIN = (
     os.environ.get("DATATRACKER_ENFORCE_PW_POLICY", "true").lower() != "false"
 )
 
-
-# Typesense config
-if all(
-    key in os.environ
-    for key in ["DATATRACKER_TYPESENSE_API_KEY", "DATATRACKER_TYPESENSE_API_URL"]
-):
-    TYPESENSE_API_KEY = os.environ["DATATRACKER_TYPESENSE_API_KEY"]
-    TYPESENSE_API_URL = os.environ["DATATRACKER_TYPESENSE_API_URL"]
+# Typesense search indexing
+SEARCHINDEX_CONFIG = {
+    "TYPESENSE_API_URL": os.environ.get("DATATRACKER_TYPESENSE_API_URL", ""),
+    "TYPESENSE_API_KEY": os.environ.get("DATATRACKER_TYPESENSE_API_KEY", ""),
+    "TASK_RETRY_DELAY": os.environ.get("DATATRACKER_SEARCHINDEX_TASK_RETRY_DELAY", 10),
+    "TASK_MAX_RETRIES": os.environ.get(
+        "DATATRACKER_SEARCHINDEX_TASK_MAX_RETRIES", "12"
+    ),
+}

--- a/k8s/settings_local.py
+++ b/k8s/settings_local.py
@@ -443,12 +443,8 @@ STORAGES["red_bucket"] = {
     ),
 }
 RFCINDEX_DELETE_THEN_WRITE = False  # S3Storage allows file_overwrite by default
-RFCINDEX_OUTPUT_PATH = os.environ.get(
-    "DATATRACKER_RFCINDEX_OUTPUT_PATH", "other/"
-)
-RFCINDEX_INPUT_PATH = os.environ.get(
-    "DATATRACKER_RFCINDEX_INPUT_PATH", ""
-)
+RFCINDEX_OUTPUT_PATH = os.environ.get("DATATRACKER_RFCINDEX_OUTPUT_PATH", "other/")
+RFCINDEX_INPUT_PATH = os.environ.get("DATATRACKER_RFCINDEX_INPUT_PATH", "")
 
 # Configure the blobdb app for artifact storage
 _blobdb_replication_enabled = (
@@ -471,3 +467,12 @@ BLOBDB_REPLICATION = {
 PASSWORD_POLICY_ENFORCE_AT_LOGIN = (
     os.environ.get("DATATRACKER_ENFORCE_PW_POLICY", "true").lower() != "false"
 )
+
+
+# Typesense config
+if all(
+    key in os.environ
+    for key in ["DATATRACKER_TYPESENSE_API_KEY", "DATATRACKER_TYPESENSE_API_URL"]
+):
+    TYPESENSE_API_KEY = os.environ["DATATRACKER_TYPESENSE_API_KEY"]
+    TYPESENSE_API_URL = os.environ["DATATRACKER_TYPESENSE_API_URL"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ pymemcache>=4.0.0  # for django.core.cache.backends.memcached.PyMemcacheCache
 python-mimeparse>=2.0.0  # from TastyPie
 pytz==2025.2  # Pinned as changes need to be vetted for their effect on Meeting fields
 types-pytz==2025.2.0.20251108  # match pytz version
+typesense>=2.0.0
 requests>=2.32.4
 types-requests>=2.32.4
 requests-mock>=1.12.1


### PR DESCRIPTION
Does an `upsert()` with data intended to match what the initial JS index build tool generated. Has been tested against a local typesense instance, but have not done a systematic comparison at all.

~~Draft while I work on the tests.~~ Ready to go, I think

Things to think about for ~~this or~~ later work: (edit: I think best to take this as a complete feature and leave these for future improvements)
* The `_sanitize_text()` method in `searchindex.py` is based on the JS treatment of the content field. I don't completely understand the goals, but it would be good to review this for reasonableness.
* We'll want to add a full rebuild action using typesense's bulk update API. That's not in this PR.
* Datatracker should probably be in charge of the Typesense schema for this collection. That's also not in this PR. For now, it's using what's already set up.