### PR TITLE
fix: sanitize even more xml-unfriendly chars

### DIFF
--- a/ietf/api/__init__.py
+++ b/ietf/api/__init__.py
@@ -266,7 +266,8 @@ class ToOneField(tastypie.fields.ToOneField):
 # Replace each with its Unicode control picture (U+2400 + codepoint) so the
 # substitution is lossless and the result is valid XML.
 _XML_INVALID_CTRL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
-
+# XML 1.0 also forbids the surrogate blocks and non-chars \ufffe and \uffff 
+_XML_INVALID_UNICODE_RE = re.compile(r"[\ud800-\udfff\ufffe\uffff]")
 
 class Serializer(tastypie.serializers.Serializer):
     OPTION_ESCAPE_XML_INVALID = "datatracker-escape-xml-invalid"
@@ -290,6 +291,8 @@ class Serializer(tastypie.serializers.Serializer):
             simple_data = _XML_INVALID_CTRL_RE.sub(
                 lambda m: chr(ord(m.group()) + 0x2400), simple_data
             )
+            # Replace outright invalid unicode chars with the replacement char
+            simple_data = _XML_INVALID_UNICODE_RE.sub("\uFFFD", simple_data)
         return simple_data
 
     def to_etree(self, data, options=None, name=None, depth=0):

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -5,6 +5,7 @@ import copy
 import datetime
 import json
 import html
+from itertools import chain
 from unittest import mock
 import os
 import sys
@@ -1877,7 +1878,16 @@ class TastypieApiTests(ResourceTestCaseMixin, TestCase):
         # Every control character that XML 1.0 forbids must be escaped rather than
         # causing a ValueError.  This is the class of characters that triggered the
         # production exception (lxml.etree._utf8 rejects them all).
-        invalid_chars = [chr(c) for c in list(range(0x00, 0x09)) + [0x0b, 0x0c] + list(range(0x0e, 0x20))]
+        invalid_chars = [
+            chr(c)
+            for c in chain(
+                range(0x00, 0x09),
+                [0x0B, 0x0C],
+                range(0x0E, 0x20),
+                range(0xD800, 0xDFFF),
+                [0xFFFE, 0xFFFF],
+            )
+        ]
         for ch in invalid_chars:
             try:
                 serializer.to_etree(f"string with {ch!r} in it")

--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -1876,25 +1876,47 @@ class TastypieApiTests(ResourceTestCaseMixin, TestCase):
         except ValueError:
             self.fail("serializer.to_etree raised ValueError on an ordinary string")
         # Every control character that XML 1.0 forbids must be escaped rather than
-        # causing a ValueError.  This is the class of characters that triggered the
-        # production exception (lxml.etree._utf8 rejects them all).
-        invalid_chars = [
-            chr(c)
-            for c in chain(
-                range(0x00, 0x09),
-                [0x0B, 0x0C],
-                range(0x0E, 0x20),
-                range(0xD800, 0xDFFF),
-                [0xFFFE, 0xFFFF],
-            )
+        # causing a ValueError. These should be replaced by a Unicode picture char.
+        control_chars = [
+            chr(c) for c in chain(range(0x00, 0x09), [0x0B, 0x0C], range(0x0E, 0x20))
         ]
-        for ch in invalid_chars:
+        for ch in control_chars:
             try:
-                serializer.to_etree(f"string with {ch!r} in it")
+                elt = serializer.to_etree(f"string with {str(ch)} in it")
             except ValueError:
                 self.fail(
                     f"serializer.to_etree raised ValueError on a string "
                     f"containing control character U+{ord(ch):04X}"
+                )
+            else:
+                self.assertIn(
+                    chr(0x2400 + ord(ch)),
+                    elt.text,
+                    (
+                        f"character U+{ord(ch):04X} not replaced with "
+                        f"Unicode control picture character"
+                    ),
+                )
+
+        # Unicode surrogate ranges and non-characters are not permitted in XML 1.0
+        # either. These should be replaced by the Unicode replacement character.
+        invalid_chars = [chr(c) for c in chain(range(0xD800, 0xDFFF), [0xFFFE, 0xFFFF])]
+        for ch in invalid_chars:
+            try:
+                elt = serializer.to_etree(f"string with {str(ch)} in it")
+            except ValueError:
+                self.fail(
+                    f"serializer.to_etree raised ValueError on a string "
+                    f"containing invalid character U+{ord(ch):04X}"
+                )
+            else:
+                self.assertIn(
+                    chr(0xFFFD),
+                    elt.text,
+                    (
+                        f"character U+{ord(ch):04X} not replaced with "
+                        f"Unicode replacement char"
+                     ),
                 )
 
     def test_post_detail_is_not_allowed(self):


### PR DESCRIPTION
Adds the remaining Unicode ranges forbidden by XML 1.0 to the lists replaced before being rendered as XML via Tastypie. These are the surrogate ranges and explicitly non-character code points. Replaces these with the `\ufffd` � character when rendering.