### PR TITLE
feat: include doc shepherd in survey API; rename endpoint

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1072,10 +1072,10 @@ class CustomApiTests(TestCase):
         )
 
     @override_settings(
-        APP_API_TOKENS={"ietf.api.views.rfc_authors": ["valid-token"]}
+        APP_API_TOKENS={"ietf.api.views.rfc_author_survey_recipients": ["valid-token"]}
     )
-    def test_rfc_authors(self):
-        url = urlreverse("ietf.api.views.rfc_authors")
+    def test_rfc_author_survey_recipients(self):
+        url = urlreverse("ietf.api.views.rfc_author_survey_recipients")
         # auth and method checks
         self.assertEqual(
             self.client.get(url, headers={}).status_code, 403, "No api token, no access"
@@ -1209,6 +1209,90 @@ class CustomApiTests(TestCase):
             headers={"X-Api-Key": "valid-token"},
         )
         self.assertEqual(r.status_code, 400, "out-of-order from/to parameters")
+
+    @override_settings(
+        APP_API_TOKENS={"ietf.api.views.rfc_author_survey_recipients": ["valid-token"]}
+    )
+    def test_rfc_author_survey_recipients_with_shepherd(self):
+        url = urlreverse("ietf.api.views.rfc_author_survey_recipients")
+        now = timezone.now()
+        one_day_ago = now - datetime.timedelta(days=1)
+        # A recently published RFC with a known author and shepherd
+        author = PersonFactory(name="Jane Q. Author")
+        recent_rfc = WgRfcFactory(title="A Recently Published RFC")
+        DocEventFactory(doc=recent_rfc, type="published_rfc", time=one_day_ago)
+        RfcAuthorFactory(document=recent_rfc, person=author)
+        shepherd_email = EmailFactory(person__name="Alicia Shepherd")
+        shepherd = shepherd_email.person
+        recent_rfc_draft = WgDraftFactory(shepherd_id=shepherd_email.pk)
+        recent_rfc_draft.relateddocument_set.create(
+            relationship_id="became_rfc", target=recent_rfc
+        )
+        r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers["Content-Type"], "application/json")
+        rows = json.loads(r.content)
+        expected_rows = [
+            {
+                "name": shepherd.name,
+                "email": shepherd.email_address(),
+                "type": "shepherd",
+                "rfc_number": str(recent_rfc.rfc_number),
+                "rfc_name": recent_rfc.name,
+                "rfc_number_and_title": (
+                    f"RFC {recent_rfc.rfc_number}: {recent_rfc.title}"
+                ),
+                "rfc_title": recent_rfc.title,
+                "published_date": str(recent_rfc.pub_date()),
+            },
+            {
+                "name": author.name,
+                "email": author.email_address(),
+                "type": "author",
+                "rfc_number": str(recent_rfc.rfc_number),
+                "rfc_name": recent_rfc.name,
+                "rfc_title": recent_rfc.title,
+                "rfc_number_and_title": (
+                    f"RFC {recent_rfc.rfc_number}: {recent_rfc.title}"
+                ),
+                "published_date": str(recent_rfc.pub_date()),
+            },
+        ]
+        self.assertCountEqual(
+            rows,
+            expected_rows,
+        )
+
+        # Now give the shepherd an RFC as author
+        other_rfc = WgRfcFactory(title="Other Published RFC")
+        DocEventFactory(doc=other_rfc, type="published_rfc", time=one_day_ago)
+        RfcAuthorFactory(document=other_rfc, person=shepherd)
+
+        r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers["Content-Type"], "application/json")
+        rows = json.loads(r.content)
+        # update expected rows
+        expected_rows[0]["type"] = "author/shepherd"
+        expected_rows[0]["rfc_number"] = (
+            f"{recent_rfc.rfc_number}, {other_rfc.rfc_number}"
+        )
+        expected_rows[0]["rfc_name"] = f"{recent_rfc.name}, {other_rfc.name}"
+        expected_rows[0]["rfc_title"] = f"{recent_rfc.title}, {other_rfc.title}"
+        expected_rows[0]["rfc_number_and_title"] = (
+            f"RFC {recent_rfc.rfc_number}: {recent_rfc.title}, "
+            f"RFC {other_rfc.rfc_number}: {other_rfc.title}"
+        )
+        expected_rows[0]["published_date"] = (
+            f"{recent_rfc.pub_date()}, {other_rfc.pub_date()}"
+        )
+        # and compare
+        self.assertCountEqual(
+            rows,
+            expected_rows,
+        )
+
+
 
     @override_settings(
         APP_API_TOKENS={"ietf.api.views.ingest_email": "valid-token", "ietf.api.views.ingest_email_test": "test-token"}

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1179,18 +1179,30 @@ class CustomApiTests(TestCase):
         self.assertEqual(rows[0]["name"], "Jane Q. Author")
 
         # If in test mode and testaddr parameters are present, records for those
-        # addresses should be returned with a fake RFC.
+        # addresses should be returned with a fake RFC. Also exercise specifying
+        # recipient type, including that author is the default.
         r = self.client.get(
-            url + "?testing&testaddr=fake@a.example.com&testaddr=phony@b.example.com",
+            url
+            + (
+                "?testing"
+                "&testaddr=fake@a.example.com"
+                "&testaddr=phony@b.example.com;shepherd"
+                "&testaddr=ersatz@c.example.com;shepherd,author"
+            ),
             headers={"X-Api-Key": "valid-token"},
         )
         self.assertEqual(r.status_code, 200)
         rows = json.loads(r.content)
-        self.assertEqual(len(rows), 3)
+        self.assertEqual(len(rows), 4)
         fake_author_addr = author.email().address.split("@", 1)[0] + "@fake.example.com"
         self.assertCountEqual(
-            [fake_author_addr, "fake@a.example.com", "phony@b.example.com"],
-            [r["email"] for r in rows],
+            [
+                (fake_author_addr, "author"),
+                ("fake@a.example.com", "author"),
+                ("phony@b.example.com", "shepherd"),
+                ("ersatz@c.example.com", "author/shepherd"),
+            ],
+            [(r["email"], r["type"]) for r in rows],
         )
 
         # Can only use testaddr when testing is also present

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -44,8 +44,10 @@ urlpatterns = [
     # --- Custom API endpoints, sorted alphabetically ---
     # Email alias information for drafts
     url(r'^doc/draft-aliases/$', api_views.draft_aliases),
-    # Authors of recently published RFCs, as CSV
-    url(r'^doc/rfc-authors/$', api_views.rfc_authors),
+    # Recipients for author survey for recently published RFCs
+    url(
+        r'^doc/rfc-author-survey-recipients/$', api_views.rfc_author_survey_recipients
+    ),
     # email ingestor
     url(r'email/$', api_views.ingest_email),
     # email ingestor

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -644,7 +644,7 @@ def rfc_author_survey_recipients(request):
         docevent__type="published_rfc",
         docevent__time__gte=time_range_start,
         docevent__time__lt=time_range_end,
-    ).distinct()
+    ).order_by("rfc_number").distinct()
 
     # Collect per-author data keyed by email so each author gets one row.
     # Values accumulate RFC numbers, names, titles, and dates across all RFCs.
