### PR TITLE
chore: beat termination grace period -> 10 s

### DIFF
--- a/k8s/beat.yaml
+++ b/k8s/beat.yaml
@@ -59,4 +59,4 @@ spec:
             name: files-cfgmap
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The celery beat process sometimes stops responding to TERM on the apollo cluster. This drops the grace period before a KILL is sent down to 10 seconds. The beat pod should always shut down without noticeable delay. For context, the old time (600 s) was copied from the pod container, which legitimately may need longer to finish a long-running task.