### PR TITLE
feat: plenary attendance by email address API

### DIFF
--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -72,7 +72,7 @@ urlpatterns = [
     url(r'^meeting/(?P<num>[A-Za-z0-9._+-]+)/agenda-data$', meeting_views.api_get_agenda_data),
     # Meeting session materials
     url(r'^meeting/session/(?P<session_id>[A-Za-z0-9._+-]+)/materials$', meeting_views.api_get_session_materials),
-    url(r'^meeting/registration/attended/(?P<email>[^/\x00]+)/?$', meeting_api.MeetingsAttendedByEmail.as_view()),
+    url(r'^meeting/registration/attended/(?P<email>[^/\x00]+)/?$', meeting_api.MeetingsAttendedByEmail.as_view(), name="ietf.api.meeting.registration.attended"),
     # Let MeetEcho upload bluesheets
     url(r'^notify/meeting/bluesheet/?$', meeting_views.api_upload_bluesheet),
     # Let MeetEcho tell us about session attendees

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -8,6 +8,7 @@ from django.views.generic import TemplateView
 
 from ietf import api
 from ietf.doc import views_ballot, api as doc_api
+from ietf.meeting import api as meeting_api
 from ietf.meeting import views as meeting_views
 from ietf.submit import views as submit_views
 from ietf.utils.urls import url
@@ -71,6 +72,7 @@ urlpatterns = [
     url(r'^meeting/(?P<num>[A-Za-z0-9._+-]+)/agenda-data$', meeting_views.api_get_agenda_data),
     # Meeting session materials
     url(r'^meeting/session/(?P<session_id>[A-Za-z0-9._+-]+)/materials$', meeting_views.api_get_session_materials),
+    url(r'^meeting/registration/attended/(?P<email>[^/\x00]+)/?$', meeting_api.MeetingsAttendedByEmail.as_view()),
     # Let MeetEcho upload bluesheets
     url(r'^notify/meeting/bluesheet/?$', meeting_views.api_upload_bluesheet),
     # Let MeetEcho tell us about session attendees

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -46,9 +46,9 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
             [
                 reg
                 for reg in (
-                    person.registration_set.filter(
+                    person.registration_set.with_plenary_ticket_details().filter(
                         meeting_id__in=meetings_with_data
-                    ).with_plenary_ticket_details().select_related(
+                    ).select_related(
                         "meeting"
                     )
                 )

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -1,5 +1,5 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
-from django.db.models import IntegerField, Q
+from django.db.models import IntegerField
 from django.db.models.functions import Cast
 from rest_framework import generics
 

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -46,11 +46,10 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
             [
                 reg
                 for reg in (
-                    person.registration_set.with_plenary_ticket_details().filter(
-                        meeting_id__in=meetings_with_data
-                    ).select_related(
-                        "meeting"
-                    )
+                    person.registration_set.onsite_or_remote()
+                    .with_plenary_ticket_details()
+                    .filter(meeting_id__in=meetings_with_data)
+                    .select_related("meeting")
                 )
                 if (
                     reg.attended

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -1,0 +1,56 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+from django.db.models import IntegerField, Q
+from django.db.models.functions import Cast
+from rest_framework import generics
+
+from ietf.meeting.models import Meeting
+from ietf.meeting.serializers import PersonAttendedMeetingsSerializer
+from ietf.person.models import Person
+
+
+class MeetingsAttendedByEmail(generics.RetrieveAPIView):
+    """List meetings attended by a person identified by email address
+
+    Requires API key authentication
+    """
+
+    queryset = Person.objects.all()
+    lookup_field = "email__address"
+    lookup_url_kwarg = "email"
+    serializer_class = PersonAttendedMeetingsSerializer
+    api_key_endpoint = "ietf.meeting.api.meetings_attended_by_email"
+
+    def get_object(self):
+        person = super().get_object()
+        assert isinstance(person, Person)
+        person.attended_registrations = self._meetings_attended_by_person(person)
+        return person
+
+    @staticmethod
+    def _meetings_attended_by_person(person: Person):
+        meetings_with_data = (
+            Meeting.objects.filter(type="ietf")
+            .annotate(number_as_int=Cast("number", output_field=IntegerField()))
+            .exclude(number_as_int__lt=110)
+            .values_list("pk")
+        )
+        has_attended_record = (
+            person.attended_set.filter(
+                session__meeting_id__in=meetings_with_data,
+                session__meeting__type="ietf",
+            )
+            .values_list("session__meeting__id", flat=True)
+            .distinct()
+        )
+        return sorted(
+            [
+                reg
+                for reg in person.registration_set.select_related("meeting")
+                if (
+                    reg.attended
+                    or reg.checkedin
+                    or reg.meeting_id in has_attended_record
+                )
+            ],
+            key=lambda reg: reg.meeting.date,
+        )

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -18,7 +18,7 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
     lookup_field = "email__address"
     lookup_url_kwarg = "email"
     serializer_class = PersonAttendedMeetingsSerializer
-    api_key_endpoint = "ietf.meeting.api.meetings_attended_by_email"
+    api_key_endpoint = "ietf.api.meeting.registration.attended"
 
     def get_object(self):
         person = super().get_object()

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -23,11 +23,11 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
     def get_object(self):
         person = super().get_object()
         assert isinstance(person, Person)
-        person.attended_registrations = self._meetings_attended_by_person(person)
+        person.attended_registrations = self._attended_registrations(person)
         return person
 
     @staticmethod
-    def _meetings_attended_by_person(person: Person):
+    def _attended_registrations(person: Person):
         meetings_with_data = (
             Meeting.objects.filter(type="ietf")
             .annotate(number_as_int=Cast("number", output_field=IntegerField()))
@@ -45,7 +45,13 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
         return sorted(
             [
                 reg
-                for reg in person.registration_set.select_related("meeting")
+                for reg in (
+                    person.registration_set.filter(
+                        meeting_id__in=meetings_with_data
+                    ).with_plenary_ticket_details().select_related(
+                        "meeting"
+                    )
+                )
                 if (
                     reg.attended
                     or reg.checkedin

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -1567,6 +1567,15 @@ class Attended(models.Model):
 
 
 class RegistrationQuerySet(models.QuerySet):
+    def onsite(self):
+        return self.filter(tickets__attendance_type__slug="onsite")
+
+    def remote(self):
+        return (
+            self.filter(tickets__attendance_type__slug="remote")
+            .exclude(tickets__attendance_type__slug="onsite")
+        )
+
     def with_plenary_ticket_details(self):
         """Annotate with ticket details
 
@@ -1583,20 +1592,10 @@ class RegistrationQuerySet(models.QuerySet):
         )
 
 
-class RegistrationManager(models.Manager.from_queryset(RegistrationQuerySet)):
-    def onsite(self):
-        return self.get_queryset().filter(tickets__attendance_type__slug="onsite")
-
-    def remote(self):
-        return (
-            self.get_queryset()
-            .filter(tickets__attendance_type__slug="remote")
-            .exclude(tickets__attendance_type__slug="onsite")
-        )
-
-
 class Registration(models.Model):
     """Registration attendee records from the IETF registration system"""
+    objects = RegistrationQuerySet.as_manager()  # custom manager
+
     meeting = ForeignKey(Meeting)
     first_name = models.CharField(max_length=255)
     last_name = models.CharField(max_length=255)
@@ -1609,9 +1608,6 @@ class Registration(models.Model):
     attended = models.BooleanField(default=False)
     # checkedin indicates that the badge was picked up
     checkedin = models.BooleanField(default=False)
-
-    # custom manager
-    objects = RegistrationManager()
 
     def __str__(self):
         return "{} {}".format(self.first_name, self.last_name)

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -1568,9 +1568,17 @@ class Attended(models.Model):
 
 class RegistrationQuerySet(models.QuerySet):
     def onsite(self):
+        """Only registrations with at least one `onsite` ticket
+        
+        Includes any ticket type. In particular, may be a hackathon-only registration.
+        """
         return self.filter(tickets__attendance_type__slug="onsite")
 
     def remote(self):
+        """Only registrations with no `onsite` and at least one `remote` ticket
+
+        Includes any ticket type. In particular, may be a hackathon-only registration.
+        """
         return (
             self.filter(tickets__attendance_type__slug="remote")
             .exclude(tickets__attendance_type__slug="onsite")

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -6,6 +6,8 @@
 import datetime
 import io
 import os
+from functools import cached_property
+
 import pytz
 import random
 import re
@@ -19,8 +21,7 @@ import debug                            # pyflakes:ignore
 
 from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
-from django.db.models import Max, Subquery, OuterRef, TextField, Value, Q, Case, Exists, \
-    When
+from django.db.models import Max, Subquery, OuterRef, TextField, Value, Q, Case, When
 from django.db.models.functions import Coalesce
 from django.conf import settings
 from django.urls import reverse as urlreverse
@@ -1566,25 +1567,19 @@ class Attended(models.Model):
 
 
 class RegistrationQuerySet(models.QuerySet):
-    def with_attendance_type(self):
-        """Annotate to accelerate the attendance_type property for a queryset
-        
-        n.b., this only pays attention to onsite vs remote attendance types
+    def with_plenary_ticket_details(self):
+        """Annotate with ticket details
+
+        Adds private annotations accessible via @properties
         """
-        tickets = RegistrationTicket.objects.filter(registration=OuterRef("pk"))
+        most_representative = RegistrationTicket.objects.filter(
+            registration=OuterRef("pk")
+        ).order_by_most_representative()
         return self.annotate(
-            _attendance_type=Case(
-                When(
-                    Exists(tickets.filter(attendance_type__slug="onsite")),
-                    then=Value("onsite"),
-                ),
-                When(
-                    Exists(tickets.filter(attendance_type__slug="remote")),
-                    then=Value("remote"),
-                ),
-                default=Value(None),
-                output_field=models.CharField(null=True),
-            )
+            _attendance_type=Subquery(
+                most_representative.values("attendance_type")[:1]
+            ),
+            _ticket_type=Subquery(most_representative.values("ticket_type")[:1]),
         )
 
 
@@ -1621,17 +1616,71 @@ class Registration(models.Model):
     def __str__(self):
         return "{} {}".format(self.first_name, self.last_name)
 
+    @cached_property
+    def _plenary_ticket(self):
+        return self.tickets.order_by_most_representative().first()
+
     @property
-    def attendance_type(self):
+    def plenary_attendance_type(self):
+        """Attendance type for the plenary meeting
+
+        Attendance type for the plenary meeting. Ignores hackathon/anrw or any other
+        types of registration that are tracked through tickets.
+        """
         if hasattr(self, "_attendance_type"):
-            return self._attendance_type  # added via with_attendance_type() on qs
-        if self.tickets.filter(attendance_type__slug='onsite').exists():
-            return 'onsite'
-        elif self.tickets.filter(attendance_type__slug='remote').exists():
-            return 'remote'
-        return None
+            return self._attendance_type  # added via with_plenary_ticket_details()
+        return (
+            self._plenary_ticket.attendance_type_id if self._plenary_ticket else None
+        )
+
+    @property
+    def plenary_ticket_type(self):
+        """Ticket type for the plenary meeting
+
+        Ticket type for the plenary meeting. Ignores hackathon/anrw or any other types
+        of registration that are tracked through tickets.
+        """
+        if hasattr(self, "_ticket_type"):
+            return self._ticket_type  # added via with_plenary_ticket_details()
+        return (
+            self._plenary_ticket.ticket_type_id if self._plenary_ticket else None
+        )
+
+
+class RegistrationTicketQuerySet(models.QuerySet):
+    def order_by_most_representative(self):
+        """Order-by clause for representative tickets for plenary attendance
+        
+        Filters out tickets not applicable to the plenary IETF meeting
+        """
+        # ordered lists of interesting types
+        interesting_attendance_types = ["onsite", "remote"]
+        interesting_ticket_types = ["student", "week_pass", "one_day", "unknown"]
+        case_ranking_attendance_types = Case(
+            *[
+                When(attendance_type=att_type, then=index)
+                for index, att_type in enumerate(interesting_attendance_types)
+            ]
+        )
+        case_ranking_ticket_types = Case(
+            *[
+                When(ticket_type=tkt_type, then=index)
+                for index, tkt_type in enumerate(interesting_ticket_types)
+            ]
+        )
+        return self.filter(
+            attendance_type__in=interesting_attendance_types,
+            ticket_type__in=interesting_ticket_types,
+        ).order_by(
+            case_ranking_attendance_types,
+            case_ranking_ticket_types,
+            "pk",  # deterministic tie-break
+        )
+
 
 class RegistrationTicket(models.Model):
+    objects = RegistrationTicketQuerySet.as_manager()  # custom manager
+
     registration = ForeignKey(Registration, related_name='tickets')
     attendance_type = ForeignKey(AttendanceTypeName, on_delete=models.PROTECT)
     ticket_type = ForeignKey(RegistrationTicketTypeName, on_delete=models.PROTECT)

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -1589,7 +1589,9 @@ class RegistrationQuerySet(models.QuerySet):
         
         I.e., was a registration for the plenary meeting, not e.g. hackathon-only.
         """
-        return self.filter(tickets__attendance_type__slug__in=["onsite", "remote"])
+        return self.filter(
+            tickets__attendance_type__slug__in=["onsite", "remote"]
+        ).distinct()
 
     def with_plenary_ticket_details(self):
         """Annotate with ticket details

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -19,7 +19,8 @@ import debug                            # pyflakes:ignore
 
 from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
-from django.db.models import Max, Subquery, OuterRef, TextField, Value, Q
+from django.db.models import Max, Subquery, OuterRef, TextField, Value, Q, Case, Exists, \
+    When
 from django.db.models.functions import Coalesce
 from django.conf import settings
 from django.urls import reverse as urlreverse
@@ -1564,12 +1565,40 @@ class Attended(models.Model):
         return f'{self.person} at {self.session}'
 
 
-class RegistrationManager(models.Manager):
+class RegistrationQuerySet(models.QuerySet):
+    def with_attendance_type(self):
+        """Annotate to accelerate the attendance_type property for a queryset
+        
+        n.b., this only pays attention to onsite vs remote attendance types
+        """
+        tickets = RegistrationTicket.objects.filter(registration=OuterRef("pk"))
+        return self.annotate(
+            _attendance_type=Case(
+                When(
+                    Exists(tickets.filter(attendance_type__slug="onsite")),
+                    then=Value("onsite"),
+                ),
+                When(
+                    Exists(tickets.filter(attendance_type__slug="remote")),
+                    then=Value("remote"),
+                ),
+                default=Value(None),
+                output_field=models.CharField(null=True),
+            )
+        )
+
+
+class RegistrationManager(models.Manager.from_queryset(RegistrationQuerySet)):
     def onsite(self):
-        return self.get_queryset().filter(tickets__attendance_type__slug='onsite')
+        return self.get_queryset().filter(tickets__attendance_type__slug="onsite")
 
     def remote(self):
-        return self.get_queryset().filter(tickets__attendance_type__slug='remote').exclude(tickets__attendance_type__slug='onsite')
+        return (
+            self.get_queryset()
+            .filter(tickets__attendance_type__slug="remote")
+            .exclude(tickets__attendance_type__slug="onsite")
+        )
+
 
 class Registration(models.Model):
     """Registration attendee records from the IETF registration system"""
@@ -1594,6 +1623,8 @@ class Registration(models.Model):
 
     @property
     def attendance_type(self):
+        if hasattr(self, "_attendance_type"):
+            return self._attendance_type  # added via with_attendance_type() on qs
         if self.tickets.filter(attendance_type__slug='onsite').exists():
             return 'onsite'
         elif self.tickets.filter(attendance_type__slug='remote').exists():

--- a/ietf/meeting/models.py
+++ b/ietf/meeting/models.py
@@ -1584,6 +1584,13 @@ class RegistrationQuerySet(models.QuerySet):
             .exclude(tickets__attendance_type__slug="onsite")
         )
 
+    def onsite_or_remote(self):
+        """Registrations that were onsite or remote
+        
+        I.e., was a registration for the plenary meeting, not e.g. hackathon-only.
+        """
+        return self.filter(tickets__attendance_type__slug__in=["onsite", "remote"])
+
     def with_plenary_ticket_details(self):
         """Annotate with ticket details
 

--- a/ietf/meeting/serializers.py
+++ b/ietf/meeting/serializers.py
@@ -1,0 +1,27 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+from rest_framework import serializers
+
+from ietf.meeting.models import Registration
+
+
+class AttendedMeetingSerializer(serializers.ModelSerializer):
+    """Serialize a meeting attendance record
+    
+    Only for use with attended meetings with a non-empty attendance_type
+    """
+    meeting = serializers.SlugRelatedField(slug_field="number", read_only=True)
+    attendance_type = serializers.CharField(read_only=True)
+    ticket_type = serializers.CharField(read_only=True)
+    
+    class Meta:
+        model = Registration
+        fields = [
+            "meeting",
+            "attendance_type",
+            "ticket_type",
+        ]
+
+
+class PersonAttendedMeetingsSerializer(serializers.Serializer):
+    attended = AttendedMeetingSerializer(source="attended_registrations", many=True)

--- a/ietf/meeting/serializers.py
+++ b/ietf/meeting/serializers.py
@@ -6,13 +6,14 @@ from ietf.meeting.models import Registration
 
 
 class AttendedMeetingSerializer(serializers.ModelSerializer):
-    """Serialize a meeting attendance record
-    
-    Only for use with attended meetings with a non-empty attendance_type
-    """
+    """Serialize a plenary meeting attendance record"""
     meeting = serializers.SlugRelatedField(slug_field="number", read_only=True)
-    attendance_type = serializers.CharField(read_only=True)
-    ticket_type = serializers.CharField(read_only=True)
+    attendance_type = serializers.CharField(
+        source="plenary_attendance_type", read_only=True
+    )
+    ticket_type = serializers.CharField(
+        source="plenary_ticket_type", read_only=True
+    )
     
     class Meta:
         model = Registration

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -1,20 +1,42 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+from unittest.mock import PropertyMock, patch
+
 from django.test import override_settings
 from django.urls import reverse as urlreverse
 
-from ietf.person.factories import PersonFactory
+from ietf.meeting.factories import (
+    AttendedFactory,
+    MeetingFactory,
+    RegistrationFactory,
+)
+from ietf.meeting.models import Registration
+from ietf.person.factories import EmailFactory, PersonFactory
 from ietf.utils.test_utils import TestCase
 
 
+@override_settings(
+    APP_API_TOKENS={"ietf.api.meeting.registration.attended": "valid-token"}
+)
 class MeetingsAttendedByEmailTests(TestCase):
     VIEWNAME = "ietf.api.meeting.registration.attended"
-    TOKEN_ENDPOINT = "ietf.api.meeting.registration.attended"
 
     def setUp(self):
         super().setUp()
         self.person = PersonFactory()
 
-    @override_settings(APP_API_TOKENS={TOKEN_ENDPOINT: "valid-token"})
+    def attended_for(self, email=None):
+        """Retrieve the "attended" list for an email address"""
+        url = urlreverse(
+            self.VIEWNAME, kwargs={"email": email or self.person.email_address()}
+        )
+        r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
+        self.assertEqual(r.status_code, 200)
+        return r.json()["attended"]
+
+    @staticmethod
+    def ietf_meeting(number):
+        return MeetingFactory(type_id="ietf", number=number, populate_schedule=False)
+
     def test_endpoint_is_plumbed(self):
         url = urlreverse(self.VIEWNAME, kwargs={"email": self.person.email_address()})
         # bad/missing API keys
@@ -22,7 +44,7 @@ class MeetingsAttendedByEmailTests(TestCase):
         self.assertEqual(r.status_code, 403, "should require api key")
         r = self.client.get(url, headers={"X-Api-Key": "invalid-token"})
         self.assertEqual(r.status_code, 403, "should require valid api key")
-        
+
         # valid request
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
         self.assertEqual(r.status_code, 200, "should accept valid api key")
@@ -34,5 +56,111 @@ class MeetingsAttendedByEmailTests(TestCase):
         r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
         self.assertEqual(r.status_code, 404, "404 for no such Person")
 
-    
-    
+    def test_lists_registrations_with_attendance_evidence(self):
+        """Registrations for IETF 110+ that were attended are listed
+
+        Attendance is indicated by the attended flag, the checkedin flag, or an Attended
+        record. These records only had their modern form starting at IETF 110.
+        """
+        attended = self.ietf_meeting("118")
+        RegistrationFactory(meeting=attended, person=self.person, attended=True)
+        checkedin = self.ietf_meeting("119")
+        RegistrationFactory(meeting=checkedin, person=self.person, checkedin=True)
+        session_attended = self.ietf_meeting("120")
+        RegistrationFactory(meeting=session_attended, person=self.person)
+        AttendedFactory(
+            session__meeting=session_attended,
+            session__add_to_schedule=False,  # these meetings have no timeslots
+            person=self.person,
+        )
+
+        # another person's registrations for the same meetings must not appear
+        other_person = PersonFactory()
+        for meeting in [attended, checkedin, session_attended]:
+            RegistrationFactory(meeting=meeting, person=other_person, attended=True)
+
+        self.assertCountEqual(
+            [entry["meeting"] for entry in self.attended_for()], ["118", "119", "120"]
+        )
+
+    def test_excludes_registrations_without_attendance_evidence(self):
+        """Only attended IETF meetings from 110 onwards are reported"""
+        RegistrationFactory(meeting=self.ietf_meeting("118"), person=self.person)
+        RegistrationFactory(
+            meeting=self.ietf_meeting("109"), person=self.person, attended=True
+        )
+        RegistrationFactory(
+            meeting=MeetingFactory(type_id="interim", populate_schedule=False),
+            person=self.person,
+            attended=True,
+        )
+
+        self.assertEqual(self.attended_for(), [])
+
+    def test_reports_attendance_and_ticket_type(self):
+        """Ticket details are taken from the Registration's plenary_* properties"""
+        RegistrationFactory(
+            meeting=self.ietf_meeting("118"), person=self.person, attended=True
+        )
+
+        with (
+            patch.object(
+                Registration, "plenary_attendance_type", new_callable=PropertyMock
+            ) as attendance_type,
+            patch.object(
+                Registration, "plenary_ticket_type", new_callable=PropertyMock
+            ) as ticket_type,
+        ):
+            attendance_type.return_value = "onsite"
+            ticket_type.return_value = "week_pass"
+            self.assertEqual(
+                self.attended_for(),
+                [
+                    {
+                        "meeting": "118",
+                        "attendance_type": "onsite",
+                        "ticket_type": "week_pass",
+                    }
+                ],
+            )
+
+            # absent ticket details are reported as null
+            attendance_type.return_value = None
+            ticket_type.return_value = None
+            self.assertEqual(
+                self.attended_for(),
+                [{"meeting": "118", "attendance_type": None, "ticket_type": None}],
+            )
+
+    def test_finds_person_by_any_email_address(self):
+        """Any of the Person's email addresses identifies them"""
+        RegistrationFactory(
+            meeting=self.ietf_meeting("118"), person=self.person, attended=True
+        )
+        secondary_email = EmailFactory(person=self.person)
+
+        by_secondary = self.attended_for(email=secondary_email.address)
+        self.assertEqual([entry["meeting"] for entry in by_secondary], ["118"])
+        self.assertEqual(by_secondary, self.attended_for())
+
+    def test_excludes_non_plenary_registrations(self):
+        """Registrations without an onsite or remote plenary ticket are not reported"""
+        RegistrationFactory(
+            meeting=self.ietf_meeting("118"),
+            person=self.person,
+            attended=True,
+            with_ticket={"attendance_type_id": "onsite", "ticket_type_id": "week_pass"},
+        )
+        RegistrationFactory(
+            meeting=self.ietf_meeting("119"),
+            person=self.person,
+            attended=True,
+            with_ticket={
+                "attendance_type_id": "hackathon_remote",
+                "ticket_type_id": "unknown",
+            },
+        )
+
+        attended = self.attended_for()
+        self.assertEqual([entry["meeting"] for entry in attended], ["118"])
+        self.assertEqual({entry["attendance_type"] for entry in attended}, {"onsite"})

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -1,0 +1,38 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+from django.test import override_settings
+from django.urls import reverse as urlreverse
+
+from ietf.person.factories import PersonFactory
+from ietf.utils.test_utils import TestCase
+
+
+class MeetingsAttendedByEmailTests(TestCase):
+    VIEWNAME = "ietf.api.meeting.registration.attended"
+    TOKEN_ENDPOINT = "ietf.api.meeting.registration.attended"
+
+    def setUp(self):
+        super().setUp()
+        self.person = PersonFactory()
+
+    @override_settings(APP_API_TOKENS={TOKEN_ENDPOINT: "valid-token"})
+    def test_endpoint_is_plumbed(self):
+        url = urlreverse(self.VIEWNAME, kwargs={"email": self.person.email_address()})
+        # bad/missing API keys
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 403, "should require api key")
+        r = self.client.get(url, headers={"X-Api-Key": "invalid-token"})
+        self.assertEqual(r.status_code, 403, "should require valid api key")
+        
+        # valid request
+        r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
+        self.assertEqual(r.status_code, 200, "should accept valid api key")
+        self.assertEqual(r.json(), {"attended": []})
+
+        # nonexistent person
+        self.person.email_set.update(person=None)  # detach email
+        self.person.delete()
+        r = self.client.get(url, headers={"X-Api-Key": "valid-token"})
+        self.assertEqual(r.status_code, 404, "404 for no such Person")
+
+    
+    

--- a/ietf/meeting/tests_models.py
+++ b/ietf/meeting/tests_models.py
@@ -17,8 +17,8 @@ from ietf.meeting.factories import (
     AttendedFactory,
     SessionPresentationFactory,
 )
-from ietf.meeting.factories import RegistrationFactory
-from ietf.meeting.models import Session
+from ietf.meeting.factories import RegistrationFactory, RegistrationTicketFactory
+from ietf.meeting.models import Registration, RegistrationTicket, Session
 from ietf.utils.test_utils import TestCase
 from ietf.utils.timezone import date_today, datetime_today
 
@@ -253,7 +253,7 @@ class SessionTests(TestCase):
 
     def test_chat_room_name(self):
         session = SessionFactory(group__acronym="xyzzy")
-        self.assertEqual(session.chat_room_name(), "xyzzy") 
+        self.assertEqual(session.chat_room_name(), "xyzzy")
         session.type_id = "plenary"
         self.assertEqual(session.chat_room_name(), "plenary")
         session.chat_room = "fnord"
@@ -322,4 +322,173 @@ class SessionTests(TestCase):
         self.assertEqual(
             f"IETF-ACRO-{session_time:%Y%m%d-%H%M}",  # n.b., time in label is UTC
             session._session_recording_url_label(),
+        )
+
+
+class RegistrationTests(TestCase):
+    # A ticket counts toward the plenary meeting only if both its attendance type
+    # and its ticket type are applicable. Applicable tickets are ranked by
+    # attendance type (onsite, then remote), then by ticket type (student,
+    # week_pass, one_day, then unknown), then by pk.
+    #
+    # Each case is a label, the tickets to create as (attendance_type_id,
+    # ticket_type_id) pairs, and the expected plenary_attendance_type and
+    # plenary_ticket_type.
+    PLENARY_TICKET_CASES = [
+        ("no tickets at all", [], None, None),
+        ("a single plenary ticket", [("onsite", "week_pass")], "onsite", "week_pass"),
+        (
+            "onsite outranks remote",
+            [("remote", "week_pass"), ("onsite", "week_pass")],
+            "onsite",
+            "week_pass",
+        ),
+        (
+            "attendance type outranks ticket type",
+            [("remote", "student"), ("onsite", "one_day")],
+            "onsite",
+            "one_day",
+        ),
+        (
+            "student outranks one_day",
+            [("onsite", "one_day"), ("onsite", "student")],
+            "onsite",
+            "student",
+        ),
+        (
+            "unknown ticket type ranks last",
+            [("onsite", "unknown"), ("onsite", "one_day")],
+            "onsite",
+            "one_day",
+        ),
+        (
+            "non-plenary attendance type is ignored",
+            [("hackathon_onsite", "hackathon_only")],
+            None,
+            None,
+        ),
+        (
+            "non-plenary ticket type disqualifies its ticket entirely",
+            [("onsite", "hackathon_combo"), ("remote", "week_pass")],
+            "remote",
+            "week_pass",
+        ),
+        (
+            "unknown is a plenary ticket type but not an attendance type",
+            [("unknown", "week_pass")],
+            None,
+            None,
+        ),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.meeting = MeetingFactory(type_id="ietf")
+
+    def create_registration(self, tickets):
+        """Create a Registration with the given (attendance, ticket) type pairs"""
+        registration = RegistrationFactory(meeting=self.meeting, with_ticket=False)
+        for attendance_type_id, ticket_type_id in tickets:
+            RegistrationTicketFactory(
+                registration=registration,
+                attendance_type_id=attendance_type_id,
+                ticket_type_id=ticket_type_id,
+            )
+        return registration
+
+    def test_plenary_ticket_details(self):
+        """The plenary_* properties report the most representative ticket"""
+        for label, tickets, attendance_type, ticket_type in self.PLENARY_TICKET_CASES:
+            with self.subTest(label):
+                registration = self.create_registration(tickets)
+                # refetch so the properties cannot see state left by the factories
+                registration = Registration.objects.get(pk=registration.pk)
+                self.assertEqual(registration.plenary_attendance_type, attendance_type)
+                self.assertEqual(registration.plenary_ticket_type, ticket_type)
+
+    def test_plenary_ticket_details_annotated(self):
+        """The annotations agree with the properties
+
+        The properties return the annotations when they are present, so the two
+        must rank tickets identically.
+        """
+        for label, tickets, attendance_type, ticket_type in self.PLENARY_TICKET_CASES:
+            with self.subTest(label):
+                registration = self.create_registration(tickets)
+                annotated = Registration.objects.with_plenary_ticket_details().get(
+                    pk=registration.pk
+                )
+                self.assertEqual(annotated._attendance_type, attendance_type)
+                self.assertEqual(annotated._ticket_type, ticket_type)
+                self.assertEqual(annotated.plenary_attendance_type, attendance_type)
+                self.assertEqual(annotated.plenary_ticket_type, ticket_type)
+
+    def test_plenary_ticket_details_tie_break(self):
+        """Tickets that rank equally are resolved by pk
+
+        The annotations cannot distinguish these tickets - they expose only the
+        chosen ticket's type slugs, which are identical when tickets tie.
+        """
+        registration = self.create_registration(
+            [("onsite", "week_pass"), ("onsite", "week_pass")]
+        )
+        first, second = registration.tickets.order_by("pk")
+        self.assertEqual(
+            list(registration.tickets.order_by_most_representative()), [first, second]
+        )
+        self.assertEqual(
+            Registration.objects.get(pk=registration.pk)._plenary_ticket, first
+        )
+
+    def test_plenary_ticket_details_query_counts(self):
+        """The annotation replaces the per-registration ticket queries"""
+        for tickets in [
+            [("onsite", "week_pass")],
+            [("remote", "student")],
+            [("hackathon_onsite", "hackathon_only")],
+        ]:
+            self.create_registration(tickets)
+        expected = [("onsite", "week_pass"), ("remote", "student"), (None, None)]
+
+        annotated = Registration.objects.with_plenary_ticket_details().order_by("pk")
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                [(r.plenary_attendance_type, r.plenary_ticket_type) for r in annotated],
+                expected,
+            )
+
+        # Without the annotation, one query for the registrations plus one per
+        # registration. Both properties share the _plenary_ticket cache, so
+        # reading them together does not double the count.
+        plain = Registration.objects.order_by("pk")
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                [(r.plenary_attendance_type, r.plenary_ticket_type) for r in plain],
+                expected,
+            )
+
+    def test_order_by_most_representative(self):
+        """Non-plenary tickets are dropped and the rest are ranked"""
+        registration = self.create_registration(
+            [
+                ("remote", "one_day"),
+                ("hackathon_onsite", "hackathon_only"),
+                ("onsite", "unknown"),
+                ("onsite", "student"),
+                ("remote", "week_pass"),
+                ("unknown", "week_pass"),
+            ]
+        )
+        tickets = {
+            (ticket.attendance_type_id, ticket.ticket_type_id): ticket
+            for ticket in registration.tickets.all()
+        }
+        self.assertEqual(
+            list(RegistrationTicket.objects.order_by_most_representative()),
+            [
+                tickets[("onsite", "student")],
+                tickets[("onsite", "unknown")],
+                tickets[("remote", "week_pass")],
+                tickets[("remote", "one_day")],
+            ],
         )

--- a/ietf/meeting/tests_models.py
+++ b/ietf/meeting/tests_models.py
@@ -347,10 +347,12 @@ class RegistrationTests(TestCase):
             self.create_registration([("onsite", ticket_type.pk)]).pk
             for ticket_type in RegistrationTicketTypeName.objects.filter(used=True)
         ]
-
         for attendance_type in AttendanceTypeName.objects.filter(used=True):
             if attendance_type.pk == "onsite":
                 continue  # we already have one
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True):
+                self.create_registration([(attendance_type.pk, ticket_type.pk)])
+
         self.assertCountEqual(
             Registration.objects.onsite().values_list("pk", flat=True),
             expected_onsite_pks,
@@ -361,13 +363,42 @@ class RegistrationTests(TestCase):
             self.create_registration([("remote", ticket_type.pk)]).pk
             for ticket_type in RegistrationTicketTypeName.objects.filter(used=True)
         ]
-
         for attendance_type in AttendanceTypeName.objects.filter(used=True):
-            if attendance_type.pk == "onsite":
+            if attendance_type.pk == "remote":
                 continue  # we already have one
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True):
+                self.create_registration([(attendance_type.pk, ticket_type.pk)])
+
         self.assertCountEqual(
             Registration.objects.remote().values_list("pk", flat=True),
             expected_remote_pks,
+        )
+
+    def test_onsite_or_remote(self):
+        expected_onsite_pks = [
+            self.create_registration([("onsite", ticket_type.pk)]).pk
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True)
+        ]
+        expected_remote_pks = [
+            self.create_registration([("remote", ticket_type.pk)]).pk
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True)
+        ]
+        for attendance_type in AttendanceTypeName.objects.filter(used=True):
+            if attendance_type.pk in ["onsite", "remote"]:
+                continue  # we already have one
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True):
+                self.create_registration([(attendance_type.pk, ticket_type.pk)])
+        # create a remote ticket for an onsite registration to probe whether this
+        # leads to duplicate records
+        RegistrationTicketFactory(
+            # arbitrary registration
+            registration=(Registration.objects.get(pk=expected_onsite_pks[0])),
+            attendance_type_id="remote",
+            ticket_type_id="week_pass",
+        )
+        self.assertCountEqual(
+            Registration.objects.onsite_or_remote().values_list("pk", flat=True),
+            expected_onsite_pks + expected_remote_pks,
         )
 
     # A ticket counts toward the plenary meeting only if both its attendance type

--- a/ietf/meeting/tests_models.py
+++ b/ietf/meeting/tests_models.py
@@ -19,6 +19,7 @@ from ietf.meeting.factories import (
 )
 from ietf.meeting.factories import RegistrationFactory, RegistrationTicketFactory
 from ietf.meeting.models import Registration, RegistrationTicket, Session
+from ietf.name.models import RegistrationTicketTypeName, AttendanceTypeName
 from ietf.utils.test_utils import TestCase
 from ietf.utils.timezone import date_today, datetime_today
 
@@ -326,6 +327,49 @@ class SessionTests(TestCase):
 
 
 class RegistrationTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.meeting = MeetingFactory(type_id="ietf")
+
+    def create_registration(self, tickets):
+        """Create a Registration with the given (attendance, ticket) type pairs"""
+        registration = RegistrationFactory(meeting=self.meeting, with_ticket=False)
+        for attendance_type_id, ticket_type_id in tickets:
+            RegistrationTicketFactory(
+                registration=registration,
+                attendance_type_id=attendance_type_id,
+                ticket_type_id=ticket_type_id,
+            )
+        return registration
+
+    def test_onsite(self):
+        expected_onsite_pks = [
+            self.create_registration([("onsite", ticket_type.pk)]).pk
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True)
+        ]
+
+        for attendance_type in AttendanceTypeName.objects.filter(used=True):
+            if attendance_type.pk == "onsite":
+                continue  # we already have one
+        self.assertCountEqual(
+            Registration.objects.onsite().values_list("pk", flat=True),
+            expected_onsite_pks,
+        )
+
+    def test_remote(self):
+        expected_remote_pks = [
+            self.create_registration([("remote", ticket_type.pk)]).pk
+            for ticket_type in RegistrationTicketTypeName.objects.filter(used=True)
+        ]
+
+        for attendance_type in AttendanceTypeName.objects.filter(used=True):
+            if attendance_type.pk == "onsite":
+                continue  # we already have one
+        self.assertCountEqual(
+            Registration.objects.remote().values_list("pk", flat=True),
+            expected_remote_pks,
+        )
+
     # A ticket counts toward the plenary meeting only if both its attendance type
     # and its ticket type are applicable. Applicable tickets are ranked by
     # attendance type (onsite, then remote), then by ticket type (student,
