### PR TITLE
fix(bibxml): Improve author name processing

### DIFF
--- a/ietf/sync/bibxml.py
+++ b/ietf/sync/bibxml.py
@@ -98,6 +98,11 @@ ORG_LOOKUP = {
 }
 
 
+CHUNK = r"(?:[A-Z]|\([A-Z]+\))+"
+INITIAL = rf"(?:{CHUNK}-)*{CHUNK}\."
+NAME_RE = re.compile(rf"^\s*(?P<initials>(?:{INITIAL}[-\s]*)*)(?P<surname>.*?)\s*$")
+
+
 class BibXMLException(Exception):
     pass
 
@@ -153,7 +158,9 @@ def get_rfc_bibxml(rfc):
                 )
         else:
             try:
-                initials, surname = author.titlepage_name.split(maxsplit=1)
+                name_parts = NAME_RE.match(author.titlepage_name)
+                initials = name_parts["initials"].strip()
+                surname = name_parts["surname"]
                 if author.is_editor:
                     author_entry = f"""<author fullname={qa(author.titlepage_name)} initials={qa(initials)} surname={qa(surname)} role="editor"/>"""
                 else:

--- a/ietf/sync/bibxml.py
+++ b/ietf/sync/bibxml.py
@@ -99,7 +99,11 @@ ORG_LOOKUP = {
 
 
 CHUNK = r"(?:[A-Z]|\([A-Z]+\))+"
-INITIAL = rf"(?:{CHUNK}-)*{CHUNK}\."
+PARENY = r"[A-Z]*(?:\([A-Z]+\)[A-Z]*)+"
+DOTTED = rf"(?:{CHUNK}-)*{CHUNK}\."
+BARE = rf"(?:{PARENY}|[A-Z]+)(?=[-\s])"
+INITIAL = rf"(?:{DOTTED}|{BARE})"
+
 NAME_RE = re.compile(rf"^\s*(?P<initials>(?:{INITIAL}[-\s]*)*)(?P<surname>.*?)\s*$")
 
 
@@ -161,10 +165,13 @@ def get_rfc_bibxml(rfc):
                 name_parts = NAME_RE.match(author.titlepage_name)
                 initials = name_parts["initials"].strip()
                 surname = name_parts["surname"]
+                initials_attr = ""
+                if initials:
+                    initials_attr = f"initials={qa(initials)}"
                 if author.is_editor:
-                    author_entry = f"""<author fullname={qa(author.titlepage_name)} initials={qa(initials)} surname={qa(surname)} role="editor"/>"""
+                    author_entry = f"""<author fullname={qa(author.titlepage_name)} {initials_attr} surname={qa(surname)} role="editor"/>"""
                 else:
-                    author_entry = f"""<author fullname={qa(author.titlepage_name)} initials={qa(initials)} surname={qa(surname)}/>"""
+                    author_entry = f"""<author fullname={qa(author.titlepage_name)} {initials_attr} surname={qa(surname)}/>"""
             except ValueError:
                 # Case where author has single name.
                 author_entry = f"""<author fullname={qa(author.titlepage_name)} />"""


### PR DESCRIPTION
This PR improves author name processing.
While this matches the existing output mostly, there are some improvements.
Improved scenarios:

* When the initials has a hyphen.
  Example: [RFC 9845](https://www.rfc-editor.org/info/rfc9845)
  Existing output: `<author fullname="M-P. Odini" surname="M-P. Odini"/>`
  New output: `<author fullname="M-P. Odini" initials="M-P." surname="Odini"/>`

* When the initials has multiple letters.
  Example: [RFC 5930](https://www.rfc-editor.org/info/rfc5930)
  Existing output: `<author fullname="NSS. Murthy" surname="NSS. Murthy"/>`
  New output: `<author fullname="NSS. Murthy" initials="NSS." surname="Murthy"/>`

* When the author has brackets in initials (without period).
  Example: [RFC 7893](https://www.rfc-editor.org/info/rfc7893)
  Existing output: `<author fullname="Y(J) Stein" surname="Y(J) Stein"/>`
  New output: `<author fullname="Y(J) Stein" initials="Y(J)" surname="Stein"/>`

* When the author has brackets in initials (without out period).
  Example: [RFC 6310](https://www.rfc-editor.org/info/rfc6310)
  Existing output: `<author fullname="Y(J). Stein" surname="Y(J). Stein"/>`
  New output: `<author fullname="Y(J). Stein" initials="Y(J)." surname="Stein"/>`

NOTE that regex in this PR is assisted by Claude Opus 5.