@@ -680,16 +680,17 @@ def rfc_author_survey_recipients(request):
         ):
             # Use email_address() to find an active address if this one is stale
             shepherd_email = originating_draft.shepherd.email_address()
+            shepherd = originating_draft.shepherd.person
             if shepherd_email is not None:
                 recipients.append({
-                    "name": shepherd_email.person.name,
-                    "email": shepherd_email.address,
+                    "name": shepherd.name,
+                    "email": shepherd_email,
                     "type": "shepherd",
                 })
             else:
                 log.log(
                     f"rfc_authors(): shepherd for {rfc.name}, has no active email "
-                    f"address, omitting shepherd"
+                    f"address, omitting shepherd ({shepherd.name})"
                 )
 
         for recipient in recipients:
@@ -725,7 +726,7 @@ def rfc_author_survey_recipients(request):
             recipient_data[email] = {
                 "name": f"Test Author {n + 1}",
                 "email": email,
-                "type": "author",
+                "types": {"author"},
                 "rfc_numbers": ["99999"],
                 "rfc_names": ["rfc99999"],
                 "rfc_titles": ["A Fake RFC for Testing"],

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -566,8 +566,12 @@ def role_holder_addresses(request):
 
 @requires_api_token
 @csrf_exempt
-def rfc_authors(request):
-    """Return authors of published RFCs as a JSON list of objects.
+def rfc_author_survey_recipients(request):
+    """Return recipients of the RFC Author Survey for RFCs in a time range
+
+    Returns the authors and (if present) document shepherd for RFCs as a JSON
+    structure. This is intended for generation of the post-publication Author
+    Survey and is not likely to be useful elsewhere.
 
     Finds authors by date, though this could be extended to other selection
     criteria in the future. Specify the range as ?from=<datetime>&to=<datetime>.
@@ -576,6 +580,11 @@ def rfc_authors(request):
 
     Each author appears once, with their RFC numbers, names, titles, and
     publication dates accumulated across every RFC they published in the window.
+    Authors have `"type": "author"` in their records.
+
+    If an RFC has a shepherd assigned to its originating draft, that shepherd is
+    included in the list of recipients alongside the authors. Shepherds have
+    `"type": "shepherd"` in their records.
 
     When the ?testing query parameter is supplied, each author's real email
     address is replaced with a fake one that keeps the original mailbox but uses
@@ -634,7 +643,7 @@ def rfc_authors(request):
         docevent__type="published_rfc",
         docevent__time__gte=time_range_start,
         docevent__time__lt=time_range_end,
-    ).distinct().select_related("shepherd__person")  # avoid a query per RFC when reading rfc.shepherd below
+    ).distinct()
 
     # Collect per-author data keyed by email so each author gets one row.
     # Values accumulate RFC numbers, names, titles, and dates across all RFCs.