@@ -380,21 +424,6 @@ class RegistrationTests(TestCase):
             None,
         ),
     ]
-
-    def setUp(self):
-        super().setUp()
-        self.meeting = MeetingFactory(type_id="ietf")
-
-    def create_registration(self, tickets):
-        """Create a Registration with the given (attendance, ticket) type pairs"""
-        registration = RegistrationFactory(meeting=self.meeting, with_ticket=False)
-        for attendance_type_id, ticket_type_id in tickets:
-            RegistrationTicketFactory(
-                registration=registration,
-                attendance_type_id=attendance_type_id,
-                ticket_type_id=ticket_type_id,
-            )
-        return registration
 
     def test_plenary_ticket_details(self):
         """The plenary_* properties report the most representative ticket"""

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -4838,19 +4838,14 @@ def proceedings_attendees(request, num=None):
         onsite_pks = frozenset(p.pk for p in onsite)
         remote_pks = frozenset(p.pk for p in remote)
 
+        regs_to_consider = (
+            Registration.objects.filter(meeting__number=num)
+            .with_plenary_ticket_details()
+            .select_related("person")
+        )
         regs = [
-            reg
-            for reg in Registration.objects.onsite()
-            .filter(meeting__number=num)
-            .select_related("person")
-            if reg.person.pk in onsite_pks
-        ] + [
-            reg
-            for reg in Registration.objects.remote()
-            .filter(meeting__number=num)
-            .select_related("person")
-            if reg.person.pk in remote_pks
-        ]
+            reg for reg in regs_to_consider.onsite() if reg.person.pk in onsite_pks
+        ] + [reg for reg in regs_to_consider.remote() if reg.person.pk in remote_pks]
         registrations = sorted(regs, key=lambda x: (x.last_name, x.first_name))
 
         country_codes = [r.country_code for r in registrations if r.country_code]

