### PR TITLE
chore(dev): allow passwordless login for dev

### DIFF
--- a/docker/configs/settings_local.py
+++ b/docker/configs/settings_local.py
@@ -1,4 +1,4 @@
-# Copyright The IETF Trust 2007-2025, All Rights Reserved
+# Copyright The IETF Trust 2007-2026, All Rights Reserved
 # -*- coding: utf-8 -*-
 
 from ietf.settings import *  # pyflakes:ignore
@@ -11,6 +11,9 @@ from ietf.settings import (
 )
 
 ALLOWED_HOSTS = ['*']
+
+# Allow login with any account without password check. ONLY FOR DEV!
+AUTHENTICATION_BACKENDS = ("ietf.ietfauth.backends.UnsafeAllowAnyModelBackend",)
 
 from ietf.settings_postgresqldb import DATABASES  # pyflakes:ignore
 DATABASE_ROUTERS = ["ietf.blobdb.routers.BlobdbStorageRouter"]

--- a/ietf/ietfauth/backends.py
+++ b/ietf/ietfauth/backends.py
@@ -1,9 +1,15 @@
+# Copyright The IETF Trust 2023-2026, All Rights Reserved
+from typing import Any
 
-# From https://simpleisbetterthancomplex.com/tutorial/2017/02/06/how-to-implement-case-insensitive-username.html
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpRequest
 
 
+# From https://simpleisbetterthancomplex.com/tutorial/2017/02/06/how-to-implement-case-insensitive-username.html
 class CaseInsensitiveModelBackend(ModelBackend):
     def authenticate(self, request, username=None, password=None, **kwargs):
         UserModel = get_user_model()
@@ -19,3 +25,34 @@ class CaseInsensitiveModelBackend(ModelBackend):
         else:
             if user.check_password(password) and self.user_can_authenticate(user):
                 return user
+
+
+class UnsafeAllowAnyModelBackend(ModelBackend):
+    """UNSAFE backend that allows login with the password "password"
+
+    Will not work except in dev mode.
+    """
+
+    def authenticate(
+        self,
+        request: HttpRequest | None,
+        username: str | None = None,
+        password: str | None = None,
+        **kwargs: Any,
+    ) -> AbstractBaseUser | None:
+        if settings.SERVER_MODE not in ("development", "test"):
+            raise ImproperlyConfigured(f"Cannot use {self.__class__.__name__} backend when SERVER_MODE={settings.SERVER_MODE}")
+        UserModel = get_user_model()
+        if username is None:
+            username = kwargs.get(UserModel.USERNAME_FIELD)
+        if username is None:
+            return None
+        try:
+            case_insensitive_username_field = '{}__iexact'.format(UserModel.USERNAME_FIELD)
+            user = UserModel._default_manager.get(**{case_insensitive_username_field: username})
+        except UserModel.DoesNotExist:
+            return None
+        if self.user_can_authenticate(user):
+            # DOES NOT CHECK PASSWORD (this is intentional, but not ok for production)
+            return user
+        return None


### PR DESCRIPTION
Completely bypasses password check instead of counting on the password being replaced in the DB dump. In a world where Datatracker uses OIDC for login and no longer maintains its own passwords, this will continue to allow login. To make this work, we'll also need to expose the traditional Django login instead of or parallel to the OIDC login views.

Continues to allow login using any email address.

To prevent accidental use in production, only configures the backend via `settings_local.py` in dev environments for now. A guard in the backend class throws an exception if it's used in other than development and test modes. That will prevent accidental use, even if we deploy this to the sandbox k8s environment where a misconfiguration could more plausibly enable this for production.