### PR TITLE
fix: backport CVE-2026-35192 fix from Django 5.2

### DIFF
--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -1261,7 +1261,10 @@ CHECKS_LIBRARY_PATCHES_TO_APPLY = [
     'patch/change-oidc-provider-field-sizes-228.patch',
     'patch/fix-oidc-access-token-post.patch',
     'patch/fix-jwkest-jwt-logging.patch',
-    'patch/django-cookie-delete-with-all-settings.patch',
+    # Patch includes old cookie-delete-with-all-settings and a backport of the fix
+    # to CVE-2026-35192 from Django 5.2. The patches conflict, so cannot be applied
+    # separately.
+    'patch/django-cookie-delete-settings-and-CVE-2026-35192.patch',
     'patch/tastypie-django22-fielderror-response.patch',
 ]
 if DEBUG:

--- a/patch/django-cookie-delete-settings-and-CVE-2026-35192.patch
+++ b/patch/django-cookie-delete-settings-and-CVE-2026-35192.patch
@@ -44,9 +44,9 @@
              expires="Thu, 01 Jan 1970 00:00:00 GMT",
              samesite=samesite,
          )
---- django/contrib/sessions/middleware.py.orig	2020-08-13 12:12:12.401898114 +0200
-+++ django/contrib/sessions/middleware.py	2020-08-13 12:14:52.690520659 +0200
-@@ -38,6 +38,8 @@
+--- django/contrib/sessions/middleware.py.old	2026-05-12 15:18:07.673997003 +0000
++++ django/contrib/sessions/middleware.py	2026-05-12 15:18:15.770997007 +0000
+@@ -38,12 +38,15 @@
                  settings.SESSION_COOKIE_NAME,
                  path=settings.SESSION_COOKIE_PATH,
                  domain=settings.SESSION_COOKIE_DOMAIN,
@@ -54,4 +54,23 @@
 +                httponly=settings.SESSION_COOKIE_HTTPONLY or None,
                  samesite=settings.SESSION_COOKIE_SAMESITE,
              )
-             patch_vary_headers(response, ("Cookie",))
+-            patch_vary_headers(response, ("Cookie",))
++            need_vary_cookie = True
+         else:
+-            if accessed:
+-                patch_vary_headers(response, ("Cookie",))
++            # If the session was accessed, it must be varied on, regardless of
++            # whether it was modified or will be saved.
++            need_vary_cookie = accessed
+             if (modified or settings.SESSION_SAVE_EVERY_REQUEST) and not empty:
+                 if request.session.get_expire_at_browser_close():
+                     max_age = None
+@@ -74,4 +77,8 @@
+                         httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+                         samesite=settings.SESSION_COOKIE_SAMESITE,
+                     )
++                    # With a session cookie set, it must be varied on.
++                    need_vary_cookie = True
++        if need_vary_cookie:
++            patch_vary_headers(response, ("Cookie",))
+         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ botocore>=1.39.15
 celery>=5.5.3
 coverage>=7.9.2
 defusedxml>=0.7.1    # for TastyPie when using xml; not a declared dependency
-Django>4.2,<5
+Django>=4.2.30,<5
 django-admin-rangefilter>=0.13.3
 django-analytical>=3.2.0
 django-bootstrap5>=25.1


### PR DESCRIPTION
CVE-2026-35192: Session fixation via public cached pages and SESSION_SAVE_EVERY_REQUEST

Patch from https://github.com/django/django/commit/47cf968c125e3fab317e10fe150ec479e745f995

Verified that Django's new tests pass after patching 4.2.30.