### PR TITLE
chore(dev): fix nginx config

### DIFF
--- a/docker/configs/nginx-proxy.conf
+++ b/docker/configs/nginx-proxy.conf
@@ -1,6 +1,7 @@
 upstream datatracker_backend {
     server 127.0.0.1:8001;
-    keepalive 0; # default = 32 since nginx 1.29.7
+# Uncomment when changing to nginx 1.29.7 or later. 
+#     keepalive 0; # default = 32 since nginx 1.29.7
 }
 
 server {


### PR DESCRIPTION
keepalive 0 is not supported by the version of nginx in the dev container