### PR TITLE
chore: deduplicate logging and clean up config

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2007-2025, All Rights Reserved
+# Copyright The IETF Trust 2007-2026, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 
@@ -13,6 +13,7 @@ import pathlib
 import warnings
 from hashlib import sha384
 from typing import Any, Dict, List, Tuple # pyflakes:ignore
+from django.http import UnreadablePostError
 
 # DeprecationWarnings are suppressed by default, enable them
 warnings.simplefilter("always", DeprecationWarning)
@@ -236,21 +237,19 @@ AUTHENTICATION_BACKENDS = ( 'ietf.ietfauth.backends.CaseInsensitiveModelBackend'
 
 FILE_UPLOAD_PERMISSIONS = 0o644          
 
-# ------------------------------------------------------------------------
-# Django/Python Logging Framework Modifications
-
-# Filter out UreadablePostError:
-from django.http import UnreadablePostError
-def skip_unreadable_post(record):
-    if record.exc_info:
-        exc_type, exc_value = record.exc_info[:2] # pylint: disable=unused-variable
-        if isinstance(exc_value, UnreadablePostError):
-            return False
-    return True
 
 #
 # Logging config
 #
+
+# Callback to filter out UnreadablePostError:
+def skip_unreadable_post(record):
+    if record.exc_info:
+        exc_type, exc_value = record.exc_info[:2]  # pylint: disable=unused-variable
+        if isinstance(exc_value, UnreadablePostError):
+            return False
+    return True
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -273,7 +272,7 @@ LOGGING = {
             "propagate": False,  # no further handling please
         },
         "django.server": {
-            # Only used by runserver debug server
+            # Only used by Django's runserver development server
             "handlers": ["django.server"],
             "level": "INFO",
         },
@@ -335,7 +334,10 @@ LOGGING = {
         "json": {
             "class": "ietf.utils.jsonlogger.DatatrackerJsonFormatter",
             "style": "{",
-            "format": "{asctime}{levelname}{message}{name}{pathname}{lineno}{funcName}{process}",
+            "format": (
+                "{asctime}{levelname}{message}{name}{pathname}{lineno}{funcName}"
+                "{process}"
+            ),
         },
     },
 }

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1511,7 +1511,7 @@ if SERVER_MODE != 'production':
     if 'NOMCOM_APP_SECRET' not in locals():
         NOMCOM_APP_SECRET = b'\x9b\xdas1\xec\xd5\xa0SI~\xcb\xd4\xf5t\x99\xc4i\xd7\x9f\x0b\xa9\xe8\xfeY\x80$\x1e\x12tN:\x84'
 
