### PR TITLE
fix: datatracker shepherd writeup template is authoritative

### DIFF
--- a/ietf/templates/doc/shepherd_writeup.txt
+++ b/ietf/templates/doc/shepherd_writeup.txt
@@ -1,4 +1,4 @@
-{# Keep in sync with https://github.com/ietf-chairs/chairs.ietf.org/blob/main/documents/qa-style-writeup-template.md #}{% if stream %}{% if stream == 'ietf' %}# Document Shepherd Write-Up{% if type != "individ" %} for Group Documents{% else %} for Individual Documents{% endif %}
+{# For more information see https://github.com/ietf/chairs.ietf.org/blob/main/documents/document-shepherding.md #}{% if stream %}{% if stream == 'ietf' %}# Document Shepherd Write-Up{% if type != "individ" %} for Group Documents{% else %} for Individual Documents{% endif %}
 
 *This version is dated 4 July 2022.*
 


### PR DESCRIPTION
There is no longer a shepherd writeup template hosted at chairs.ietf.org

closes #11277 