### PR TITLE
fix: Rewrite CSS style attributes in SVG

### DIFF
--- a/ietf/static/js/document_html.js
+++ b/ietf/static/js/document_html.js
@@ -117,4 +117,83 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 }
             });
     }
+
+    // Rewrite these CSS properties so that the values are available for restyling.
+    document.querySelectorAll("svg [style]").forEach(el => {
+        // Push these CSS properties into their own attributes
+        const SVG_PRESENTATION_ATTRS = new Set([
+            'alignment-baseline', 'baseline-shift', 'clip', 'clip-path', 'clip-rule',
+            'color', 'color-interpolation', 'color-interpolation-filters',
+            'color-rendering', 'cursor', 'direction', 'display', 'dominant-baseline',
+            'fill', 'fill-opacity', 'fill-rule', 'filter', 'flood-color',
+            'flood-opacity', 'font-family', 'font-size', 'font-size-adjust',
+            'font-stretch', 'font-style', 'font-variant', 'font-weight',
+            'image-rendering', 'letter-spacing', 'lighting-color', 'marker-end',
+            'marker-mid', 'marker-start', 'mask', 'opacity', 'overflow', 'paint-order',
+            'pointer-events', 'shape-rendering', 'stop-color', 'stop-opacity',
+            'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap',
+            'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width',
+            'text-anchor', 'text-decoration', 'text-rendering', 'unicode-bidi',
+            'vector-effect', 'visibility', 'word-spacing', 'writing-mode',
+        ]);
+
+        // Simple CSS splitter: respects quoted strings and parens so semicolons
+        // inside url(...) or "..." don't get treated as declaration boundaries.
+        function parseDeclarations(styleText) {
+            const decls = [];
+            let buf = '';
+            let inStr = false;
+            let strChar = '';
+            let escaped = false;
+            let depth = 0;
+
+            for (const ch of styleText) {
+                if (inStr) {
+                    if (escaped) {
+                        escaped = false;
+                    } else if (ch === '\\') {
+                        escaped = true;
+                    } else if (ch === strChar) {
+                        inStr = false;
+                    }
+                } else if (ch === '"' || ch === "'") {
+                    inStr = true;
+                    strChar = ch;
+                } else if (ch === '(') {
+                    depth++;
+                } else if (ch === ')') {
+                    depth--;
+                } else if (ch === ';' && depth === 0) {
+                    const trimmed = buf.trim();
+                    if (trimmed) {
+                        decls.push(trimmed);
+                    }
+                    buf = '';
+                    continue;
+                }
+                buf += ch;
+            }
+            const trimmed = buf.trim();
+            if (trimmed) {
+                decls.push(trimmed);
+            }
+            return decls;
+        }
+
+        const remainder = [];
+        for (const decl of parseDeclarations(el.getAttribute('style'))) {
+            const [prop, val] = decl.split(":", 2).map(v => v.trim());
+            if (val && !/!important$/.test(val) && SVG_PRESENTATION_ATTRS.has(prop)) {
+                el.setAttribute(prop, val);
+            } else {
+                remainder.push(decl);
+            }
+        }
+
+        if (remainder.length > 0) {
+            el.setAttribute('style', remainder.join('; '));
+        } else {
+            el.removeAttribute('style');
+        }
+    });
 });


### PR DESCRIPTION
This makes the dark mode work properly for drafts like https://datatracker.ietf.org/doc/html/draft-hajdusek-qirg-timing-physics-01 which have diagrams that use a mix of ordinary attributes and the style attribute.  Using the style attribute makes the rules there invisible to the method we use for the remapping of black and white for dark mode.