### PR TITLE
fix: ipv4-only for internal traffic

### DIFF
--- a/dev/build/gunicorn.conf.py
+++ b/dev/build/gunicorn.conf.py
@@ -12,9 +12,8 @@ from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 from opentelemetry.instrumentation.pymemcache import PymemcacheInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
-# Bind all ipv4 interfaces and ipv6 loopback interface. Would prefer to bind all
-# ipv6 as well, but something conflicts with [::]:8000.
-bind = ["0.0.0.0:8000", "[::1]:8000"]
+# Bind all ipv4 interfaces (nginx uses loopback, but k8s health checks don't)
+bind = ["0.0.0.0:8001"]
 
 # Disable control socket
 control_socket_disable = True

--- a/docker/configs/nginx-proxy.conf
+++ b/docker/configs/nginx-proxy.conf
@@ -1,3 +1,7 @@
+upstream datatracker_backend {
+    server 127.0.0.1:8001;
+}
+
 server {
     listen 8000 default_server;
     listen [::]:8000 default_server;
@@ -24,7 +28,7 @@ server {
 
     location / {
         error_page 502 /502.html;
-        proxy_pass http://localhost:8001/;
+        proxy_pass http://datatracker_backend/;
         proxy_set_header Host localhost:8000;
     }
 

--- a/k8s/nginx-datatracker.conf
+++ b/k8s/nginx-datatracker.conf
@@ -1,3 +1,7 @@
+upstream datatracker_backend {
+    server 127.0.0.1:8000;
+}
+
 server {
     listen 8080 default_server;
     server_name _;
@@ -22,7 +26,7 @@ server {
         proxy_set_header X-Request-Start "t=$${keepempty}msec";
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
         proxy_hide_header X-Datatracker-Is-Authenticated; # hide this from the outside world
-        proxy_pass http://localhost:8000;
+        proxy_pass http://datatracker_backend;
         # Set timeouts longer than Cloudflare proxy limits
         proxy_connect_timeout 60;  # nginx default (Cf = 15)
         proxy_read_timeout 120;  # nginx default = 60 (Cf = 100) 


### PR DESCRIPTION
Listening on ipv6 interfaces may have contributed to increased CPU usage during heavy traffic. This switches back to ipv4 only and configures nginx to use 127.0.0.1 instead of localhost for proxying.

Does not affect external access, this is purely internal to the k8s cluster.