### PR TITLE
chore: .npmrc security tweaks

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -41,3 +41,5 @@ supportedArchitectures:
     - win32
 
 yarnPath: .yarn/releases/yarn-3.2.2.cjs
+
+enableScripts: false

--- a/dev/coverage-action/.npmrc
+++ b/dev/coverage-action/.npmrc
@@ -1,2 +1,7 @@
 save-exact = true
 save-prefix = ""
+audit = false
+fund = false
+min-release-age=3
+allow-git=none
+ignore-scripts=true

--- a/dev/deploy-to-container/.npmrc
+++ b/dev/deploy-to-container/.npmrc
@@ -1,3 +1,6 @@
 audit = false
 fund = false
 save-exact = true
+min-release-age=3
+allow-git=none
+ignore-scripts=true

--- a/dev/k8s-get-deploy-name/.npmrc
+++ b/dev/k8s-get-deploy-name/.npmrc
@@ -1,3 +1,6 @@
 audit = false
 fund = false
 save-exact = true
+min-release-age=3
+allow-git=none
+ignore-scripts=true

--- a/playwright/.npmrc
+++ b/playwright/.npmrc
@@ -1,1 +1,7 @@
 save-prefix = ""
+audit = false
+fund = false
+save-exact = true
+min-release-age=3
+allow-git=none
+ignore-scripts=true


### PR DESCRIPTION
this shouldn't be merged yet, it needs testing and more discussion.

## chore

We use `npm` and `yarn` and there some flags that might help with supply chain security.

* `min-release-age`: gives community time to flag malicious publishes,
* `allow-git`: don't allow dependencies from `github:user/repo`, `git+ssh://`, `git+https`; instead preferring NPM which is more scrutinised,
* `ignore-scripts`: don't run preinstall/postinstall scripts as this is a common mechanism for compromised packages. So we should only enable if needed.

### `/.yarnrc.yml`
Yarn supports `ignore-scripts` and `yarn build` and `yarn legacy:build` work so it seems we can enable this.

Yarn 3.2.2 doesn't support `min-release-age` or `allow-git` those were added in 4.10.0.

### `/playwright/.npmrc`
Currently this uses Node 16 / NPM 8. `ignore-scripts` is supported, but we'd need to upgrade to use `min-release-age` and `allow-git`.

`ignore-scripts`: I'd guess that Chrome binaries are installed in a preinstall/postinstall script so this flag might break something.

### `/dev/coverage-action/.npmrc`

Currently this uses Node 16 / NPM 8. `ignore-scripts` is supported, but we'd need to upgrade to use `min-release-age` and `allow-git`.

No testing done yet.

### `/dev/deploy-to-container/.npmrc`

Currently this uses Node 16 / NPM 8. `ignore-scripts` is supported, but we'd need to upgrade to use `min-release-age` and `allow-git`.

No testing done yet.

### `/dev/k8s-get-deploy-name/.npmrc`
 
Currently this uses Node 16 / NPM 8. `ignore-scripts` is supported, but we'd need to upgrade to use `min-release-age` and `allow-git`.

No testing done yet.