-    ALLOWED_HOSTS = ['borkbork.org',]
+    ALLOWED_HOSTS = ['*',]
 
     try:
         # see https://github.com/omarish/django-cprofile-middleware

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -265,6 +265,14 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "loggers": {
+        "celery": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "datatracker": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
         "django": {
             "handlers": ["console", "mail_admins"],
             "level": "INFO",
@@ -277,14 +285,6 @@ LOGGING = {
         "oidc_provider": {
             "handlers": ["console"],
             "level": "DEBUG",
-        },
-        "datatracker": {
-            "handlers": ["console"],
-            "level": "INFO",
-        },
-        "celery": {
-            "handlers": ["console"],
-            "level": "INFO",
         },
     },
     "handlers": {

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -262,92 +262,92 @@ def skip_unreadable_post(record):
 # Logging config
 #
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'loggers': {
-        'django': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
+    "version": 1,
+    "disable_existing_loggers": False,
+    "loggers": {
+        "django": {
+            "handlers": ["console", "mail_admins"],
+            "level": "INFO",
         },
-        'django.server': {
+        "django.server": {
             # Only used by runserver debug server
-            'handlers': ['django.server'],
-            'level': 'INFO',
+            "handlers": ["django.server"],
+            "level": "INFO",
         },
-        'oidc_provider': {
-            'handlers': ['console', ],
-            'level': 'DEBUG',
+        "oidc_provider": {
+            "handlers": ["console"],
+            "level": "DEBUG",
         },
-        'datatracker': {
-            'handlers': ['console'],
-            'level': 'INFO',
+        "datatracker": {
+            "handlers": ["console"],
+            "level": "INFO",
         },
-        'celery': {
-            'handlers': ['console'],
-            'level': 'INFO',
+        "celery": {
+            "handlers": ["console"],
+            "level": "INFO",
         },
     },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'plain',
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "plain",
         },
-        'debug_console': {
-            'level': 'DEBUG',
-            'filters': ['require_debug_true'],
-            'class': 'logging.StreamHandler',
-            'formatter': 'plain',
+        "debug_console": {
+            "level": "DEBUG",
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+            "formatter": "plain",
         },
-        'django.server': {
-            'level': 'INFO',
-            'class': 'logging.StreamHandler',
-            'formatter': 'django.server',
+        "django.server": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "django.server",
         },
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': [
-                'require_debug_false',
-                'skip_suspicious_operations',
-                'skip_unreadable_posts',
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": [
+                "require_debug_false",
+                "skip_suspicious_operations",
+                "skip_unreadable_posts",
             ],
-            'class': 'django.utils.log.AdminEmailHandler',
-            'include_html': True,
-        }
+            "class": "django.utils.log.AdminEmailHandler",
+            "include_html": True,
+        },
     },
     # All these are used by handlers
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse',
+    "filters": {
+        "require_debug_false": {
+            "()": "django.utils.log.RequireDebugFalse",
         },
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue',
-        },
-        # custom filter, function defined above:
-        'skip_suspicious_operations': {
-            '()': 'django.utils.log.CallbackFilter',
-            'callback': skip_suspicious_operations,
+        "require_debug_true": {
+            "()": "django.utils.log.RequireDebugTrue",
         },
         # custom filter, function defined above:
-        'skip_unreadable_posts': {
-            '()': 'django.utils.log.CallbackFilter',
-            'callback': skip_unreadable_post,
+        "skip_suspicious_operations": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": skip_suspicious_operations,
+        },
+        # custom filter, function defined above:
+        "skip_unreadable_posts": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": skip_unreadable_post,
         },
     },
-    'formatters': {
-        'django.server': {
-            '()': 'django.utils.log.ServerFormatter',
-            'format': '[%(server_time)s] %(message)s',
+    "formatters": {
+        "django.server": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[%(server_time)s] %(message)s",
         },
-        'plain': {
-            'style': '{',
-            'format': '{levelname}: {name}:{lineno}: {message}',
+        "plain": {
+            "style": "{",
+            "format": "{levelname}: {name}:{lineno}: {message}",
         },
-        'json' : {
+        "json": {
             "class": "ietf.utils.jsonlogger.DatatrackerJsonFormatter",
             "style": "{",
             "format": "{asctime}{levelname}{message}{name}{pathname}{lineno}{funcName}{process}",
-        }
+        },
     },
 }
 

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -267,8 +267,8 @@ LOGGING = {
             "level": "INFO",
         },
         "django.request": {"level": "ERROR"},  # only log 5xx, ignore 4xx
-        "django.security.DisallowedHost": {
-            # Invalid Host header - log only to console
+        "django.security": {
+            # SuspiciousOperation errors - log to console only
             "handlers": ["console"],
             "propagate": False,  # no further handling please
         },

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -239,16 +239,6 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 # ------------------------------------------------------------------------
 # Django/Python Logging Framework Modifications
 
-# Filter out "Invalid HTTP_HOST" emails
-# Based on http://www.tiwoc.de/blog/2013/03/django-prevent-email-notification-on-suspiciousoperation/
-from django.core.exceptions import SuspiciousOperation
-def skip_suspicious_operations(record):
-    if record.exc_info:
-        exc_value = record.exc_info[1]
-        if isinstance(exc_value, SuspiciousOperation):
-            return False
-    return True
-
 # Filter out UreadablePostError:
 from django.http import UnreadablePostError
 def skip_unreadable_post(record):
@@ -276,6 +266,11 @@ LOGGING = {
         "django": {
             "handlers": ["console", "mail_admins"],
             "level": "INFO",
+        },
+        "django.security.DisallowedHost": {
+            # Invalid Host header - log only to console
+            "handlers": ["console"],
+            "propagate": False,  # no further handling please
         },
         "django.server": {
             # Only used by runserver debug server
@@ -308,7 +303,6 @@ LOGGING = {
             "level": "ERROR",
             "filters": [
                 "require_debug_false",
-                "skip_suspicious_operations",
                 "skip_unreadable_posts",
             ],
             "class": "django.utils.log.AdminEmailHandler",
@@ -322,11 +316,6 @@ LOGGING = {
         },
         "require_debug_true": {
             "()": "django.utils.log.RequireDebugTrue",
-        },
-        # custom filter, function defined above:
-        "skip_suspicious_operations": {
-            "()": "django.utils.log.CallbackFilter",
-            "callback": skip_suspicious_operations,
         },
         # custom filter, function defined above:
         "skip_unreadable_posts": {
@@ -1520,7 +1509,7 @@ if SERVER_MODE != 'production':
     if 'NOMCOM_APP_SECRET' not in locals():
         NOMCOM_APP_SECRET = b'\x9b\xdas1\xec\xd5\xa0SI~\xcb\xd4\xf5t\x99\xc4i\xd7\x9f\x0b\xa9\xe8\xfeY\x80$\x1e\x12tN:\x84'
 
-    ALLOWED_HOSTS = ['*',]
+    ALLOWED_HOSTS = ['borkbork.org',]
 
     try:
         # see https://github.com/omarish/django-cprofile-middleware

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -266,6 +266,7 @@ LOGGING = {
             "handlers": ["console", "mail_admins"],
             "level": "INFO",
         },
+        "django.request": {"level": "ERROR"},  # only log 5xx, ignore 4xx
         "django.security.DisallowedHost": {
             # Invalid Host header - log only to console
             "handlers": ["console"],
@@ -336,7 +337,7 @@ LOGGING = {
             "style": "{",
             "format": (
                 "{asctime}{levelname}{message}{name}{pathname}{lineno}{funcName}"
-                "{process}"
+                "{process}{status_code}"
             ),
         },
     },

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -258,43 +258,20 @@ def skip_unreadable_post(record):
             return False
     return True
 
-# Copied from DEFAULT_LOGGING as of Django 1.10.5 on 22 Feb 2017, and modified
-# to incorporate html logging, invalid http_host filtering, and more.
-# Changes from the default has comments.
-
-# The Python logging flow is as follows:
-# (see https://docs.python.org/2.7/howto/logging.html#logging-flow)
 #
-#   Init: get a Logger: logger = logging.getLogger(name)
+# Logging config
 #
-#   Logging call, e.g. logger.error(level, msg, *args, exc_info=(...), extra={...})
-#   --> Logger (discard if level too low for this logger)
-#       (create log record from level, msg, args, exc_info, extra)
-#       --> Filters (discard if any filter attach to logger rejects record)
-#           --> Handlers (discard if level too low for handler)
-#               --> Filters (discard if any filter attached to handler rejects record)
-#                   --> Formatter (format log record and emit)
-#
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    #
     'loggers': {
         'django': {
             'handlers': ['console', 'mail_admins'],
             'level': 'INFO',
         },
-        'django.request': {
-            'handlers': ['console'],
-            'level': 'ERROR',
-        },
         'django.server': {
+            # Only used by runserver debug server
             'handlers': ['django.server'],
-            'level': 'INFO',
-        },
-        'django.security': {
-            'handlers': ['console', ],
             'level': 'INFO',
         },
         'oidc_provider': {
@@ -310,9 +287,6 @@ LOGGING = {
             'level': 'INFO',
         },
     },
-    #
-    # No logger filters
-    #
     'handlers': {
         'console': {
             'level': 'DEBUG',
@@ -320,7 +294,6 @@ LOGGING = {
             'formatter': 'plain',
         },
         'debug_console': {
-            # Active only when DEBUG=True
             'level': 'DEBUG',
             'filters': ['require_debug_true'],
             'class': 'logging.StreamHandler',
@@ -335,14 +308,13 @@ LOGGING = {
             'level': 'ERROR',
             'filters': [
                 'require_debug_false',
-                'skip_suspicious_operations', # custom
-                'skip_unreadable_posts', # custom
+                'skip_suspicious_operations',
+                'skip_unreadable_posts',
             ],
             'class': 'django.utils.log.AdminEmailHandler',
-            'include_html': True,       # non-default
+            'include_html': True,
         }
     },
-    #
     # All these are used by handlers
     'filters': {
         'require_debug_false': {
@@ -362,7 +334,6 @@ LOGGING = {
             'callback': skip_unreadable_post,
         },
     },
-    # And finally the formatters
     'formatters': {
         'django.server': {
             '()': 'django.utils.log.ServerFormatter',
@@ -379,9 +350,6 @@ LOGGING = {
         }
     },
 }
-
-# End logging
-# ------------------------------------------------------------------------
 
 
 X_FRAME_OPTIONS = 'SAMEORIGIN'


### PR DESCRIPTION
The only functional change here is preventing double log entries on 5xx requests. This was happening because the `django.request` logger had its own handler attached. As refactored here, 4xx errors (warnings) are discarded by the `"level"` filter in the `django.request` logger, and the actual log is emitted after propagating up to the `django` logger.

Along with the above, reformats the LOGGING code using ruff style and removes old comments that are more confusing than helpful at this point. Removes the Django 1.x method of suppressing admin mail for `SuspiciousOperation` errors. Instead, configures the `django.security` logger to be console-only and not to propagate.

Adds `status_code` to the JSON log. This is only relevant for `django.request` logs, where it will normally be 500. Other logs will have a null value.

Beware a little bit of churn in the commits...