### PR TITLE
fix: correct the rfc-index example (See Also is STD/BCP/FYI, not RFC)

### DIFF
--- a/ietf/templates/sync/rfc-index.txt
+++ b/ietf/templates/sync/rfc-index.txt
@@ -21,9 +21,10 @@ or
 
 For example:
 
-  1129 Internet Time Synchronization: The Network Time Protocol. D.L.
-       Mills. October 1989. (Format: TXT, PS, PDF, HTML) (Also RFC1119)
-       (Status: INFORMATIONAL) (DOI: 10.17487/RFC1129)
+  9915 Dynamic Host Configuration Protocol for IPv6 (DHCPv6). T. Mrugalski,
+       B. Volz, M. Richardson, S. Jiang, T. Winters. January 2026. (Format:
+       HTML, TXT, PDF, XML) (Obsoletes RFC8415) (Also STD102) (Status:
+       INTERNET STANDARD) (DOI: 10.17487/RFC9915)
 
 Key to citations:
 


### PR DESCRIPTION
The example at the top of the generated `rfc-index.txt` (from `ietf/templates/sync/rfc-index.txt`) shows RFC 1129 with a `(Also RFC1119)` See Also:

```
  1129 Internet Time Synchronization: The Network Time Protocol. D.L.
       Mills. October 1989. (Format: TXT, PS, PDF, HTML) (Also RFC1119)
       (Status: INFORMATIONAL) (DOI: 10.17487/RFC1129)
```

But the file's own "Key to citations" states that `(Also FYI ##)` / `(Also STD ##)` / `(Also BCP ##)` only give an equivalent FYI/STD/BCP number — a See Also never points at another RFC — and the actual RFC 1129 entry has no See Also. So `(Also RFC1119)` is not a valid example.

This replaces it with the RFC 9915 example suggested in #11280, which carries a genuine `(Also STD102)`:

```
  9915 Dynamic Host Configuration Protocol for IPv6 (DHCPv6). T. Mrugalski,
       B. Volz, M. Richardson, S. Jiang, T. Winters. January 2026. (Format:
       HTML, TXT, PDF, XML) (Obsoletes RFC8415) (Also STD102) (Status:
       INTERNET STANDARD) (DOI: 10.17487/RFC9915)
```

Continuation lines are indented to align under the title, matching the surrounding template style. One file, docs/template only.

Closes #11280.

---

Disclosure: prepared with AI assistance; I reviewed the change against the file's Key to citations and the suggested fix in the issue.
