### PR TITLE
feat: generate RFC json at publication time

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -805,7 +805,7 @@ class RfcFileSerializer(serializers.Serializer):
     # works.
     allowed_extensions = (
         ".html",
-        ".json",
+        ".json",  # deprecated - accepted but ignored, datatracker generates its own
         ".notprepped.xml",
         ".pdf",
         ".txt",

--- a/ietf/api/tests_views_rpc.py
+++ b/ietf/api/tests_views_rpc.py
@@ -224,6 +224,7 @@ class RpcApiTests(APITestCase):
         self.assertEqual(mock_kwargs["rfc_number_list"], expected_rfc_number_list)
 
     @override_settings(APP_API_TOKENS={"ietf.api.views_rpc": ["valid-token"]})
+    @mock.patch("ietf.api.views_rpc.update_rfc_json_task")
     @mock.patch("ietf.api.views_rpc.rebuild_reference_relations_task")
     @mock.patch("ietf.api.views_rpc.update_rfc_searchindex_task")
     @mock.patch("ietf.api.views_rpc.trigger_red_precomputer_task")
@@ -232,6 +233,7 @@ class RpcApiTests(APITestCase):
         mock_trigger_red_task,
         mock_update_searchindex_task,
         mock_rebuild_relations,
+        mock_update_rfc_json,
     ):
         def _valid_post_data():
             """Generate a valid post data dict
@@ -292,7 +294,7 @@ class RpcApiTests(APITestCase):
                     ContentFile(b"", "myfile.txt"),
                     ContentFile(b"", "myfile.html"),
                     ContentFile(b"", "myfile.pdf"),
-                    ContentFile(b"", "myfile.json"),
+                    ContentFile(b"", "myfile.json"),  # deprecated!
                     ContentFile(b"", "myfile.notprepped.xml"),
                 ]
             },
@@ -346,18 +348,19 @@ class RpcApiTests(APITestCase):
 
         # valid post
         mock_trigger_red_task.delay.reset_mock()
-        r = self.client.post(
-            url,
-            _valid_post_data(),
-            format="multipart",
-            headers={"X-Api-Key": "valid-token"},
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            r = self.client.post(
+                url,
+                _valid_post_data(),
+                format="multipart",
+                headers={"X-Api-Key": "valid-token"},
+            )
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
             mock_update_searchindex_task.delay.call_args,
             mock.call(rfc.rfc_number),
         )
-        for extension in ["xml", "txt", "html", "pdf", "json"]:
+        for extension in ["xml", "txt", "html", "pdf"]:  # no "json"!
             filename = f"{rfc.name}.{extension}"
             self.assertEqual(
                 (rfc_path / filename).read_text(),
@@ -389,6 +392,12 @@ class RpcApiTests(APITestCase):
             b"This is .notprepped.xml",
             ".notprepped.xml blob should contain the expected content",
         )
+        # special case for json (deprecated and should be ignored)
+        self.assertFalse((rfc_path / f"{rfc.name}.json").exists())
+        self.assertFalse(
+            Blob.objects.filter(bucket="rfc", name=f"json/{rfc.name}.json").exists()
+        )
+
         # Confirm that the red precomputer was triggered correctly
         self.assertTrue(mock_trigger_red_task.delay.called)
         _, mock_kwargs = mock_trigger_red_task.delay.call_args
@@ -404,6 +413,10 @@ class RpcApiTests(APITestCase):
         _, mock_kwargs = mock_rebuild_relations.delay.call_args
         self.assertIn("doc_names", mock_kwargs)
         self.assertEqual(mock_kwargs["doc_names"], [rfc.name])
+        # Confirm rfc JSON creation was triggered correctly
+        self.assertTrue(mock_update_rfc_json.delay.called)
+        mock_args, _ = mock_update_rfc_json.delay.call_args
+        self.assertEqual(mock_args[0], [rfc.rfc_number])
 
         # re-post with replace = False should now fail
         mock_update_searchindex_task.reset_mock()

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -1,6 +1,7 @@
 # Copyright The IETF Trust 2023-2026, All Rights Reserved
 import os
 import shutil
+from functools import partial
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -463,6 +464,8 @@ class RfcPubNotificationView(DestinationHelperMixin, APIView):
             {d.rfc_number for d in rfc.related_that_doc(("updates", "obs"))}
         )
         if related_numbers:
+            # Only update json for related rfcs. We can't generate json for _this_ rfc
+            # until we receive the files and know what formats we have.
             transaction.on_commit(lambda: update_rfc_json_task.delay(related_numbers))
         return Response(NotificationAckSerializer().data)
 
@@ -523,6 +526,10 @@ class RfcPubFilesView(DestinationHelperMixin, APIView):
             for upfile in uploaded_files:
                 uploaded_filename = Path(upfile.name)  # name supplied by request
                 uploaded_ext = "".join(uploaded_filename.suffixes)
+                # Ignore json files, which are deprecated. Remove this when purple no
+                # longer tries to send them.
+                if uploaded_ext == ".json":
+                    continue
                 tempfile_path = tmpfile_stem.with_suffix(uploaded_ext)
                 with tempfile_path.open("wb") as dest:
                     for chunk in upfile.chunks():
@@ -565,9 +572,10 @@ class RfcPubFilesView(DestinationHelperMixin, APIView):
         trigger_red_precomputer_task.delay(rfc_number_list=sorted(needs_updating))
         # Trigger search index update
         update_rfc_searchindex_task.delay(rfc.rfc_number)
-        # Trigger reference relation srebuild
+        # Trigger reference relations rebuild
         rebuild_reference_relations_task.delay(doc_names=[rfc.name])
-
+        # Build rfc json (json for related rfcs was updated in RfcPubNotificationView) 
+        transaction.on_commit(partial(update_rfc_json_task.delay, [rfc.rfc_number]))
         return Response(NotificationAckSerializer().data)
 
 

--- a/ietf/api/views_rpc.py
+++ b/ietf/api/views_rpc.py
@@ -466,7 +466,7 @@ class RfcPubNotificationView(DestinationHelperMixin, APIView):
         if related_numbers:
             # Only update json for related rfcs. We can't generate json for _this_ rfc
             # until we receive the files and know what formats we have.
-            transaction.on_commit(lambda: update_rfc_json_task.delay(related_numbers))
+            transaction.on_commit(partial(update_rfc_json_task.delay, related_numbers))
         return Response(NotificationAckSerializer().data)
 
 


### PR DESCRIPTION
Datatracker has taken over generating RFC JSON when RFC metadata are updated or when the RFC itself is obsoleted or updated by a new publication. This extends that to creating the initial JSON file.

After this change is deployed, Purple can stop sending its version of the JSON. To ease that transition, this continues to accept JSON but ignores the file.