### PR TITLE
chore: "nginxinc" GH org is now "nginx"

### DIFF
--- a/k8s/auth.yaml
+++ b/k8s/auth.yaml
@@ -69,7 +69,7 @@ spec:
         # Nginx Container
         # -----------------------------------------------------
         - name: nginx
-          image: "ghcr.io/nginxinc/nginx-unprivileged:1.27"
+          image: "ghcr.io/nginx/nginx-unprivileged:1.30"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/datatracker.yaml
+++ b/k8s/datatracker.yaml
@@ -69,7 +69,7 @@ spec:
         # Nginx Container
         # -----------------------------------------------------
         - name: nginx
-          image: "ghcr.io/nginxinc/nginx-unprivileged:1.30"
+          image: "ghcr.io/nginx/nginx-unprivileged:1.30"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Also fixes a missed 1.27 -> 1.30 change, but we're not talking about that.