### PR TITLE
feat: add email/name for ADs and WG Chairs

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -27,7 +27,7 @@ from ietf.doc.utils import (
     update_action_holders,
     update_rfcauthors,
 )
-from ietf.group.models import Group
+from ietf.group.models import Group, Role
 from ietf.group.serializers import AreaSerializer
 from ietf.name.models import StreamName, StdLevelName
 from ietf.person.models import Person
@@ -97,6 +97,21 @@ class DraftWithAuthorsSerializer(serializers.ModelSerializer):
         fields = ["draft_name", "authors"]
 
 
+class WgChairSerializer(serializers.Serializer):
+    """Serialize a WG chair's name and email from a Role"""
+
+    name = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.CharField)
+    def get_name(self, role: Role) -> str:
+        return role.person.plain_name()
+
+    @extend_schema_field(serializers.EmailField)
+    def get_email(self, role: Role) -> str:
+        return role.email.email_address()
+
+
 class DocumentAuthorSerializer(serializers.ModelSerializer):
     """Serializer for a Person in a response"""
 
@@ -126,6 +141,7 @@ class FullDraftSerializer(serializers.ModelSerializer):
         source="shepherd.person", read_only=True
     )
     consensus = serializers.SerializerMethodField()
+    wg_chairs = serializers.SerializerMethodField()
 
     class Meta:
         model = Document
@@ -145,10 +161,20 @@ class FullDraftSerializer(serializers.ModelSerializer):
             "consensus",
             "shepherd",
             "ad",
+            "wg_chairs",
         ]
 
     def get_consensus(self, doc: Document) -> Optional[bool]:
         return default_consensus(doc)
+
+    @extend_schema_field(WgChairSerializer(many=True))
+    def get_wg_chairs(self, doc: Document):
+        if doc.group is None:
+            return []
+        chairs = doc.group.role_set.filter(name_id="chair").select_related(
+            "person", "email"
+        )
+        return WgChairSerializer(chairs, many=True).data
 
     def get_source_format(
         self, doc: Document

--- a/ietf/group/serializers.py
+++ b/ietf/group/serializers.py
@@ -20,7 +20,13 @@ class AreaDirectorSerializer(serializers.Serializer):
     Works with Email or Role
     """
 
+    name = serializers.SerializerMethodField()
     email = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.CharField)
+    def get_name(self, instance: Email | Role):
+        person = getattr(instance, 'person', None)
+        return person.plain_name() if person else None
 
     @extend_schema_field(serializers.EmailField)
     def get_email(self, instance: Email | Role):

--- a/ietf/group/tests_serializers.py
+++ b/ietf/group/tests_serializers.py
@@ -31,7 +31,7 @@ class AreaDirectorSerializerTests(TestCase):
         serialized = AreaDirectorSerializer(role).data
         self.assertEqual(
             serialized,
-            {"email": role.email.email_address()},
+            {"email": role.email.email_address(), "name": role.person.plain_name()},
         )
 
     def test_serializes_email(self):
@@ -40,7 +40,10 @@ class AreaDirectorSerializerTests(TestCase):
         serialized = AreaDirectorSerializer(email).data
         self.assertEqual(
             serialized,
-            {"email": email.email_address()},
+            {
+                "email": email.email_address(),
+                "name": email.person.plain_name() if email.person else None,
+            },
         )
 
 
@@ -63,7 +66,10 @@ class AreaSerializerTests(TestCase):
         self.assertEqual(serialized["name"], area.name)
         self.assertCountEqual(
             serialized["ads"],
-            [{"email": ad.email.email_address()} for ad in ad_roles],
+            [
+                {"email": ad.email.email_address(), "name": ad.person.plain_name()}
+                for ad in ad_roles
+            ],
         )
 
     def test_serializes_inactive_area(self):


### PR DESCRIPTION
adding "wg_chairs" field for purple API,
also adding the name if AD in existing AreaDirectorSerializer.

Both is needed in purple emails, relates to https://github.com/ietf-tools/purple/pull/1028