### PR TITLE
fix: Use primary address for ballot email from for non ietf-stream docs

### DIFF
--- a/ietf/doc/tests_draft.py
+++ b/ietf/doc/tests_draft.py
@@ -2785,3 +2785,43 @@ class BallotEmailAjaxTests(TestCase):
         ]:
             self.assertIn(snippet, response["text"])
 
+        # Non-IETF stream: from address uses balloter.formatted_email(), not role_email("ad").
+        # Give the balloter a chair role (in a different RG) with a distinct email to prove
+        # that chair role address is not used; formatted_email() uses the primary email.
+        irtf_doc = RgDraftFactory()
+        non_ad_balloter = PersonFactory(name="Some Irsgmember")
+        other_rg = GroupFactory(type_id="rg")
+        chair_role_email = EmailFactory(
+            person=non_ad_balloter, address="chair-role@example.com"
+        )
+        RoleFactory(
+            name_id="chair",
+            group=other_rg,
+            person=non_ad_balloter,
+            email=chair_role_email,
+        )
+        response = _post_json(
+            self,
+            url,
+            {
+                "post_data": {
+                    "discuss": "",
+                    "comment": "cccccc",
+                    "position": "yes",
+                    "balloter": non_ad_balloter.pk,
+                    "docname": irtf_doc.name,
+                    "cc_choices": [],
+                    "additional_cc": "",
+                }
+            },
+        )
+        self.assertTrue(response["success"])
+        from_line = next(
+            line for line in response["text"].split("\n") if line.startswith("From: ")
+        )
+        # formatted_email() uses the primary email, not the chair role email
+        self.assertIn(non_ad_balloter.email().address, from_line)
+        self.assertNotIn(chair_role_email.address, from_line)
+        for snippet in ["cccccc", non_ad_balloter.plain_name(), irtf_doc.name]:
+            self.assertIn(snippet, response["text"])
+

--- a/ietf/doc/views_ballot.py
+++ b/ietf/doc/views_ballot.py
@@ -425,7 +425,10 @@ def build_position_email_from_dict(pos_dict):
                                  pos=pos_name,
                                  blocking_name=blocking_name,
                                  settings=settings))
-    frm = balloter.role_email("ad").formatted_email()
+    if doc.stream_id == "ietf":
+        frm = balloter.role_email("ad").formatted_email()
+    else:
+        frm = balloter.formatted_email()
 
     if doc.stream_id == "irtf":
         addrs = gather_address_lists('irsg_ballot_saved',doc=doc)

--- a/ietf/nomcom/tests.py
+++ b/ietf/nomcom/tests.py
@@ -1190,8 +1190,8 @@ class ReminderTest(TestCase):
         today = datetime_today()
         t_minus_3 = today - datetime.timedelta(days=3)
         t_minus_4 = today - datetime.timedelta(days=4)
-        e1 = EmailFactory(address="nominee1@example.org", person=PersonFactory(name="Nominee 1"), origin='test')
-        e2 = EmailFactory(address="nominee2@example.org", person=PersonFactory(name="Nominee 2"), origin='test')
+        e1 = EmailFactory(address="nominee1@example.org", person__name="Nominee 1", origin='test', primary=True)
+        e2 = EmailFactory(address="nominee2@example.org", person__name="Nominee 2", origin='test', primary=True)
         n = make_nomineeposition(self.nomcom,e1.person,gen,None)
         np = n.nomineeposition_set.get(position=gen)
         np.time = t_minus_3

--- a/ietf/person/factories.py
+++ b/ietf/person/factories.py
@@ -93,7 +93,7 @@ class PersonFactory(factory.django.DjangoModelFactory):
     def default_emails(obj, create, extracted, **kwargs): # pylint: disable=no-self-argument
         if extracted is None:
             extracted = True
-        if create and extracted:           
+        if create and extracted:
             make_email = getattr(EmailFactory, 'create' if create else 'build')
             make_email(person=obj, address=obj.user.email, primary=True, **kwargs)
 

--- a/ietf/person/factories.py
+++ b/ietf/person/factories.py
@@ -93,9 +93,9 @@ class PersonFactory(factory.django.DjangoModelFactory):
     def default_emails(obj, create, extracted, **kwargs): # pylint: disable=no-self-argument
         if extracted is None:
             extracted = True
-        if create and extracted:
+        if create and extracted:           
             make_email = getattr(EmailFactory, 'create' if create else 'build')
-            make_email(person=obj, address=obj.user.email)
+            make_email(person=obj, address=obj.user.email, primary=True, **kwargs)
 
     @factory.post_generation
     def default_photo(obj, create, extracted, **kwargs): # pylint: disable=no-self-argument
@@ -151,7 +151,7 @@ class EmailFactory(factory.django.DjangoModelFactory):
         django_get_or_create = ('address',)
 
     address = factory.Sequence(fake_email_address)
-    person = factory.SubFactory(PersonFactory)
+    person = factory.SubFactory(PersonFactory, default_emails=False)
 
     active = True
     primary = False

--- a/ietf/person/tests.py
+++ b/ietf/person/tests.py
@@ -78,7 +78,9 @@ class PersonTests(TestCase):
 
     def test_default_email(self):
         person = PersonFactory()
-        primary = EmailFactory(person=person, primary=True, active=True)
+        primary = person.email_set.get()
+        self.assertEqual(primary.primary, True)
+        self.assertEqual(primary.active, True)
         EmailFactory(person=person, primary=False, active=True)
         EmailFactory(person=person, primary=False, active=False)
         self.assertTrue(primary.address in person.formatted_email())
@@ -358,7 +360,7 @@ class PersonUtilsTests(TestCase):
         source = PersonFactory()
         target = PersonFactory()
         extra = get_extra_primary(source, target)
-        self.assertTrue(extra == list(source.email_set.filter(primary=True)))
+        self.assertEqual(set(extra), set(source.email_set.filter(primary=True)))
 
     def test_dedupe_aliases(self):
         person = PersonFactory()


### PR DESCRIPTION
Fixes #11114

Note that this changes the default behavior of the Person factory to generate a primary Email object for the Person.