@@ -654,20 +663,33 @@ def rfc_authors(request):
             for a in rfc.rfcauthor_set.select_related("person").order_by("order")
         ]
 
-        # The rfc Document doesn't always carry its own shepherd - it's often only set on
-        # the draft it came from. Fall back to the draft's shepherd in that case. came_from_draft()
-        # can return None (e.g. very old RFCs with no tracked originating draft), so guard for that.
-        draft = rfc.came_from_draft()
-        if rfc.shepherd_id or (draft and draft.shepherd_id):
-            shepherd_rfc = rfc if rfc.shepherd_id else draft
-
-            authors.append({
-                # shepherd.person should always be set (see assertion in views_doc.py), but
-                # fall back to None rather than crash if that invariant is ever violated.
-                "name": shepherd_rfc.shepherd.person.name if shepherd_rfc.shepherd.person else None,
-                "email": shepherd_rfc.shepherd_id,  # Email's primary key is the address itself
-                "type": "shepherd",
-            })
+        # As of Aug 2026, the rfc Document doesn't carry its own shepherd - it's only 
+        # set on the draft it came from. If the shepherd changes, the value on the draft
+        # will be kept up to date.
+        #
+        # came_from_draft() can return None (e.g. very old RFCs with no tracked
+        # originating draft, April 1 RFCs, and other special cases), so guard for that.
+        # Also, shepherd.person should always be set (see assertion in views_doc.py)
+        # but skip rather than crash if that invariant is ever violated.
+        originating_draft = rfc.came_from_draft()
+        if (
+            originating_draft 
+            and originating_draft.shepherd is not None
+            and originating_draft.shepherd.person is not None
+        ):
+            # Use email_address() to find an active address if this one is stale
+            shepherd_email = originating_draft.shepherd.email_address()
+            if shepherd_email is not None:
+                authors.append({
+                    "name": shepherd_email.person.name,
+                    "email": shepherd_email.address,
+                    "type": "shepherd",
+                })
+            else:
+                log.log(
+                    f"rfc_authors(): shepherd for {rfc.name}, has no active email "
+                    f"address, omitting shepherd"
+                )
 
         for author in authors:
             if not author["email"]:

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -573,7 +573,7 @@ def rfc_author_survey_recipients(request):
     structure. This is intended for generation of the post-publication Author
     Survey and is not likely to be useful elsewhere.
 