--- a/ietf/templates/meeting/proceedings_attendees.html
+++ b/ietf/templates/meeting/proceedings_attendees.html
@@ -80,7 +80,7 @@
                 <td>{{ reg.first_name }}</td>
                 <td>{{ reg.affiliation }}</td>
                 <td>{{ reg.country_code }}</td>
-                <td>{{ reg.attendance_type }}</td>
+                <td>{{ reg.plenary_attendance_type }}</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
Adds an API that looks up plenary meeting attendance for a person by email address. Uses any email address (including inactive). Only returns data for meeting 110 onward, where we have modern attendance data. The filtering is intended to agree with the current attendance calculations - if it does not, that is a bug.

Will return attendance type as "onsite" or "remote". Only "student", "week_pass", "one_day", or "unknown" ticket types are returned. I believe these are the only combinations that reflect plenary registration / attendance.

Refactors the `Registration.attendance_type` property to work with bulk operations. Adds tests.

Eliminates per-row queries in the `proceedings_attendees()` view, dropping it from ~ 2000 to 2.

A few cases where one person has multiple `Registration`s for a single meeting exist. These are represented as multiple entries with the same `"meeting"` value in the returned list. I.e., each individual `Registration` is resolved to a single attendance type / ticket type, but no attempt to reconcile multiple `Registration` records for a single meeting.

Output looks like:
```json
{
  "attended": [
    {
      "meeting": "110",
      "attendance_type": "remote",
      "ticket_type": "unknown"
    },
    {
      "meeting": "111",
      "attendance_type": "remote",
      "ticket_type": "week_pass"
    },
    {
      "meeting": "112",
      "attendance_type": "remote",
      "ticket_type": "unknown"
    },
    {
      "meeting": "113",
      "attendance_type": "remote",
      "ticket_type": "week_pass"
    },
    {
      "meeting": "114",
      "attendance_type": "remote",
      "ticket_type": "week_pass"
    }
  ]
}
```
