### PR TITLE
fix: Use non-four digit RFC numbers for DOI

### DIFF
--- a/ietf/doc/models.py
+++ b/ietf/doc/models.py
@@ -163,7 +163,7 @@ class DocumentInfo(models.Model):
     @property
     def doi(self) -> str | None:
         if self.type_id == "rfc" and self.rfc_number is not None:
-            return f"{settings.IETF_DOI_PREFIX}/RFC{self.rfc_number:04d}"
+            return f"{settings.IETF_DOI_PREFIX}/RFC{self.rfc_number}"
         return None
 
     def file_extension(self):


### PR DESCRIPTION
Fixes #11047 