### PR TITLE
fix: Use 'Working Group' or 'BOF' on session notification messages

### DIFF
--- a/ietf/meeting/tests_session_requests.py
+++ b/ietf/meeting/tests_session_requests.py
@@ -12,6 +12,7 @@ from ietf.utils.test_utils import TestCase
 from ietf.group.factories import GroupFactory, RoleFactory
 from ietf.meeting.models import Session, ResourceAssociation, SchedulingEvent, Constraint
 from ietf.meeting.factories import MeetingFactory, SessionFactory
+from ietf.meeting.views_session_request import get_requester_text
 from ietf.name.models import ConstraintName, TimerangeName
 from ietf.person.factories import PersonFactory
 from ietf.person.models import Person
@@ -723,6 +724,70 @@ class SubmitRequestCase(TestCase):
             f"{header} meeting session request has just been submitted by {requester.name}.",
             get_payload_text(msg),
         )
+
+    def test_wg_request_notification_msg(self):
+        to = "<iesg-secretary@ietf.org>"
+        subject = "Dummy subject"
+        template = "meeting/session_request_notification.txt"
+        header = "A new"
+        meeting = MeetingFactory(type_id="ietf", date=date_today())
+        area = GroupFactory(type_id='area')
+        mars = GroupFactory(parent=area, acronym='mars')
+        secretariat_role = RoleFactory(group__acronym='secretariat', name_id='secr')
+        requester = get_requester_text(secretariat_role.person, mars)
+        context = {"header": header, "meeting": meeting, "requester": requester}
+        cc = "cc.a@example.com, cc.b@example.com"
+        bcc = "bcc@example.com"
+
+        msg = send_mail(
+            None,
+            to,
+            None,
+            subject,
+            template,
+            context,
+            cc=cc,
+            bcc=bcc,
+        )
+        # Undo the text wrapping for simple checking
+        payload = get_payload_text(msg).replace("\n"," ")
+        self.assertIn(
+            f"{header} meeting session request has just been submitted by {requester}",
+            payload,
+        )
+        self.assertIn("MARS Working Group", payload)
+
+    def test_bof_request_notification_msg(self):
+        to = "<iesg-secretary@ietf.org>"
+        subject = "Dummy subject"
+        template = "meeting/session_request_notification.txt"
+        header = "A new"
+        meeting = MeetingFactory(type_id="ietf", date=date_today())
+        bof = RoleFactory(group__type_id="wg", group__state_id="bof", name_id="chair").group
+        secretariat_role = RoleFactory(group__acronym='secretariat', name_id='secr')
+        requester = get_requester_text(secretariat_role.person, bof)
+        context = {"header": header, "meeting": meeting, "requester": requester}
+        cc = "cc.a@example.com, cc.b@example.com"
+        bcc = "bcc@example.com"
+
+        msg = send_mail(
+            None,
+            to,
+            None,
+            subject,
+            template,
+            context,
+            cc=cc,
+            bcc=bcc,
+        )
+        # Undo the text wrapping for simple checking
+        payload = get_payload_text(msg).replace("\n"," ")
+        self.assertIn(
+            f"{header} meeting session request has just been submitted by {requester}",
+            payload,
+        )
+        self.assertIn("BOF", payload)
+        self.assertNotIn("Working Group", payload)
 
     def test_request_notification_third_session(self):
         meeting = MeetingFactory(type_id='ietf', date=date_today())

--- a/ietf/meeting/views_session_request.py
+++ b/ietf/meeting/views_session_request.py
@@ -200,6 +200,9 @@ def get_requester_text(person, group):
     in the session request notification email, ie. Joe Smith, a Chair of the ancp
     working group
     """
+    group_type = group.type.verbose_name
+    if group_type == "Working Group" and group.state_id == "bof":
+        group_type = group.state_id.upper()
     roles = group.role_set.filter(name__in=("chair", "secr", "ad"), person=person)
     if roles:
         rolename = str(roles[0].name)
@@ -207,13 +210,13 @@ def get_requester_text(person, group):
             person.name,
             inflect.engine().a(rolename),
             group.acronym.upper(),
-            group.type.verbose_name,
+            group_type,
         )
     if person.role_set.filter(name="secr", group__acronym="secretariat"):
         return "%s, on behalf of the %s %s" % (
             person.name,
             group.acronym.upper(),
-            group.type.verbose_name,
+            group_type,
         )
 
 

--- a/ietf/templates/meeting/session_request_info.txt
+++ b/ietf/templates/meeting/session_request_info.txt
@@ -1,7 +1,7 @@
 {# Copyright The IETF Trust 2025, All Rights Reserved #}
 {% load ams_filters %}
 ---------------------------------------------------------
-Working Group Name: {{ group.name }}
+Group Name: {{ group.name }}
 Area Name: {{ group.parent }}
 Session Requester: {{ login }}
 {% if session.joint_with_groups %}{{ session.joint_for_session_display }} joint with: {{ session.joint_with_groups }}{% endif %}

--- a/ietf/templates/meeting/session_request_view_table.html
+++ b/ietf/templates/meeting/session_request_view_table.html
@@ -3,7 +3,7 @@
 
 <div class="row mb-3">
     <div class="col-md-2 fw-bold">
-        Working Group Name
+        Group Name
     </div>
     <div class="col">
         {{ group.name }} ({{ group.acronym }})


### PR DESCRIPTION
fix: Use 'Working Group' or 'BOF' on session notification messages (fixes #11028)