### PR TITLE
fix: add email validation to secr announcement form

### DIFF
--- a/ietf/secr/announcement/forms.py
+++ b/ietf/secr/announcement/forms.py
@@ -9,6 +9,7 @@ from ietf.utils.html import unescape
 from ietf.ietfauth.utils import has_role
 from ietf.message.models import Message, AnnouncementFrom
 from ietf.utils.fields import MultiEmailField
+from ietf.utils.mail import is_valid_email
 
 # ---------------------------------------------
 # Globals
@@ -152,6 +153,15 @@ class AnnounceForm(forms.ModelForm):
             return self.cleaned_data
         if data["to"] == "Other..." and not data["to_custom"]:
             raise forms.ValidationError('You must enter a "To" email address')
+        if data["to"] == "Other..." and data["to_custom"]:
+            addrlist = data["to_custom"]
+        else:
+            addrlist = data["to"]
+        emails = [email.strip() for email in addrlist if email.strip()]
+        for email in emails:
+            if not is_valid_email(email):
+                raise forms.ValidationError("An exception occured while trying to send email to '%s'" % email)
+            
         for k in [
             "to",
             "frm",

--- a/ietf/secr/announcement/forms.py
+++ b/ietf/secr/announcement/forms.py
@@ -157,10 +157,11 @@ class AnnounceForm(forms.ModelForm):
             addrlist = data["to_custom"]
         else:
             addrlist = data["to"]
+        addrlist.extend([data["cc"]])
         emails = [email.strip() for email in addrlist if email.strip()]
         for email in emails:
             if not is_valid_email(email):
-                raise forms.ValidationError("An exception occured while trying to send email to '%s'" % email)
+                raise forms.ValidationError("An exception occurred while trying to send email to '%s'" % email)
             
         for k in [
             "to",

--- a/ietf/secr/announcement/forms.py
+++ b/ietf/secr/announcement/forms.py
@@ -156,8 +156,10 @@ class AnnounceForm(forms.ModelForm):
         if data["to"] == "Other..." and data["to_custom"]:
             addrlist = data["to_custom"]
         else:
-            addrlist = data["to"]
-        addrlist.extend([data["cc"]])
+            addrlist = [data["to"]]
+        if data["cc"]:
+            cc = [email.strip() for email in data["cc"].split(",") if email.strip()]
+            addrlist.extend(cc)
         emails = [email.strip() for email in addrlist if email.strip()]
         for email in emails:
             if not is_valid_email(email):

--- a/ietf/secr/announcement/tests.py
+++ b/ietf/secr/announcement/tests.py
@@ -100,7 +100,7 @@ class SubmitAnnouncementCase(TestCase):
             "nomcom": nomcom.pk,
             "to": "Other...",
             "to_custom": "phil@example.com",
-            "cc": "lizz@example.com, test@example.com",
+            "cc": "lizz@example.com, no-brackets@example.com",
             "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
             "reply_to": "secretariat@ietf.org",
             "subject": "Test Subject",
@@ -113,11 +113,32 @@ class SubmitAnnouncementCase(TestCase):
         self.assertRedirects(response, url)
         self.assertEqual(len(outbox), 1)
         self.assertEqual(outbox[0]["subject"], "Test Subject")
-        self.assertEqual(outbox[0]["to"], "<phil@example.com>, <lizz@example.com>, <test@example.com>")
+        self.assertEqual(outbox[0]["to"], "<phil@example.com>, <lizz@example.com>, <no-brackets@example.com>")
         message = Message.objects.filter(by__user__username="secretary").last()
         self.assertEqual(message.subject, "Test Subject")
         self.assertTrue(nomcom in message.related_groups.all())
     
+    def test_empty_submit(self):
+            "Submit Empty Email Fields"
+            nomcom_test_data()
+            empty_outbox()
+            url = reverse("ietf.secr.announcement.views.main")
+            nomcom = Group.objects.get(type="nomcom")
+            post_data = {
+                    "nomcom": nomcom.pk,
+                    "to": "Other...",
+                    "to_custom": "",
+                    "cc": "",
+                    "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
+                    "reply_to": "secretariat@ietf.org",
+                    "subject": "Test Subject",
+                    "body": "This is a test.",
+                }
+            self.client.login(username="secretary", password="secretary+password")
+            response = self.client.post(url, post_data)
+            self.assertNotContains(response, "Confirm Announcement")
+            self.assertEqual(len(outbox), 0)
+            
     def test_invalid_submit(self):
         "Invalid Submit"
         nomcom_test_data()
@@ -134,8 +155,35 @@ class SubmitAnnouncementCase(TestCase):
                 "subject": "Test Subject",
                 "body": "This is a test.",
             }
+        post_data_badlist_to = {
+                                "nomcom": nomcom.pk,
+                                "to": "Other...",
+                                "to_custom": "phil@example.com; test@example.com",
+                                "cc": "lizz@example.com, person@example.com",
+                                "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
+                                "reply_to": "secretariat@ietf.org",
+                                "subject": "Test Subject",
+                                "body": "This is a test.",
+                            }
+        post_data_badlist_cc = {
+                        "nomcom": nomcom.pk,
+                        "to": "Other...",
+                        "to_custom": "phil@example.com, test@example.com",
+                        "cc": "lizz@example.com; person@example.com",
+                        "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
+                        "reply_to": "secretariat@ietf.org",
+                        "subject": "Test Subject",
+                        "body": "This is a test.",
+                    }
         self.client.login(username="secretary", password="secretary+password")
         response = self.client.post(url, post_data)
         self.assertNotContains(response, "Confirm Announcement")
         self.assertEqual(len(outbox), 0)
+        response = self.client.post(url, post_data_badlist_to)
+        self.assertNotContains(response, "Confirm Announcement")
+        self.assertEqual(len(outbox), 0)
+        response = self.client.post(url, post_data_badlist_cc)
+        self.assertNotContains(response, "Confirm Announcement")
+        self.assertEqual(len(outbox), 0)
+        
         

--- a/ietf/secr/announcement/tests.py
+++ b/ietf/secr/announcement/tests.py
@@ -116,3 +116,24 @@ class SubmitAnnouncementCase(TestCase):
         message = Message.objects.filter(by__user__username="secretary").last()
         self.assertEqual(message.subject, "Test Subject")
         self.assertTrue(nomcom in message.related_groups.all())
+    
+    def test_invalid_submit(self):
+        "Invalid Submit"
+        nomcom_test_data()
+        empty_outbox()
+        url = reverse("ietf.secr.announcement.views.main")
+        nomcom = Group.objects.get(type="nomcom")
+        post_data = {
+                "nomcom": nomcom.pk,
+                "to": "Other...",
+                "to_custom": "test@test",
+                "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
+                "reply_to": "secretariat@ietf.org",
+                "subject": "Test Subject",
+                "body": "This is a test.",
+            }
+        self.client.login(username="secretary", password="secretary+password")
+        response = self.client.post(url, post_data)
+        self.assertNotContains(response, "Confirm Announcement")
+        self.assertEqual(len(outbox), 0)
+        

--- a/ietf/secr/announcement/tests.py
+++ b/ietf/secr/announcement/tests.py
@@ -100,6 +100,7 @@ class SubmitAnnouncementCase(TestCase):
             "nomcom": nomcom.pk,
             "to": "Other...",
             "to_custom": "phil@example.com",
+            "cc": "lizz@example.com, test@example.com",
             "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
             "reply_to": "secretariat@ietf.org",
             "subject": "Test Subject",
@@ -112,7 +113,7 @@ class SubmitAnnouncementCase(TestCase):
         self.assertRedirects(response, url)
         self.assertEqual(len(outbox), 1)
         self.assertEqual(outbox[0]["subject"], "Test Subject")
-        self.assertEqual(outbox[0]["to"], "<phil@example.com>")
+        self.assertEqual(outbox[0]["to"], "<phil@example.com>, <lizz@example.com>, <test@example.com>")
         message = Message.objects.filter(by__user__username="secretary").last()
         self.assertEqual(message.subject, "Test Subject")
         self.assertTrue(nomcom in message.related_groups.all())
@@ -127,7 +128,7 @@ class SubmitAnnouncementCase(TestCase):
                 "nomcom": nomcom.pk,
                 "to": "Other...",
                 "to_custom": "phil@example.com",
-                "cc": "lizz@example.com, test@invalid_email",
+                "cc": "lizz@example.com, invalid_email@example",
                 "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
                 "reply_to": "secretariat@ietf.org",
                 "subject": "Test Subject",

--- a/ietf/secr/announcement/tests.py
+++ b/ietf/secr/announcement/tests.py
@@ -126,7 +126,8 @@ class SubmitAnnouncementCase(TestCase):
         post_data = {
                 "nomcom": nomcom.pk,
                 "to": "Other...",
-                "to_custom": "test@test",
+                "to_custom": "phil@example.com",
+                "cc": "lizz@example.com, test@invalid_email",
                 "frm": "IETF Secretariat &lt;ietf-secretariat@ietf.org&gt;",
                 "reply_to": "secretariat@ietf.org",
                 "subject": "Test Subject",


### PR DESCRIPTION
fixes [#11180](https://github.com/ietf-tools/datatracker/issues/11180#event-28158027013)