### PR TITLE
fix: avoid PosixPath.endswith() in run_yang_model_checks_task

### DIFF
--- a/ietf/submit/utils.py
+++ b/ietf/submit/utils.py
@@ -1612,6 +1612,4 @@ def populate_yang_model_dirs():
             log.log(f"Error processing {item.name}: {e}")
 
     ftp_moddir = Path(settings.FTP_DIR) / "yang" / "draftmod/"
-    if not moddir.endswith("/"):
-        moddir += "/"
-    subprocess.call(("/usr/bin/rsync", "-aq", "--delete", moddir, ftp_moddir))
+    subprocess.call(("/usr/bin/rsync", "-aq", "--delete", f"{moddir}/", str(ftp_moddir)))


### PR DESCRIPTION
Fixes #10818.

`populate_yang_model_dirs` was calling `.endswith("/")` on `moddir`, which is a `pathlib.Path` (not a `str`), causing the daily `run_yang_model_checks_task` to fail with `AttributeError("'PosixPath' object has no attribute 'endswith'")`. Pass an `f"{moddir}/"` source directly to rsync so the trailing slash is always present and drop the broken `if` block.