### PR TITLE
feat: add group type to search index

### DIFF
--- a/ietf/utils/searchindex.py
+++ b/ietf/utils/searchindex.py
@@ -171,6 +171,7 @@ def typesense_doc_from_rfc(rfc: Document) -> DocumentSchema:
             "acronym": rfc.group.acronym,
             "name": rfc.group.name,
             "full": f"{rfc.group.acronym} - {rfc.group.name}",
+            "type": rfc.group.type.slug,
         }
     if (
         rfc.group.parent is not None


### PR DESCRIPTION
Adds `group.type` to the search results from the `docs` collection in typesense. Values are slugs, and as of now are one of
* `wg`
* `individ`
* `area`
* `ietf`
* `rg`
* `ag`
* `edwg`
* `rag`