### PR TITLE
feat: unmask exceptions on blob retrieve error

### DIFF
--- a/ietf/doc/storage_utils.py
+++ b/ietf/doc/storage_utils.py
@@ -178,8 +178,7 @@ def retrieve_bytes(kind: str, name: str) -> bytes:
                     content = f.read()
         except Exception as err:
             log(f"Blobstore Error: Failed to read bytes from {kind}:{name}: {repr(err)}")
-            if settings.SERVER_MODE == "development":
-                raise
+            raise
     return content
 
 
@@ -192,6 +191,5 @@ def retrieve_str(kind: str, name: str) -> str:
             content = content_bytes.decode("utf-8")
         except Exception as err:
             log(f"Blobstore Error: Failed to read string from {kind}:{name}: {repr(err)}")
-            if settings.SERVER_MODE == "development":
-                raise
+            raise
     return content


### PR DESCRIPTION
These have not been encountered in at least three months, likely longer.

Still remains to unmask exceptions when storing blobs. We are probably ready to do that, but log noise caused by expected failures makes it hard to be certain. Soon...

Originally proposed in #10692 