-    Finds authors by date, though this could be extended to other selection
+    Finds RFCs by date, though this could be extended to other selection
     criteria in the future. Specify the range as ?from=<datetime>&to=<datetime>.
     Each <datetime> is an ISO-8601 timestamp, treated as UTC if it does not include
     time zone information. Defaults to `to`=now, `from`=14 days before `to`
@@ -584,7 +584,8 @@ def rfc_author_survey_recipients(request):
 
     If an RFC has a shepherd assigned to its originating draft, that shepherd is
     included in the list of recipients alongside the authors. Shepherds have
-    `"type": "shepherd"` in their records.
+    `"type": "shepherd"` in their records. If a shepherd is also an author, then
+    `"type": "author/shepherd"`.
 
     When the ?testing query parameter is supplied, each author's real email
     address is replaced with a fake one that keeps the original mailbox but uses
@@ -705,7 +706,7 @@ def rfc_author_survey_recipients(request):
                 recipient_data[email] = {
                     "name": recipient["name"],
                     "email": email,
-                    "type": recipient["type"],
+                    "types": set(),
                     "rfc_numbers": [],
                     "rfc_names": [],
                     "rfc_titles": [],
@@ -715,6 +716,7 @@ def rfc_author_survey_recipients(request):
             recipient_data[email]["rfc_names"].append(rfc.name)
             recipient_data[email]["rfc_titles"].append(rfc.title)
             recipient_data[email]["published_dates"].append(str(rfc.pub_date()))
+            recipient_data[email]["types"].add(recipient["type"])
 
     if testing:
         for n, email in enumerate(test_addresses):
@@ -732,11 +734,12 @@ def rfc_author_survey_recipients(request):
 
     rows = []
     for entry in recipient_data.values():
+        entry_type = "/".join(sorted(entry["types"]))
         rows.append(
             {
                 "name": entry["name"],
                 "email": entry["email"],
-                "type": entry["type"],  # "author" or "shepherd"
+                "type": entry_type,  # "author", "shepherd", or "author/shepherd"
                 "rfc_number": ", ".join(entry["rfc_numbers"]),
                 "rfc_name": ", ".join(entry["rfc_names"]),
                 "rfc_title": ", ".join(entry["rfc_titles"]),

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -647,12 +647,12 @@ def rfc_author_survey_recipients(request):
 
     # Collect per-author data keyed by email so each author gets one row.
     # Values accumulate RFC numbers, names, titles, and dates across all RFCs.
-    author_data = {}
+    recipient_data = {}
 
     for rfc in rfcs:
         # RfcAuthor is the authoritative source for RFC authors. Documents of
         # type "rfc" always have an rfcauthor_set, so no fallback is needed.
-        authors = [
+        recipients = [
             {
                 "name": a.person.name if a.person else a.titlepage_name,
                 "email": a.person.email().address
@@ -680,7 +680,7 @@ def rfc_author_survey_recipients(request):
             # Use email_address() to find an active address if this one is stale
             shepherd_email = originating_draft.shepherd.email_address()
             if shepherd_email is not None:
-                authors.append({
+                recipients.append({
                     "name": shepherd_email.person.name,
                     "email": shepherd_email.address,
                     "type": "shepherd",
@@ -691,39 +691,39 @@ def rfc_author_survey_recipients(request):
                     f"address, omitting shepherd"
                 )
 
-        for author in authors:
-            if not author["email"]:
+        for recipient in recipients:
+            if not recipient["email"]:
                 continue
 
             if testing:
-                mailbox = author["email"].split("@", 1)[0]
+                mailbox = recipient["email"].split("@", 1)[0]
                 email = f"{mailbox}@fake.example.com"
             else:
-                email = author["email"]
+                email = recipient["email"]
 
-            if email not in author_data:
-                author_data[email] = {
-                    "name": author["name"],
+            if email not in recipient_data:
+                recipient_data[email] = {
+                    "name": recipient["name"],
                     "email": email,
-                    "type": author["type"],
+                    "type": recipient["type"],
                     "rfc_numbers": [],
                     "rfc_names": [],
                     "rfc_titles": [],
                     "published_dates": [],
                 }
-            author_data[email]["rfc_numbers"].append(str(rfc.rfc_number))
-            author_data[email]["rfc_names"].append(rfc.name)
-            author_data[email]["rfc_titles"].append(rfc.title)
-            author_data[email]["published_dates"].append(str(rfc.pub_date()))
+            recipient_data[email]["rfc_numbers"].append(str(rfc.rfc_number))
+            recipient_data[email]["rfc_names"].append(rfc.name)
+            recipient_data[email]["rfc_titles"].append(rfc.title)
+            recipient_data[email]["published_dates"].append(str(rfc.pub_date()))
 
     if testing:
         for n, email in enumerate(test_addresses):
-            if email in author_data:
+            if email in recipient_data:
                 continue  # author will already be included
-            author_data[email] = {
+            recipient_data[email] = {
                 "name": f"Test Author {n + 1}",
                 "email": email,
-                "type": "author",  # matches the shape of real entries now that "type" is included below
+                "type": "author",
                 "rfc_numbers": ["99999"],
                 "rfc_names": ["rfc99999"],
                 "rfc_titles": ["A Fake RFC for Testing"],
@@ -731,12 +731,12 @@ def rfc_author_survey_recipients(request):
             }
 
     rows = []
-    for entry in author_data.values():
+    for entry in recipient_data.values():
         rows.append(
             {
                 "name": entry["name"],
                 "email": entry["email"],
-                "type": entry["type"],  # "author" or "shepherd", surfaced in the API response
+                "type": entry["type"],  # "author" or "shepherd"
                 "rfc_number": ", ".join(entry["rfc_numbers"]),
                 "rfc_name": ", ".join(entry["rfc_names"]),
                 "rfc_title": ", ".join(entry["rfc_titles"]),

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -590,13 +590,15 @@ def rfc_author_survey_recipients(request):
     When the ?testing query parameter is supplied, each author's real email
     address is replaced with a fake one that keeps the original mailbox but uses
     the "fake.example.com" domain, so the output can be shared without exposing
-    real addresses.
+    real addresses. 
     
     When the ?testing query parameter is supplied, one or more testaddr=ADDRESS query
     parameters can also be specified. The value of each parameter is an email
     address. When these parameters are present, the response data will include an
-    entry for each address as though it belonged to the author of a recently published
-    RFC.
+    entry for each address as though it belonged to an author or shepherd of a recently
+    published RFC. To specify the recipient type, append ";author", ";shepherd",
+    or ";author,shepherd" to the end of the email address. E.g.,
+    "?testing&testaddr=somebody@example.com;author,shepherd"
     """
     if request.method != "GET":
         return HttpResponse(status=405)
@@ -722,11 +724,21 @@ def rfc_author_survey_recipients(request):
     if testing:
         for n, email in enumerate(test_addresses):
             if email in recipient_data:
-                continue  # author will already be included
+                continue  # recipient will already be included
+            # see if a type list was included
+            if ";" in email:
+                email, types = email.rsplit(";", 1)
+                types = {type_.strip() for type_ in types.split(",")}
+                if len(types.difference({"author", "shepherd"})) != 0:
+                    return HttpResponseBadRequest(
+                        f"Invalid types for testaddr={email}"
+                    )
+            else:
+                types = {"author"}
             recipient_data[email] = {
                 "name": f"Test Author {n + 1}",
                 "email": email,
-                "types": {"author"},
+                "types": types,
                 "rfc_numbers": ["99999"],
                 "rfc_names": ["rfc99999"],
                 "rfc_titles": ["A Fake RFC for Testing"],

--- a/ietf/api/views.py
+++ b/ietf/api/views.py
@@ -634,7 +634,7 @@ def rfc_authors(request):
         docevent__type="published_rfc",
         docevent__time__gte=time_range_start,
         docevent__time__lt=time_range_end,
-    ).distinct()
+    ).distinct().select_related("shepherd__person")  # avoid a query per RFC when reading rfc.shepherd below
 
     # Collect per-author data keyed by email so each author gets one row.
     # Values accumulate RFC numbers, names, titles, and dates across all RFCs.
@@ -649,9 +649,25 @@ def rfc_authors(request):
                 "email": a.person.email().address
                 if (a.person and a.person.email())
                 else None,
+                "type": "author",  # distinguishes authors from the shepherd entry added below
             }
             for a in rfc.rfcauthor_set.select_related("person").order_by("order")
         ]
+
+        # The rfc Document doesn't always carry its own shepherd - it's often only set on
+        # the draft it came from. Fall back to the draft's shepherd in that case. came_from_draft()
+        # can return None (e.g. very old RFCs with no tracked originating draft), so guard for that.
+        draft = rfc.came_from_draft()
+        if rfc.shepherd_id or (draft and draft.shepherd_id):
+            shepherd_rfc = rfc if rfc.shepherd_id else draft
+
+            authors.append({
+                # shepherd.person should always be set (see assertion in views_doc.py), but
+                # fall back to None rather than crash if that invariant is ever violated.
+                "name": shepherd_rfc.shepherd.person.name if shepherd_rfc.shepherd.person else None,
+                "email": shepherd_rfc.shepherd_id,  # Email's primary key is the address itself
+                "type": "shepherd",
+            })
 
         for author in authors:
             if not author["email"]:
@@ -667,6 +683,7 @@ def rfc_authors(request):
                 author_data[email] = {
                     "name": author["name"],
                     "email": email,
+                    "type": author["type"],
                     "rfc_numbers": [],
                     "rfc_names": [],
                     "rfc_titles": [],
@@ -684,6 +701,7 @@ def rfc_authors(request):
             author_data[email] = {
                 "name": f"Test Author {n + 1}",
                 "email": email,
+                "type": "author",  # matches the shape of real entries now that "type" is included below
                 "rfc_numbers": ["99999"],
                 "rfc_names": ["rfc99999"],
                 "rfc_titles": ["A Fake RFC for Testing"],
@@ -696,6 +714,7 @@ def rfc_authors(request):
             {
                 "name": entry["name"],
                 "email": entry["email"],
+                "type": entry["type"],  # "author" or "shepherd", surfaced in the API response
                 "rfc_number": ", ".join(entry["rfc_numbers"]),
                 "rfc_name": ", ".join(entry["rfc_names"]),
                 "rfc_title": ", ".join(entry["rfc_titles"]),


### PR DESCRIPTION
This adds the document shepherd to the list of recipients returned by what had been the `/api/doc/rfc-authors/` endpoint. Because it is no longer well described by that URL path, the path is changed to `/api/doc/rfc-author-survey-recipients/` to reflect the special purpose this is supporting.