### PR TITLE
fix: Disable calt font feature

### DIFF
--- a/ietf/static/css/ietf.scss
+++ b/ietf/static/css/ietf.scss
@@ -46,6 +46,11 @@ $bootstrap-icons-font-src: url("npm:bootstrap-icons/font/fonts/bootstrap-icons.w
 url("npm:bootstrap-icons/font/fonts/bootstrap-icons.woff") format("woff");
 @import "bootstrap-icons/font/bootstrap-icons";
 
+// Disable contextual alternates (calt)
+body {
+  font-feature-settings: "calt" off;
+}
+
 // Leave room for fixed-top navbar...
 body.navbar-offset {
     padding-top: 60px;


### PR DESCRIPTION
Fixes #10778 

This disables `calt` font feature site wide.
I couldn't find a way to disable this via bootstrap settings.

Screenshot:
<img width="1507" height="490" alt="Screenshot 2026-04-29 at 15 55 14" src="https://github.com/user-attachments/assets/a5ca7e1c-67f3-4ed4-9c98-bafbe5a9cb92" />
