### PR TITLE
fix(bibxml): Add Bolt Beranek and Newman Labs to org list

### DIFF
--- a/ietf/sync/bibxml.py
+++ b/ietf/sync/bibxml.py
@@ -72,6 +72,10 @@ ORG_LOOKUP = {
     "End-to-End Services Task Force": (None, "End-to-End Services Task Force"),
     "Network Technical Advisory Group": (None, "Network Technical Advisory Group"),
     "Bolt Beranek": (None, "Bolt Beranek"),
+    "Bolt Beranek and Newman Laboratories": (
+        None,
+        "Bolt Beranek and Newman Laboratories",
+    ),
     "Newman Laboratories": (None, "Newman Laboratories"),
     "Gateway Algorithms and Data Structures Task Force": (
         None,


### PR DESCRIPTION
This adds missing organization, "Bolt Beranek and Newman Lab" to the `ORG_LOOKUP`.
This improves BibXML output for [RFC 907](https://www.rfc-editor.org/info/rfc907/).

New BibXML output:
```
    <author>
      <organization>Bolt Beranek and Newman Laboratories</organization>
    </author>
```

Existing BibXML output[^1]:
```
    <author fullname="Bolt Beranek and Newman Laboratories" surname="Beranek and Newman Laboratories"/>
```


[^1]: https://bib.ietf.org/public/rfc/bibxml/reference.RFC.907.xml