### PR TITLE
fix: allow empty keyword list for Document

### DIFF
--- a/ietf/doc/migrations/0034_alter_dochistory_keywords_alter_document_keywords.py
+++ b/ietf/doc/migrations/0034_alter_dochistory_keywords_alter_document_keywords.py
@@ -1,0 +1,33 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from django.db import migrations, models
+import ietf.doc.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("doc", "0033_dochistory_keywords_document_keywords"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="dochistory",
+            name="keywords",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                max_length=1000,
+                validators=[ietf.doc.models.validate_doc_keywords],
+            ),
+        ),
+        migrations.AlterField(
+            model_name="document",
+            name="keywords",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                max_length=1000,
+                validators=[ietf.doc.models.validate_doc_keywords],
+            ),
+        ),
+    ]

--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -157,6 +157,7 @@ class DocumentInfo(models.Model):
         default=list,
         max_length=1000,
         validators=[validate_doc_keywords],
+        blank=True,
     )
 
     @property


### PR DESCRIPTION
Without this change, the Document admin won't allow saving a document without at least one keyword in its array. ModelForms involving Document would likely also have this issue.