### PR TITLE
chore: nginx -> 1.30

### DIFF
--- a/docker/configs/nginx-proxy.conf
+++ b/docker/configs/nginx-proxy.conf
@@ -1,5 +1,6 @@
 upstream datatracker_backend {
     server 127.0.0.1:8001;
+    keepalive 0; # default = 32 since nginx 1.29.7
 }
 
 server {

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -69,7 +69,7 @@ spec:
         # Nginx Container
         # -----------------------------------------------------
         - name: nginx
-          image: "ghcr.io/nginxinc/nginx-unprivileged:1.27"
+          image: "ghcr.io/nginxinc/nginx-unprivileged:1.30"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/nginx-auth.conf
+++ b/k8s/nginx-auth.conf
@@ -1,5 +1,6 @@
 upstream datatracker_backend {
     server 127.0.0.1:8000;
+    keepalive 0; # default = 32 since nginx 1.29.7
 }
 
 server {

--- a/k8s/nginx-datatracker.conf
+++ b/k8s/nginx-datatracker.conf
@@ -1,5 +1,6 @@
 upstream datatracker_backend {
     server 127.0.0.1:8000;
+    keepalive 0; # default = 32 since nginx 1.29.7
 }
 
 server {


### PR DESCRIPTION
Upgrades to the current stable version (1.30) from 1.27.

Sets `keepalive` to 0 to disable keepalives on the proxy connection. This maintains our existing behavior and is needed because of a change in nginx defaults. Continues setting the `Connection` header to `close` explicitly.