### PR TITLE
fix: feat/rpc-api timezone

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -879,7 +879,7 @@ class CustomApiTests(TestCase):
         for lib in settings.ADVERTISE_VERSIONS:
             self.assertIn(lib, data['other'])
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 +0000")
-        DumpInfo.objects.update(tz='PST8PDT')
+        DumpInfo.objects.update(tz='America/Los_Angeles')
         r = self.client.get(url)
         data = r.json()        
         self.assertEqual(data['dumptime'], "2022-08-31 07:10:01 -0700")

--- a/ietf/settings.py
+++ b/ietf/settings.py
@@ -126,7 +126,7 @@ DATABASES = {
 # although not all variations may be possible on all operating systems.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'PST8PDT'
+TIME_ZONE = 'America/Los_Angeles'
 
 # Language code for this installation. All choices can be found here:
 # http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes

--- a/ietf/utils/timezone.py
+++ b/ietf/utils/timezone.py
@@ -12,12 +12,12 @@ from django.utils import timezone
 # require code changes.
 #
 # Default time zone for deadlines / expiration dates.
-DEADLINE_TZINFO = ZoneInfo('PST8PDT')
+DEADLINE_TZINFO = ZoneInfo('America/Los_Angeles')
 
 # Time zone for dates from the RPC. This value is baked into the timestamps on DocEvents
 # of type="published_rfc" - see Document.pub_date() and ietf.sync.refceditor.update_docs_from_rfc_index()
 # for more information about how that works.
-RPC_TZINFO = ZoneInfo('PST8PDT')
+RPC_TZINFO = ZoneInfo('America/Los_Angeles')
 
 
 def _tzinfo(tz: Union[str, datetime.tzinfo, None]):


### PR DESCRIPTION
## fix

* `feat/rpc-api` timezone PST8PDT to America/Los_Angeles, per #10139 fix as main