### PR TITLE
feat: invoke list or doc aliases at IETF LC

### DIFF
--- a/ietf/doc/mails.py
+++ b/ietf/doc/mails.py
@@ -220,12 +220,14 @@ def generate_last_call_announcement(request, doc):
         if rel.is_downref() and not rel.is_approved_downref()
     ]
 
-    # documents with no group of their own get replies at the draft alias instead
+    # individual submissions, and groups with no list of their own, take replies
+    # at the document's own alias instead
+    doc_alias = f"{doc.name}@{settings.DRAFT_ALIAS_DOMAIN}"
     reply_to = ["last-call@ietf.org"]
-    if doc.group and doc.group.features.acts_like_wg and doc.group.list_email:
-        reply_to.append(doc.group.list_email)
+    if doc.group.type_id == "individ" or not doc.group.list_email:
+        reply_to.append(doc_alias)
     else:
-        reply_to.append(f"{doc.name}@{settings.DRAFT_ALIAS_DOMAIN}")
+        reply_to.append(doc.group.list_email)
 
     addrs = gather_address_lists("last_call_issued", doc=doc).as_strings()
     mail = render_to_string(

--- a/ietf/doc/mails.py
+++ b/ietf/doc/mails.py
@@ -234,7 +234,6 @@ def generate_last_call_announcement(request, doc):
         "doc/mail/last_call_announcement.txt",
         {
             "doc": doc,
-            "doc_url": settings.IDTRACKER_BASE_URL + doc.get_absolute_url() + "ballot/",
             "expiration_date": expiration_date.strftime(
                 "%Y-%m-%d"
             ),  # .strftime("%B %-d, %Y"),
@@ -243,8 +242,7 @@ def generate_last_call_announcement(request, doc):
             "reply_to": ", ".join(reply_to),
             "copy_address": copy_address,
             "group": group,
-            "docs": [doc],
-            "urls": [settings.IDTRACKER_BASE_URL + doc.get_absolute_url()],
+            "url": settings.IDTRACKER_BASE_URL + doc.get_absolute_url(),
             "ipr_links": ipr_links,
             "downrefs": downrefs,
         },

--- a/ietf/doc/mails.py
+++ b/ietf/doc/mails.py
@@ -223,11 +223,11 @@ def generate_last_call_announcement(request, doc):
     # individual submissions, and groups with no list of their own, take replies
     # at the document's own alias instead
     doc_alias = f"{doc.name}@{settings.DRAFT_ALIAS_DOMAIN}"
-    reply_to = ["last-call@ietf.org"]
     if doc.group.type_id == "individ" or not doc.group.list_email:
-        reply_to.append(doc_alias)
+        copy_address = doc_alias
     else:
-        reply_to.append(doc.group.list_email)
+        copy_address = doc.group.list_email
+    reply_to = ["last-call@ietf.org", copy_address]
 
     addrs = gather_address_lists("last_call_issued", doc=doc).as_strings()
     mail = render_to_string(
@@ -241,6 +241,7 @@ def generate_last_call_announcement(request, doc):
             "to": addrs.to,
             "cc": addrs.cc,
             "reply_to": ", ".join(reply_to),
+            "copy_address": copy_address,
             "group": group,
             "docs": [doc],
             "urls": [settings.IDTRACKER_BASE_URL + doc.get_absolute_url()],

--- a/ietf/doc/mails.py
+++ b/ietf/doc/mails.py
@@ -211,6 +211,10 @@ def generate_last_call_announcement(request, doc):
 
     downrefs = [rel for rel in doc.relateddocument_set.all() if rel.is_downref() and not rel.is_approved_downref()]
 
+    reply_to = ["last-call@ietf.org"]
+    if doc.group and doc.group.features.acts_like_wg and doc.group.list_email:
+        reply_to.append(doc.group.list_email)
+
     addrs = gather_address_lists('last_call_issued',doc=doc).as_strings()
     mail = render_to_string("doc/mail/last_call_announcement.txt",
                             dict(doc=doc,
@@ -218,6 +222,7 @@ def generate_last_call_announcement(request, doc):
                                  expiration_date=expiration_date.strftime("%Y-%m-%d"), #.strftime("%B %-d, %Y"),
                                  to=addrs.to,
                                  cc=addrs.cc,
+                                 reply_to=", ".join(reply_to),
                                  group=group,
                                  docs=[ doc ],
                                  urls=[ settings.IDTRACKER_BASE_URL + doc.get_absolute_url() ],

--- a/ietf/doc/mails.py
+++ b/ietf/doc/mails.py
@@ -198,38 +198,51 @@ def generate_last_call_announcement(request, doc):
         group = "an individual submitter"
         expiration_date += datetime.timedelta(days=14)
     else:
-        group = "the %s %s (%s)" % (doc.group.name, doc.group.type.name, doc.group.acronym)
+        group = f"the {doc.group.name} {doc.group.type.name} ({doc.group.acronym})"
 
     doc.filled_title = textwrap.fill(doc.title, width=70, subsequent_indent=" " * 3)
-    
+
     iprs = iprs_from_docs(related_docs(Document.objects.get(name=doc.name)))
     if iprs:
-        ipr_links = [ urlreverse("ietf.ipr.views.show", kwargs=dict(id=i.id)) for i in iprs]
-        ipr_links = [ settings.IDTRACKER_BASE_URL+url if not url.startswith("http") else url for url in ipr_links ]
+        ipr_links = [
+            urlreverse("ietf.ipr.views.show", kwargs={"id": i.id}) for i in iprs
+        ]
+        ipr_links = [
+            settings.IDTRACKER_BASE_URL + url if not url.startswith("http") else url
+            for url in ipr_links
+        ]
     else:
         ipr_links = None
 
-    downrefs = [rel for rel in doc.relateddocument_set.all() if rel.is_downref() and not rel.is_approved_downref()]
+    downrefs = [
+        rel
+        for rel in doc.relateddocument_set.all()
+        if rel.is_downref() and not rel.is_approved_downref()
+    ]
 
     reply_to = ["last-call@ietf.org"]
     if doc.group and doc.group.features.acts_like_wg and doc.group.list_email:
         reply_to.append(doc.group.list_email)
 
-    addrs = gather_address_lists('last_call_issued',doc=doc).as_strings()
-    mail = render_to_string("doc/mail/last_call_announcement.txt",
-                            dict(doc=doc,
-                                 doc_url=settings.IDTRACKER_BASE_URL + doc.get_absolute_url() + "ballot/",
-                                 expiration_date=expiration_date.strftime("%Y-%m-%d"), #.strftime("%B %-d, %Y"),
-                                 to=addrs.to,
-                                 cc=addrs.cc,
-                                 reply_to=", ".join(reply_to),
-                                 group=group,
-                                 docs=[ doc ],
-                                 urls=[ settings.IDTRACKER_BASE_URL + doc.get_absolute_url() ],
-                                 ipr_links=ipr_links,
-                                 downrefs=downrefs,
-                                 )
-                            )
+    addrs = gather_address_lists("last_call_issued", doc=doc).as_strings()
+    mail = render_to_string(
+        "doc/mail/last_call_announcement.txt",
+        {
+            "doc": doc,
+            "doc_url": settings.IDTRACKER_BASE_URL + doc.get_absolute_url() + "ballot/",
+            "expiration_date": expiration_date.strftime(
+                "%Y-%m-%d"
+            ),  # .strftime("%B %-d, %Y"),
+            "to": addrs.to,
+            "cc": addrs.cc,
+            "reply_to": ", ".join(reply_to),
+            "group": group,
+            "docs": [doc],
+            "urls": [settings.IDTRACKER_BASE_URL + doc.get_absolute_url()],
+            "ipr_links": ipr_links,
+            "downrefs": downrefs,
+        },
+    )
 
     e = WriteupDocEvent()
     e.type = "changed_last_call_text"
@@ -241,7 +254,7 @@ def generate_last_call_announcement(request, doc):
 
     # caller is responsible for saving, if necessary
     return e
-    
+
 
 DO_NOT_PUBLISH_IESG_STATES = ("nopubadw", "nopubanw")
 

--- a/ietf/doc/mails.py
+++ b/ietf/doc/mails.py
@@ -220,9 +220,12 @@ def generate_last_call_announcement(request, doc):
         if rel.is_downref() and not rel.is_approved_downref()
     ]
 
+    # documents with no group of their own get replies at the draft alias instead
     reply_to = ["last-call@ietf.org"]
     if doc.group and doc.group.features.acts_like_wg and doc.group.list_email:
         reply_to.append(doc.group.list_email)
+    else:
+        reply_to.append(f"{doc.name}@{settings.DRAFT_ALIAS_DOMAIN}")
 
     addrs = gather_address_lists("last_call_issued", doc=doc).as_strings()
     mail = render_to_string(

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -327,11 +327,23 @@ class BallotWriteupsTests(TestCase):
             ad=Person.objects.get(user__username="ad"),
             states=[("draft", "active"), ("draft-iesg", "ad-eval")],
         )
-        self.assertFalse(draft.group.features.acts_like_wg)
+        self.assertEqual(draft.group.type_id, "individ")
         url = urlreverse(
             "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
         )
         login_testing_unauthorized(self, "secretary", url)
+
+        r = self.client.post(url, {"regenerate_last_call_text": "1"})
+        self.assertEqual(r.status_code, 200)
+        text = textarea_value(r.content, "last_call_text")
+        self.assertIn(
+            f"Reply-To: last-call@ietf.org, {draft.name}@{settings.DRAFT_ALIAS_DOMAIN}\n",
+            text,
+        )
+
+        # even if the individ group somehow has a list, the draft alias wins
+        draft.group.list_email = "none@ietf.org"
+        draft.group.save()
 
         r = self.client.post(url, {"regenerate_last_call_text": "1"})
         self.assertEqual(r.status_code, 200)
@@ -355,6 +367,18 @@ class BallotWriteupsTests(TestCase):
         self.assertEqual(r.status_code, 200)
         text = textarea_value(r.content, "last_call_text")
         self.assertIn(f"Reply-To: last-call@ietf.org, {draft.group.list_email}\n", text)
+
+        # a group with no list of its own falls back to the draft alias
+        draft.group.list_email = ""
+        draft.group.save()
+
+        r = self.client.post(url, {"regenerate_last_call_text": "1"})
+        self.assertEqual(r.status_code, 200)
+        text = textarea_value(r.content, "last_call_text")
+        self.assertIn(
+            f"Reply-To: last-call@ietf.org, {draft.name}@{settings.DRAFT_ALIAS_DOMAIN}\n",
+            text,
+        )
 
     def test_request_last_call(self):
         ad = Person.objects.get(user__username="ad")

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -11,6 +11,7 @@ from pyquery import PyQuery
 
 import debug                            # pyflakes:ignore
 
+from django.conf import settings
 from django.test import RequestFactory
 from django.utils.text import slugify
 from django.urls import reverse as urlreverse
@@ -321,11 +322,12 @@ class BallotWriteupsTests(TestCase):
         self.assertTrue("Subject: Last Call" in text)
 
     def test_last_call_text_reply_to(self):
-        # an individual submission has no group list to reply to
+        # an individual submission has no group list, so it uses the draft alias
         draft = IndividualDraftFactory(
             ad=Person.objects.get(user__username="ad"),
             states=[("draft", "active"), ("draft-iesg", "ad-eval")],
         )
+        self.assertFalse(draft.group.features.acts_like_wg)
         url = urlreverse(
             "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
         )
@@ -334,7 +336,10 @@ class BallotWriteupsTests(TestCase):
         r = self.client.post(url, {"regenerate_last_call_text": "1"})
         self.assertEqual(r.status_code, 200)
         text = textarea_value(r.content, "last_call_text")
-        self.assertIn("Reply-To: last-call@ietf.org\n", text)
+        self.assertIn(
+            f"Reply-To: last-call@ietf.org, {draft.name}@{settings.DRAFT_ALIAS_DOMAIN}\n",
+            text,
+        )
 
         # a working group draft replies to the group list as well
         draft = WgDraftFactory(

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -338,6 +338,32 @@ class BallotWriteupsTests(TestCase):
             unwrap(text),
         )
 
+    def test_last_call_text_document_layout(self):
+        # ietf.utils.text.wordwrap joins a line onto the previous one when that one
+        # had to be wrapped and the two indents match, so the document lines have to
+        # stay indented to keep them off the end of the sentence introducing them
+        draft = WgDraftFactory(
+            ad=Person.objects.get(user__username="ad"),
+            states=[("draft", "active"), ("draft-iesg", "ad-eval")],
+            title="A short title",
+            intended_std_level_id="ps",
+        )
+        login_testing_unauthorized(
+            self,
+            "secretary",
+            urlreverse(
+                "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+            ),
+        )
+
+        text = self._regenerate_last_call_text(draft)
+        self.assertIn(
+            "consider the following document:\n"
+            f"  'A short title'\n"
+            f"  {draft.file_tag()} as Proposed Standard\n",
+            text,
+        )
+
     def test_last_call_text_reply_to(self):
         # an individual submission has no group list, so it uses the draft alias
         draft = IndividualDraftFactory(

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -276,7 +276,7 @@ def textarea_value(content, name):
     otherwise round-tripping a preformatted announcement through the form mangles
     its headers.
     """
-    value = PyQuery(content)('textarea[name=%s]' % name).text()
+    value = PyQuery(content)(f"textarea[name={name}]").text()
     return unescape(value.removeprefix("\n"))
 
 
@@ -320,28 +320,36 @@ class BallotWriteupsTests(TestCase):
         text = q("[name=last_call_text]").text()
         self.assertTrue("Subject: Last Call" in text)
 
-
     def test_last_call_text_reply_to(self):
         # an individual submission has no group list to reply to
-        draft = IndividualDraftFactory(ad=Person.objects.get(user__username='ad'),states=[('draft','active'),('draft-iesg','ad-eval')])
-        url = urlreverse('ietf.doc.views_ballot.lastcalltext', kwargs=dict(name=draft.name))
+        draft = IndividualDraftFactory(
+            ad=Person.objects.get(user__username="ad"),
+            states=[("draft", "active"), ("draft-iesg", "ad-eval")],
+        )
+        url = urlreverse(
+            "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+        )
         login_testing_unauthorized(self, "secretary", url)
 
-        r = self.client.post(url, dict(regenerate_last_call_text="1"))
+        r = self.client.post(url, {"regenerate_last_call_text": "1"})
         self.assertEqual(r.status_code, 200)
         text = textarea_value(r.content, "last_call_text")
         self.assertIn("Reply-To: last-call@ietf.org\n", text)
 
         # a working group draft replies to the group list as well
-        draft = WgDraftFactory(ad=Person.objects.get(user__username='ad'),states=[('draft','active'),('draft-iesg','ad-eval')])
+        draft = WgDraftFactory(
+            ad=Person.objects.get(user__username="ad"),
+            states=[("draft", "active"), ("draft-iesg", "ad-eval")],
+        )
         self.assertTrue(draft.group.list_email)
-        url = urlreverse('ietf.doc.views_ballot.lastcalltext', kwargs=dict(name=draft.name))
+        url = urlreverse(
+            "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+        )
 
-        r = self.client.post(url, dict(regenerate_last_call_text="1"))
+        r = self.client.post(url, {"regenerate_last_call_text": "1"})
         self.assertEqual(r.status_code, 200)
         text = textarea_value(r.content, "last_call_text")
-        self.assertIn("Reply-To: last-call@ietf.org, %s\n" % draft.group.list_email, text)
-
+        self.assertIn(f"Reply-To: last-call@ietf.org, {draft.group.list_email}\n", text)
 
     def test_request_last_call(self):
         ad = Person.objects.get(user__username="ad")
@@ -949,84 +957,127 @@ class MakeLastCallTests(TestCase):
 
     def test_make_last_call_reply_to(self):
         ad = Person.objects.get(user__username="ad")
-        draft = WgDraftFactory(group__acronym='mars',ad=ad,states=[('draft-iesg','lc-req')],intended_std_level_id='ps')
+        draft = WgDraftFactory(
+            group__acronym="mars",
+            ad=ad,
+            states=[("draft-iesg", "lc-req")],
+            intended_std_level_id="ps",
+        )
 
-        request = RequestFactory().get('/')
-        request.user = Person.objects.get(user__username='secretary').user
+        request = RequestFactory().get("/")
+        request.user = Person.objects.get(user__username="secretary").user
         e = generate_last_call_announcement(request, draft)
         self.assertIn("Reply-To: last-call@ietf.org, mars@ietf.org\n", e.text)
 
         # the secretariat may edit the announcement before it is issued
-        e.text = e.text.replace("Reply-To: last-call@ietf.org, mars@ietf.org",
-                                "Reply-To: last-call@ietf.org, mars@ietf.org, edited@example.com")
+        e.text = e.text.replace(
+            "Reply-To: last-call@ietf.org, mars@ietf.org",
+            "Reply-To: last-call@ietf.org, mars@ietf.org, edited@example.com",
+        )
         e.save()
 
-        url = urlreverse('ietf.doc.views_ballot.make_last_call', kwargs=dict(name=draft.name))
+        url = urlreverse(
+            "ietf.doc.views_ballot.make_last_call", kwargs={"name": draft.name}
+        )
         login_testing_unauthorized(self, "secretary", url)
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         q = PyQuery(r.content)
 
         empty_outbox()
-        r = self.client.post(url,
-                             dict(last_call_sent_date=q('input[name=last_call_sent_date]')[0].get("value"),
-                                  last_call_expiration_date=q('input[name=last_call_expiration_date]')[0].get("value")
-                                  ))
+        r = self.client.post(
+            url,
+            {
+                "last_call_sent_date": q("input[name=last_call_sent_date]")[0].get(
+                    "value"
+                ),
+                "last_call_expiration_date": q("input[name=last_call_expiration_date]")[
+                    0
+                ].get("value"),
+            },
+        )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(len(outbox), 2)
 
         # the edited Reply-To is parsed out of the announcement and set on the message
-        self.assertIsNotNone(outbox[-2].get('Reply-To'))
-        reply_to = [parseaddr(a)[1] for a in outbox[-2].get('Reply-To').split(',')]
-        self.assertCountEqual(reply_to, ['last-call@ietf.org', 'mars@ietf.org', 'edited@example.com'])
+        self.assertIsNotNone(outbox[-2].get("Reply-To"))
+        reply_to = [parseaddr(a)[1] for a in outbox[-2].get("Reply-To").split(",")]
+        self.assertCountEqual(
+            reply_to, ["last-call@ietf.org", "mars@ietf.org", "edited@example.com"]
+        )
 
         # ... but the IANA copy explicitly suppresses it
-        self.assertNotIn('mars@ietf.org', outbox[-1].get('Reply-To', ''))
+        self.assertNotIn("mars@ietf.org", outbox[-1].get("Reply-To", ""))
 
     def test_make_last_call_reply_to_via_form(self):
         ad = Person.objects.get(user__username="ad")
-        draft = WgDraftFactory(group__acronym='mars',ad=ad,states=[('draft-iesg','lc-req')],intended_std_level_id='ps')
+        draft = WgDraftFactory(
+            group__acronym="mars",
+            ad=ad,
+            states=[("draft-iesg", "lc-req")],
+            intended_std_level_id="ps",
+        )
 
-        writeup_url = urlreverse('ietf.doc.views_ballot.lastcalltext', kwargs=dict(name=draft.name))
+        writeup_url = urlreverse(
+            "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+        )
         login_testing_unauthorized(self, "secretary", writeup_url)
 
-        r = self.client.post(writeup_url, dict(regenerate_last_call_text="1"))
+        r = self.client.post(writeup_url, {"regenerate_last_call_text": "1"})
         self.assertEqual(r.status_code, 200)
         text = textarea_value(r.content, "last_call_text")
         self.assertIn("Reply-To: last-call@ietf.org, mars@ietf.org\n", text)
 
         # the secretariat edits the announcement and saves it back through the form
-        edited = text.replace("Reply-To: last-call@ietf.org, mars@ietf.org",
-                              "Reply-To: last-call@ietf.org, mars@ietf.org, edited@example.com")
+        edited = text.replace(
+            "Reply-To: last-call@ietf.org, mars@ietf.org",
+            "Reply-To: last-call@ietf.org, mars@ietf.org, edited@example.com",
+        )
         self.assertNotEqual(edited, text)
-        r = self.client.post(writeup_url, dict(last_call_text=edited.replace("\n", "\r\n"),
-                                               save_last_call_text="1"))
+        r = self.client.post(
+            writeup_url,
+            {
+                "last_call_text": edited.replace("\n", "\r\n"),
+                "save_last_call_text": "1",
+            },
+        )
         self.assertEqual(r.status_code, 200)
-        self.assertFalse(PyQuery(r.content)('form .is-invalid'))
+        self.assertFalse(PyQuery(r.content)("form .is-invalid"))
         # the form round-trip leaves the announcement otherwise intact
         saved = draft.latest_event(WriteupDocEvent, type="changed_last_call_text")
         self.assertEqual(saved.text, edited)
 
-        url = urlreverse('ietf.doc.views_ballot.make_last_call', kwargs=dict(name=draft.name))
+        url = urlreverse(
+            "ietf.doc.views_ballot.make_last_call", kwargs={"name": draft.name}
+        )
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         q = PyQuery(r.content)
 
         empty_outbox()
-        r = self.client.post(url,
-                             dict(last_call_sent_date=q('input[name=last_call_sent_date]')[0].get("value"),
-                                  last_call_expiration_date=q('input[name=last_call_expiration_date]')[0].get("value")
-                                  ))
+        r = self.client.post(
+            url,
+            {
+                "last_call_sent_date": q("input[name=last_call_sent_date]")[0].get(
+                    "value"
+                ),
+                "last_call_expiration_date": q("input[name=last_call_expiration_date]")[
+                    0
+                ].get("value"),
+            },
+        )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(len(outbox), 2)
 
         # the Reply-To saved through the form reaches the announcement
-        self.assertIsNotNone(outbox[-2].get('Reply-To'))
-        reply_to = [parseaddr(a)[1] for a in outbox[-2].get('Reply-To').split(',')]
-        self.assertCountEqual(reply_to, ['last-call@ietf.org', 'mars@ietf.org', 'edited@example.com'])
+        self.assertIsNotNone(outbox[-2].get("Reply-To"))
+        reply_to = [parseaddr(a)[1] for a in outbox[-2].get("Reply-To").split(",")]
+        self.assertCountEqual(
+            reply_to, ["last-call@ietf.org", "mars@ietf.org", "edited@example.com"]
+        )
         # the rest of the announcement survived the round-trip too
-        self.assertIn('ietf-announce@ietf.org', outbox[-2]['To'])
-        self.assertTrue(outbox[-2]['Subject'].startswith('Last Call:'))
+        self.assertIn("ietf-announce@ietf.org", outbox[-2]["To"])
+        self.assertTrue(outbox[-2]["Subject"].startswith("Last Call:"))
 
     def test_make_last_call_yang_document(self):
         yd = ReviewTeamFactory(acronym='yangdoctors')

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -4,6 +4,9 @@
 
 import datetime
 
+from email.utils import parseaddr
+from html import unescape
+
 from pyquery import PyQuery
 
 import debug                            # pyflakes:ignore
@@ -17,6 +20,7 @@ from ietf.doc.models import (Document, State, DocEvent,
                              BallotPositionDocEvent, LastCallDocEvent, WriteupDocEvent, TelechatDocEvent)
 from ietf.doc.factories import (DocumentFactory, IndividualDraftFactory, IndividualRfcFactory, WgDraftFactory,
                                 BallotPositionDocEventFactory, BallotDocEventFactory, IRSGBallotDocEventFactory, RgDraftFactory)
+from ietf.doc.mails import generate_last_call_announcement
 from ietf.doc.templatetags.ietf_filters import can_defer
 from ietf.doc.utils import create_ballot_if_not_open
 from ietf.doc.views_ballot import parse_ballot_edit_return_point
@@ -264,6 +268,18 @@ class EditPositionTests(TestCase):
         
 
 
+def textarea_value(content, name):
+    """Get the value a browser would submit for a textarea
+
+    lxml treats textarea content as raw text, so it neither decodes entities nor
+    drops the leading newline the HTML parser is supposed to swallow. Undo both,
+    otherwise round-tripping a preformatted announcement through the form mangles
+    its headers.
+    """
+    value = PyQuery(content)('textarea[name=%s]' % name).text()
+    return unescape(value.removeprefix("\n"))
+
+
 class BallotWriteupsTests(TestCase):
     def test_edit_last_call_text(self):
         draft = IndividualDraftFactory(ad=Person.objects.get(user__username='ad'),states=[('draft','active'),('draft-iesg','ad-eval')])
@@ -303,6 +319,28 @@ class BallotWriteupsTests(TestCase):
         q = PyQuery(r.content)
         text = q("[name=last_call_text]").text()
         self.assertTrue("Subject: Last Call" in text)
+
+
+    def test_last_call_text_reply_to(self):
+        # an individual submission has no group list to reply to
+        draft = IndividualDraftFactory(ad=Person.objects.get(user__username='ad'),states=[('draft','active'),('draft-iesg','ad-eval')])
+        url = urlreverse('ietf.doc.views_ballot.lastcalltext', kwargs=dict(name=draft.name))
+        login_testing_unauthorized(self, "secretary", url)
+
+        r = self.client.post(url, dict(regenerate_last_call_text="1"))
+        self.assertEqual(r.status_code, 200)
+        text = textarea_value(r.content, "last_call_text")
+        self.assertIn("Reply-To: last-call@ietf.org\n", text)
+
+        # a working group draft replies to the group list as well
+        draft = WgDraftFactory(ad=Person.objects.get(user__username='ad'),states=[('draft','active'),('draft-iesg','ad-eval')])
+        self.assertTrue(draft.group.list_email)
+        url = urlreverse('ietf.doc.views_ballot.lastcalltext', kwargs=dict(name=draft.name))
+
+        r = self.client.post(url, dict(regenerate_last_call_text="1"))
+        self.assertEqual(r.status_code, 200)
+        text = textarea_value(r.content, "last_call_text")
+        self.assertIn("Reply-To: last-call@ietf.org, %s\n" % draft.group.list_email, text)
 
 
     def test_request_last_call(self):
@@ -908,6 +946,87 @@ class MakeLastCallTests(TestCase):
         self.assertTrue("drafts-lastcall@icann.org" in outbox[-1]['To'])
 
         self.assertTrue("Last Call" in draft.message_set.order_by("-time")[0].subject)
+
+    def test_make_last_call_reply_to(self):
+        ad = Person.objects.get(user__username="ad")
+        draft = WgDraftFactory(group__acronym='mars',ad=ad,states=[('draft-iesg','lc-req')],intended_std_level_id='ps')
+
+        request = RequestFactory().get('/')
+        request.user = Person.objects.get(user__username='secretary').user
+        e = generate_last_call_announcement(request, draft)
+        self.assertIn("Reply-To: last-call@ietf.org, mars@ietf.org\n", e.text)
+
+        # the secretariat may edit the announcement before it is issued
+        e.text = e.text.replace("Reply-To: last-call@ietf.org, mars@ietf.org",
+                                "Reply-To: last-call@ietf.org, mars@ietf.org, edited@example.com")
+        e.save()
+
+        url = urlreverse('ietf.doc.views_ballot.make_last_call', kwargs=dict(name=draft.name))
+        login_testing_unauthorized(self, "secretary", url)
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+
+        empty_outbox()
+        r = self.client.post(url,
+                             dict(last_call_sent_date=q('input[name=last_call_sent_date]')[0].get("value"),
+                                  last_call_expiration_date=q('input[name=last_call_expiration_date]')[0].get("value")
+                                  ))
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(len(outbox), 2)
+
+        # the edited Reply-To is parsed out of the announcement and set on the message
+        self.assertIsNotNone(outbox[-2].get('Reply-To'))
+        reply_to = [parseaddr(a)[1] for a in outbox[-2].get('Reply-To').split(',')]
+        self.assertCountEqual(reply_to, ['last-call@ietf.org', 'mars@ietf.org', 'edited@example.com'])
+
+        # ... but the IANA copy explicitly suppresses it
+        self.assertNotIn('mars@ietf.org', outbox[-1].get('Reply-To', ''))
+
+    def test_make_last_call_reply_to_via_form(self):
+        ad = Person.objects.get(user__username="ad")
+        draft = WgDraftFactory(group__acronym='mars',ad=ad,states=[('draft-iesg','lc-req')],intended_std_level_id='ps')
+
+        writeup_url = urlreverse('ietf.doc.views_ballot.lastcalltext', kwargs=dict(name=draft.name))
+        login_testing_unauthorized(self, "secretary", writeup_url)
+
+        r = self.client.post(writeup_url, dict(regenerate_last_call_text="1"))
+        self.assertEqual(r.status_code, 200)
+        text = textarea_value(r.content, "last_call_text")
+        self.assertIn("Reply-To: last-call@ietf.org, mars@ietf.org\n", text)
+
+        # the secretariat edits the announcement and saves it back through the form
+        edited = text.replace("Reply-To: last-call@ietf.org, mars@ietf.org",
+                              "Reply-To: last-call@ietf.org, mars@ietf.org, edited@example.com")
+        self.assertNotEqual(edited, text)
+        r = self.client.post(writeup_url, dict(last_call_text=edited.replace("\n", "\r\n"),
+                                               save_last_call_text="1"))
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(PyQuery(r.content)('form .is-invalid'))
+        # the form round-trip leaves the announcement otherwise intact
+        saved = draft.latest_event(WriteupDocEvent, type="changed_last_call_text")
+        self.assertEqual(saved.text, edited)
+
+        url = urlreverse('ietf.doc.views_ballot.make_last_call', kwargs=dict(name=draft.name))
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        q = PyQuery(r.content)
+
+        empty_outbox()
+        r = self.client.post(url,
+                             dict(last_call_sent_date=q('input[name=last_call_sent_date]')[0].get("value"),
+                                  last_call_expiration_date=q('input[name=last_call_expiration_date]')[0].get("value")
+                                  ))
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(len(outbox), 2)
+
+        # the Reply-To saved through the form reaches the announcement
+        self.assertIsNotNone(outbox[-2].get('Reply-To'))
+        reply_to = [parseaddr(a)[1] for a in outbox[-2].get('Reply-To').split(',')]
+        self.assertCountEqual(reply_to, ['last-call@ietf.org', 'mars@ietf.org', 'edited@example.com'])
+        # the rest of the announcement survived the round-trip too
+        self.assertIn('ietf-announce@ietf.org', outbox[-2]['To'])
+        self.assertTrue(outbox[-2]['Subject'].startswith('Last Call:'))
 
     def test_make_last_call_yang_document(self):
         yd = ReviewTeamFactory(acronym='yangdoctors')

--- a/ietf/doc/tests_ballot.py
+++ b/ietf/doc/tests_ballot.py
@@ -321,6 +321,23 @@ class BallotWriteupsTests(TestCase):
         text = q("[name=last_call_text]").text()
         self.assertTrue("Subject: Last Call" in text)
 
+    def _regenerate_last_call_text(self, draft):
+        url = urlreverse(
+            "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+        )
+        r = self.client.post(url, {"regenerate_last_call_text": "1"})
+        self.assertEqual(r.status_code, 200)
+        return textarea_value(r.content, "last_call_text")
+
+    def _assertCopyAddress(self, text, address):
+        """The address the announcement replies to is the one it asks to be copied"""
+        self.assertIn(f"Reply-To: last-call@ietf.org, {address}\n", text)
+        self.assertIn(
+            "Please send substantive comments to the last-call@ietf.org mailing"
+            f" list, with {address} copied, no later than ",
+            unwrap(text),
+        )
+
     def test_last_call_text_reply_to(self):
         # an individual submission has no group list, so it uses the draft alias
         draft = IndividualDraftFactory(
@@ -328,56 +345,44 @@ class BallotWriteupsTests(TestCase):
             states=[("draft", "active"), ("draft-iesg", "ad-eval")],
         )
         self.assertEqual(draft.group.type_id, "individ")
-        url = urlreverse(
-            "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+        doc_alias = f"{draft.name}@{settings.DRAFT_ALIAS_DOMAIN}"
+        login_testing_unauthorized(
+            self,
+            "secretary",
+            urlreverse(
+                "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+            ),
         )
-        login_testing_unauthorized(self, "secretary", url)
 
-        r = self.client.post(url, {"regenerate_last_call_text": "1"})
-        self.assertEqual(r.status_code, 200)
-        text = textarea_value(r.content, "last_call_text")
+        text = self._regenerate_last_call_text(draft)
+        self._assertCopyAddress(text, doc_alias)
         self.assertIn(
-            f"Reply-To: last-call@ietf.org, {draft.name}@{settings.DRAFT_ALIAS_DOMAIN}\n",
-            text,
+            "The IESG plans to make a decision on this document in the coming weeks,"
+            " and hereby solicits last call comments.",
+            unwrap(text),
         )
 
         # even if the individ group somehow has a list, the draft alias wins
         draft.group.list_email = "none@ietf.org"
         draft.group.save()
+        self._assertCopyAddress(self._regenerate_last_call_text(draft), doc_alias)
 
-        r = self.client.post(url, {"regenerate_last_call_text": "1"})
-        self.assertEqual(r.status_code, 200)
-        text = textarea_value(r.content, "last_call_text")
-        self.assertIn(
-            f"Reply-To: last-call@ietf.org, {draft.name}@{settings.DRAFT_ALIAS_DOMAIN}\n",
-            text,
-        )
-
-        # a working group draft replies to the group list as well
+        # a working group draft asks for the group list to be copied instead
         draft = WgDraftFactory(
             ad=Person.objects.get(user__username="ad"),
             states=[("draft", "active"), ("draft-iesg", "ad-eval")],
         )
         self.assertTrue(draft.group.list_email)
-        url = urlreverse(
-            "ietf.doc.views_ballot.lastcalltext", kwargs={"name": draft.name}
+        self._assertCopyAddress(
+            self._regenerate_last_call_text(draft), draft.group.list_email
         )
-
-        r = self.client.post(url, {"regenerate_last_call_text": "1"})
-        self.assertEqual(r.status_code, 200)
-        text = textarea_value(r.content, "last_call_text")
-        self.assertIn(f"Reply-To: last-call@ietf.org, {draft.group.list_email}\n", text)
 
         # a group with no list of its own falls back to the draft alias
         draft.group.list_email = ""
         draft.group.save()
-
-        r = self.client.post(url, {"regenerate_last_call_text": "1"})
-        self.assertEqual(r.status_code, 200)
-        text = textarea_value(r.content, "last_call_text")
-        self.assertIn(
-            f"Reply-To: last-call@ietf.org, {draft.name}@{settings.DRAFT_ALIAS_DOMAIN}\n",
-            text,
+        self._assertCopyAddress(
+            self._regenerate_last_call_text(draft),
+            f"{draft.name}@{settings.DRAFT_ALIAS_DOMAIN}",
         )
 
     def test_request_last_call(self):

--- a/ietf/templates/doc/mail/last_call_announcement.txt
+++ b/ietf/templates/doc/mail/last_call_announcement.txt
@@ -1,7 +1,7 @@
 {% load ietf_filters %}{% load mail_filters %}{% autoescape off %}From: The IESG <iesg-secretary@ietf.org>
 To: {{ to }}{% if cc %}
 CC: {{ cc }}{% endif %}
-Reply-To: last-call@ietf.org
+Reply-To: {{ reply_to }}
 Sender: <iesg-secretary@ietf.org>
 Subject: Last Call: {{ doc.file_tag }} ({{ doc.title|clean_whitespace }}) to {{ doc|std_level_prompt }}
 

--- a/ietf/templates/doc/mail/last_call_announcement.txt
+++ b/ietf/templates/doc/mail/last_call_announcement.txt
@@ -10,7 +10,7 @@ The IESG has received a request from {{ group }} to consider the following docum
 - '{{ d.filled_title }}'
   {{ d.file_tag }} as {{ d|std_level_prompt }}{% endfor %}
 
-The IESG plans to make a decision in the next few weeks, and solicits final comments on this action. Please send substantive comments to the last-call@ietf.org mailing lists by {{ expiration_date }}. Exceptionally, comments may be sent to iesg@ietf.org instead. In either case, please retain the beginning of the Subject line to allow automated sorting.{% endfilter %}
+The IESG plans to make a decision on this document in the coming weeks, and hereby solicits last call comments. Please send substantive comments to the last-call@ietf.org mailing list, with {{ copy_address }} copied, no later than {{ expiration_date }}. Exceptionally, comments may be sent to iesg@ietf.org instead. In either case, please retain the beginning of the Subject line to allow automated sorting.{% endfilter %}
 
 Abstract{{ docs|pluralize }}
 

--- a/ietf/templates/doc/mail/last_call_announcement.txt
+++ b/ietf/templates/doc/mail/last_call_announcement.txt
@@ -6,22 +6,19 @@ Sender: <iesg-secretary@ietf.org>
 Subject: Last Call: {{ doc.file_tag }} ({{ doc.title|clean_whitespace }}) to {{ doc|std_level_prompt }}
 
 {% filter wordwrap:78 %}
-The IESG has received a request from {{ group }} to consider the following document{{ docs|pluralize }}:{% for d in docs %}
-- '{{ d.filled_title }}'
-  {{ d.file_tag }} as {{ d|std_level_prompt }}{% endfor %}
+The IESG has received a request from {{ group }} to consider the following document:
+  '{{ doc.filled_title }}'
+  {{ doc.file_tag }} as {{ doc|std_level_prompt }}
 
 The IESG plans to make a decision on this document in the coming weeks, and hereby solicits last call comments. Please send substantive comments to the last-call@ietf.org mailing list, with {{ copy_address }} copied, no later than {{ expiration_date }}. Exceptionally, comments may be sent to iesg@ietf.org instead. In either case, please retain the beginning of the Subject line to allow automated sorting.{% endfilter %}
 
-Abstract{{ docs|pluralize }}
+Abstract
 
-{% for d in docs %}
-{{ d.abstract}}
+{{ doc.abstract }}
 
-{% endfor %}
 
-The file{{ urls|pluralize }} can be obtained via
-{% for u in urls %}{{ u }}
-{% endfor %}
+The file can be obtained via
+{{ url }}
 
 {% if ipr_links %}The following IPR Declarations may be related to this I-D:
 


### PR DESCRIPTION
The IESG has requested a set of changes to IETF LC email bodies and the addition of a Reply-To header to explicitly include the group list, or the document alias if there is no appropriate group list.