### PR TITLE
ci: pin xym until we can adapt to new required arguments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -90,6 +90,6 @@ unidecode>=1.4.0
 urllib3>=2.5.0
 weasyprint>=66.0
 xml2rfc>=3.30.0
-xym>=0.6,<1.0
+xym>=0.6,<0.10.0
 zxcvbn>=4.5.0
 types-zxcvbn~=4.5.0.20250223  # match zxcvbn version


### PR DESCRIPTION
Without the pin, we are getting:
```
'YangModuleExtractor.get_extracted_models() missing 2 required positional arguments: 'extract_semver' and 'semver_symlink'
```