### PR TITLE
feat: API Key and person UUID based meetecho APIs

### DIFF
--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -99,6 +99,11 @@ urlpatterns = [
         name="ietf.api.meeting.session.bluesheet",
     ),
     path(
+        "meeting/session/<int:session_id>/attendees/",
+        meeting_api.SessionAttendeesView.as_view(),
+        name="ietf.api.meeting.session.attendees",
+    ),
+    path(
         "meeting/session/<int:session_id>/chatlog/",
         meeting_api.SessionChatlogView.as_view(),
         name="ietf.api.meeting.session.chatlog",

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -81,6 +81,33 @@ urlpatterns = [
     url(r'^meeting/(?P<num>[A-Za-z0-9._+-]+)/agenda-data$', meeting_views.api_get_agenda_data),
     # Meeting session materials
     url(r'^meeting/session/(?P<session_id>[A-Za-z0-9._+-]+)/materials$', meeting_views.api_get_session_materials),
+    # Session data pushed by the conference system. api-key authenticated
+    # counterparts of the personal-api-key endpoints above.
+    path(
+        "meeting/session/<int:session_id>/video-url/",
+        meeting_api.SessionVideoUrlView.as_view(),
+        name="ietf.api.meeting.session.video_url",
+    ),
+    path(
+        "meeting/session/<int:session_id>/recording-name/",
+        meeting_api.SessionRecordingNameView.as_view(),
+        name="ietf.api.meeting.session.recording_name",
+    ),
+    path(
+        "meeting/session/<int:session_id>/bluesheet/",
+        meeting_api.SessionBluesheetView.as_view(),
+        name="ietf.api.meeting.session.bluesheet",
+    ),
+    path(
+        "meeting/session/<int:session_id>/chatlog/",
+        meeting_api.SessionChatlogView.as_view(),
+        name="ietf.api.meeting.session.chatlog",
+    ),
+    path(
+        "meeting/session/<int:session_id>/polls/",
+        meeting_api.SessionPollsView.as_view(),
+        name="ietf.api.meeting.session.polls",
+    ),
     url(r'^meeting/registration/attended/(?P<email>[^/\x00]+)/?$', meeting_api.MeetingsAttendedByEmail.as_view(), name="ietf.api.meeting.registration.attended"),
     # Let MeetEcho upload bluesheets
     url(r'^notify/meeting/bluesheet/?$', meeting_views.api_upload_bluesheet),

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -113,6 +113,12 @@ urlpatterns = [
         meeting_api.SessionPollsView.as_view(),
         name="ietf.api.meeting.session.polls",
     ),
+    # Before the email-keyed route below so "by-uuid" is never read as an address.
+    path(
+        "meeting/registration/attended/by-uuid/<anycase_uuid:uuid>/",
+        meeting_api.MeetingsAttendedByUuid.as_view(),
+        name="ietf.api.meeting.registration.attended_by_uuid",
+    ),
     url(r'^meeting/registration/attended/(?P<email>[^/\x00]+)/?$', meeting_api.MeetingsAttendedByEmail.as_view(), name="ietf.api.meeting.registration.attended"),
     # Let MeetEcho upload bluesheets
     url(r'^notify/meeting/bluesheet/?$', meeting_views.api_upload_bluesheet),

--- a/ietf/api/urls.py
+++ b/ietf/api/urls.py
@@ -31,6 +31,12 @@ person_router.register(
     "uuid", person_uuid_api.PersonUUIDViewSet, basename="person-uuid"
 )
 
+# Session data pushed by the conference system
+meeting_router = PrefixedSimpleRouter(
+    use_regex_path=False, name_prefix="ietf.api.meeting"
+)
+meeting_router.register("session", meeting_api.SessionDataViewSet, basename="session")
+
 # todo more general name for this API?
 red_router = PrefixedSimpleRouter(name_prefix="ietf.api.red_api")  # red api router
 red_router.register("doc", doc_api.RfcViewSet)
@@ -48,6 +54,7 @@ urlpatterns = [
     # --- DRF API ---
     # path("core/", include(core_router.urls)),
     path("purple/", include("ietf.api.urls_rpc")),
+    path("meeting/", include(meeting_router.urls)),
     path("red/", include(red_router.urls)),
     path("schema/", SpectacularAPIView.as_view()),
     #
@@ -81,38 +88,6 @@ urlpatterns = [
     url(r'^meeting/(?P<num>[A-Za-z0-9._+-]+)/agenda-data$', meeting_views.api_get_agenda_data),
     # Meeting session materials
     url(r'^meeting/session/(?P<session_id>[A-Za-z0-9._+-]+)/materials$', meeting_views.api_get_session_materials),
-    # Session data pushed by the conference system. api-key authenticated
-    # counterparts of the personal-api-key endpoints above.
-    path(
-        "meeting/session/<int:session_id>/video-url/",
-        meeting_api.SessionVideoUrlView.as_view(),
-        name="ietf.api.meeting.session.video_url",
-    ),
-    path(
-        "meeting/session/<int:session_id>/recording-name/",
-        meeting_api.SessionRecordingNameView.as_view(),
-        name="ietf.api.meeting.session.recording_name",
-    ),
-    path(
-        "meeting/session/<int:session_id>/bluesheet/",
-        meeting_api.SessionBluesheetView.as_view(),
-        name="ietf.api.meeting.session.bluesheet",
-    ),
-    path(
-        "meeting/session/<int:session_id>/attendees/",
-        meeting_api.SessionAttendeesView.as_view(),
-        name="ietf.api.meeting.session.attendees",
-    ),
-    path(
-        "meeting/session/<int:session_id>/chatlog/",
-        meeting_api.SessionChatlogView.as_view(),
-        name="ietf.api.meeting.session.chatlog",
-    ),
-    path(
-        "meeting/session/<int:session_id>/polls/",
-        meeting_api.SessionPollsView.as_view(),
-        name="ietf.api.meeting.session.polls",
-    ),
     # Before the email-keyed route below so "by-uuid" is never read as an address.
     path(
         "meeting/registration/attended/by-uuid/<anycase_uuid:uuid>/",

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -3,8 +3,9 @@ from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import IntegerField
 from django.db.models.functions import Cast
+from django.http import Http404
 from django.template.loader import render_to_string
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import generics, serializers, status
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
@@ -28,6 +29,37 @@ from ietf.meeting.utils import (
     save_session_video_url,
 )
 from ietf.person.models import Person, PersonUUID
+from ietf.person.utils import get_person_uuid_object
+
+
+def attended_registrations(person: Person):
+    meetings_with_data = (
+        Meeting.objects.filter(type="ietf")
+        .annotate(number_as_int=Cast("number", output_field=IntegerField()))
+        .exclude(number_as_int__lt=110)
+        .values_list("pk")
+    )
+    has_attended_record = (
+        person.attended_set.filter(
+            session__meeting_id__in=meetings_with_data,
+            session__meeting__type="ietf",
+        )
+        .values_list("session__meeting__id", flat=True)
+        .distinct()
+    )
+    return sorted(
+        [
+            reg
+            for reg in (
+                person.registration_set.onsite_or_remote()
+                .with_plenary_ticket_details()
+                .filter(meeting_id__in=meetings_with_data)
+                .select_related("meeting")
+            )
+            if (reg.attended or reg.checkedin or reg.meeting_id in has_attended_record)
+        ],
+        key=lambda reg: reg.meeting.date,
+    )
 
 
 class MeetingsAttendedByEmail(generics.RetrieveAPIView):
@@ -45,42 +77,43 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
     def get_object(self):
         person = super().get_object()
         assert isinstance(person, Person)
-        person.attended_registrations = self._attended_registrations(person)
+        person.attended_registrations = attended_registrations(person)
         return person
 
-    @staticmethod
-    def _attended_registrations(person: Person):
-        meetings_with_data = (
-            Meeting.objects.filter(type="ietf")
-            .annotate(number_as_int=Cast("number", output_field=IntegerField()))
-            .exclude(number_as_int__lt=110)
-            .values_list("pk")
-        )
-        has_attended_record = (
-            person.attended_set.filter(
-                session__meeting_id__in=meetings_with_data,
-                session__meeting__type="ietf",
-            )
-            .values_list("session__meeting__id", flat=True)
-            .distinct()
-        )
-        return sorted(
-            [
-                reg
-                for reg in (
-                    person.registration_set.onsite_or_remote()
-                    .with_plenary_ticket_details()
-                    .filter(meeting_id__in=meetings_with_data)
-                    .select_related("meeting")
-                )
-                if (
-                    reg.attended
-                    or reg.checkedin
-                    or reg.meeting_id in has_attended_record
-                )
-            ],
-            key=lambda reg: reg.meeting.date,
-        )
+
+@extend_schema(tags=["meeting"])
+@extend_schema_view(
+    get=extend_schema(
+        operation_id="meeting_registration_attended_by_uuid",
+        summary="List the IETF meetings a person attended",
+        description=(
+            "Lists the person's attended IETF meeting registrations from IETF 110 "
+            "onwards, which is where these records took their modern form.\n\n"
+            "Accepts any UUID the datatracker has issued for the person, so a UUID that "
+            "stopped being primary because of a merge still resolves. A 404 means no "
+            "person has this UUID."
+        ),
+        responses={200: PersonAttendedMeetingsSerializer},
+    )
+)
+class MeetingsAttendedByUuid(generics.RetrieveAPIView):
+    """List meetings attended by a person identified by Person UUID
+
+    The UUID-keyed counterpart of MeetingsAttendedByEmail. An email address identifies a
+    person only until they stop using it; a UUID the datatracker issued always resolves.
+    """
+
+    queryset = Person.objects.all()
+    serializer_class = PersonAttendedMeetingsSerializer
+    api_key_endpoint = "ietf.api.meeting.registration.attended_by_uuid"
+
+    def get_object(self):
+        person_uuid = get_person_uuid_object(self.kwargs["uuid"])
+        if person_uuid is None:
+            raise Http404("No such person identifier")
+        person = person_uuid.person
+        person.attended_registrations = attended_registrations(person)
+        return person
 
 
 @extend_schema(tags=["meeting"])

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -1,5 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 from django.core.files.base import ContentFile
+from django.db import transaction
 from django.db.models import IntegerField
 from django.db.models.functions import Cast
 from django.template.loader import render_to_string
@@ -9,9 +10,10 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ietf.meeting.models import Meeting, Session
+from ietf.meeting.models import Attended, Meeting, Session
 from ietf.meeting.serializers import (
     PersonAttendedMeetingsSerializer,
+    SessionAttendeesSerializer,
     SessionBluesheetSerializer,
     SessionChatlogSerializer,
     SessionPollsSerializer,
@@ -20,11 +22,12 @@ from ietf.meeting.serializers import (
     SessionVideoUrlSerializer,
 )
 from ietf.meeting.utils import (
+    generate_bluesheet,
     save_bluesheet,
     save_session_json_doc,
     save_session_video_url,
 )
-from ietf.person.models import Person
+from ietf.person.models import Person, PersonUUID
 
 
 class MeetingsAttendedByEmail(generics.RetrieveAPIView):
@@ -184,6 +187,72 @@ class SessionBluesheetView(SessionDataView):
                 Person.objects.get(name="(System)"),
             ),
         )
+
+
+class SessionAttendeesView(SessionDataView):
+    api_key_endpoint = "ietf.api.meeting.session.attendees"
+    request_serializer_class = SessionAttendeesSerializer
+
+    @extend_schema(
+        operation_id="meeting_session_add_attendees",
+        summary="Record attendees for a session",
+        description=(
+            "Records an Attended row per attendee. An attendee already recorded for the "
+            "session keeps their existing join time.\n\n"
+            "Each attendee is identified by any UUID the datatracker has issued them, so "
+            "a UUID superseded by a merge still resolves. If any UUID fails to resolve "
+            "the whole request is rejected and nothing is recorded.\n\n"
+            "join_time must carry an explicit UTC offset.\n\n"
+            "For an interim meeting this also regenerates the session's bluesheet."
+        ),
+        request=SessionAttendeesSerializer,
+        responses={200: SessionUpdatedSerializer},
+    )
+    def post(self, request, session_id):
+        session = self.get_session(session_id)
+        attendees = self.validated(request)["attendees"]
+
+        person_by_uuid = {
+            row.uuid: row.person
+            for row in PersonUUID.objects.filter(
+                uuid__in=[a["person_uuid"] for a in attendees]
+            ).select_related("person")
+        }
+        unresolved = sorted(
+            {
+                str(a["person_uuid"])
+                for a in attendees
+                if a["person_uuid"] not in person_by_uuid
+            }
+        )
+        if unresolved:
+            # All-or-nothing: a partial success leaves the caller unable to tell which
+            # rows landed. TODO: investigate reporting per-attendee outcomes, as the
+            # ietf.person.api_uuid batch endpoints do.
+            raise serializers.ValidationError({"person_uuid": unresolved})
+
+        # One transaction so a bluesheet failure does not leave the Attended rows
+        # behind. Anything the bluesheet step wrote to disk is not rolled back.
+        with transaction.atomic():
+            # ignore_conflicts because attendees are pushed repeatedly as a session runs
+            Attended.objects.bulk_create(
+                [
+                    Attended(
+                        session=session,
+                        person=person_by_uuid[a["person_uuid"]],
+                        time=a["join_time"],
+                    )
+                    for a in attendees
+                ],
+                ignore_conflicts=True,
+            )
+
+            save_error = None
+            if session.meeting.type_id == "interim":
+                save_error = generate_bluesheet(
+                    request, session, Person.objects.get(name="(System)")
+                )
+            return self.applied(session, save_error)
 
 
 class SessionChatlogView(SessionDataView):

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -1,10 +1,29 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+from django.core.files.base import ContentFile
 from django.db.models import IntegerField
 from django.db.models.functions import Cast
-from rest_framework import generics
+from django.template.loader import render_to_string
+from drf_spectacular.utils import extend_schema
+from rest_framework import generics, serializers, status
+from rest_framework.generics import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from ietf.meeting.models import Meeting
-from ietf.meeting.serializers import PersonAttendedMeetingsSerializer
+from ietf.meeting.models import Meeting, Session
+from ietf.meeting.serializers import (
+    PersonAttendedMeetingsSerializer,
+    SessionBluesheetSerializer,
+    SessionChatlogSerializer,
+    SessionPollsSerializer,
+    SessionRecordingNameSerializer,
+    SessionUpdatedSerializer,
+    SessionVideoUrlSerializer,
+)
+from ietf.meeting.utils import (
+    save_bluesheet,
+    save_session_json_doc,
+    save_session_video_url,
+)
 from ietf.person.models import Person
 
 
@@ -58,4 +77,164 @@ class MeetingsAttendedByEmail(generics.RetrieveAPIView):
                 )
             ],
             key=lambda reg: reg.meeting.date,
+        )
+
+
+@extend_schema(tags=["meeting"])
+class SessionDataView(APIView):
+    """Base for the endpoints that push data about one session
+
+    The session is addressed by its pk. Only person references use UUIDs.
+
+    These endpoints authenticate an application by token, so there is no requesting
+    person; document events are authored by the (System) Person.
+    """
+
+    request_serializer_class: type
+
+    def get_session(self, session_id):
+        return get_object_or_404(Session, pk=session_id)
+
+    def validated(self, request):
+        serializer = self.request_serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
+    def applied(self, session, save_error=None):
+        if save_error:
+            raise serializers.ValidationError({"detail": save_error})
+        return Response(
+            SessionUpdatedSerializer({"session_id": session.pk}).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+class SessionVideoUrlView(SessionDataView):
+    api_key_endpoint = "ietf.api.meeting.session.video_url"
+    request_serializer_class = SessionVideoUrlSerializer
+
+    @extend_schema(
+        operation_id="meeting_session_set_video_url",
+        summary="Set a session's video recording URL",
+        description=(
+            "Points the session's video recording at the given URL, updating the newest "
+            "existing video recording document or creating one."
+        ),
+        request=SessionVideoUrlSerializer,
+        responses={200: SessionUpdatedSerializer},
+    )
+    def post(self, request, session_id):
+        session = self.get_session(session_id)
+        data = self.validated(request)
+        return self.applied(
+            session,
+            save_session_video_url(
+                session, data["url"], Person.objects.get(name="(System)")
+            ),
+        )
+
+
+class SessionRecordingNameView(SessionDataView):
+    api_key_endpoint = "ietf.api.meeting.session.recording_name"
+    request_serializer_class = SessionRecordingNameSerializer
+
+    @extend_schema(
+        operation_id="meeting_session_set_recording_name",
+        summary="Set the name of a session's recording",
+        description="Sets the name the recording is served under by the player.",
+        request=SessionRecordingNameSerializer,
+        responses={200: SessionUpdatedSerializer},
+    )
+    def post(self, request, session_id):
+        session = self.get_session(session_id)
+        data = self.validated(request)
+        session.meetecho_recording_name = data["name"]
+        session.save()
+        return self.applied(session)
+
+
+class SessionBluesheetView(SessionDataView):
+    api_key_endpoint = "ietf.api.meeting.session.bluesheet"
+    request_serializer_class = SessionBluesheetSerializer
+
+    @extend_schema(
+        operation_id="meeting_session_upload_bluesheet",
+        summary="Upload a session's bluesheet",
+        description=(
+            "Renders the entries into a new revision of the session's bluesheet "
+            "document. Entries are free text: they are what the uploader observed, and "
+            "are not resolved to datatracker persons."
+        ),
+        request=SessionBluesheetSerializer,
+        responses={200: SessionUpdatedSerializer},
+    )
+    def post(self, request, session_id):
+        session = self.get_session(session_id)
+        data = self.validated(request)
+        text = render_to_string(
+            "meeting/bluesheet.txt",
+            {"data": data["bluesheet"], "session": session},
+        )
+        return self.applied(
+            session,
+            save_bluesheet(
+                request,
+                session,
+                ContentFile(text.encode("utf-8"), name="bluesheet.txt"),
+                Person.objects.get(name="(System)"),
+            ),
+        )
+
+
+class SessionChatlogView(SessionDataView):
+    api_key_endpoint = "ietf.api.meeting.session.chatlog"
+    request_serializer_class = SessionChatlogSerializer
+
+    @extend_schema(
+        operation_id="meeting_session_upload_chatlog",
+        summary="Upload a session's chat log",
+        description=(
+            "Stores the entries as a new revision of the session's chatlog document. "
+            "Entries are stored as sent; `author` is a display name, not a person "
+            "reference."
+        ),
+        request=SessionChatlogSerializer,
+        responses={200: SessionUpdatedSerializer},
+    )
+    def post(self, request, session_id):
+        session = self.get_session(session_id)
+        data = self.validated(request)
+        return self.applied(
+            session,
+            save_session_json_doc(
+                session,
+                "chatlog",
+                data["chatlog"],
+                Person.objects.get(name="(System)"),
+            ),
+        )
+
+
+class SessionPollsView(SessionDataView):
+    api_key_endpoint = "ietf.api.meeting.session.polls"
+    request_serializer_class = SessionPollsSerializer
+
+    @extend_schema(
+        operation_id="meeting_session_upload_polls",
+        summary="Upload a session's polls",
+        description=(
+            "Stores the polls as a new revision of the session's polls document. Polls "
+            "carry aggregate counts, not per-person responses."
+        ),
+        request=SessionPollsSerializer,
+        responses={200: SessionUpdatedSerializer},
+    )
+    def post(self, request, session_id):
+        session = self.get_session(session_id)
+        data = self.validated(request)
+        return self.applied(
+            session,
+            save_session_json_doc(
+                session, "polls", data["polls"], Person.objects.get(name="(System)")
+            ),
         )

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -6,10 +6,9 @@ from django.db.models.functions import Cast
 from django.http import Http404
 from django.template.loader import render_to_string
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import generics, serializers, status
-from rest_framework.generics import get_object_or_404
+from rest_framework import generics, serializers, status, viewsets
+from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from ietf.meeting.models import Attended, Meeting, Session
 from ietf.meeting.serializers import (
@@ -117,8 +116,8 @@ class MeetingsAttendedByUuid(generics.RetrieveAPIView):
 
 
 @extend_schema(tags=["meeting"])
-class SessionDataView(APIView):
-    """Base for the endpoints that push data about one session
+class SessionDataViewSet(viewsets.GenericViewSet):
+    """Endpoints that push data about one session
 
     The session is addressed by its pk. Only person references use UUIDs.
 
@@ -126,13 +125,29 @@ class SessionDataView(APIView):
     person; document events are authored by the (System) Person.
     """
 
-    request_serializer_class: type
+    queryset = Session.objects.all()
 
-    def get_session(self, session_id):
-        return get_object_or_404(Session, pk=session_id)
+    # One token per action, so any single capability can be withdrawn on its own.
+    # A property rather than a class attribute because the action is only known per
+    # request; self.action is set before permissions are checked.
+    @property
+    def api_key_endpoint(self):
+        return f"ietf.api.meeting.session.{self.action}"
+
+    serializer_classes = {  # noqa: RUF012
+        "video_url": SessionVideoUrlSerializer,
+        "recording_name": SessionRecordingNameSerializer,
+        "bluesheet": SessionBluesheetSerializer,
+        "attendees": SessionAttendeesSerializer,
+        "chatlog": SessionChatlogSerializer,
+        "polls": SessionPollsSerializer,
+    }
+
+    def get_serializer_class(self):
+        return self.serializer_classes[self.action]
 
     def validated(self, request):
-        serializer = self.request_serializer_class(data=request.data)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
 
@@ -144,11 +159,6 @@ class SessionDataView(APIView):
             status=status.HTTP_200_OK,
         )
 
-
-class SessionVideoUrlView(SessionDataView):
-    api_key_endpoint = "ietf.api.meeting.session.video_url"
-    request_serializer_class = SessionVideoUrlSerializer
-
     @extend_schema(
         operation_id="meeting_session_set_video_url",
         summary="Set a session's video recording URL",
@@ -159,8 +169,9 @@ class SessionVideoUrlView(SessionDataView):
         request=SessionVideoUrlSerializer,
         responses={200: SessionUpdatedSerializer},
     )
-    def post(self, request, session_id):
-        session = self.get_session(session_id)
+    @action(detail=True, methods=["post"], url_path="video-url")
+    def video_url(self, request, pk=None):
+        session = self.get_object()
         data = self.validated(request)
         return self.applied(
             session,
@@ -169,11 +180,6 @@ class SessionVideoUrlView(SessionDataView):
             ),
         )
 
-
-class SessionRecordingNameView(SessionDataView):
-    api_key_endpoint = "ietf.api.meeting.session.recording_name"
-    request_serializer_class = SessionRecordingNameSerializer
-
     @extend_schema(
         operation_id="meeting_session_set_recording_name",
         summary="Set the name of a session's recording",
@@ -181,17 +187,13 @@ class SessionRecordingNameView(SessionDataView):
         request=SessionRecordingNameSerializer,
         responses={200: SessionUpdatedSerializer},
     )
-    def post(self, request, session_id):
-        session = self.get_session(session_id)
+    @action(detail=True, methods=["post"], url_path="recording-name")
+    def recording_name(self, request, pk=None):
+        session = self.get_object()
         data = self.validated(request)
         session.meetecho_recording_name = data["name"]
         session.save()
         return self.applied(session)
-
-
-class SessionBluesheetView(SessionDataView):
-    api_key_endpoint = "ietf.api.meeting.session.bluesheet"
-    request_serializer_class = SessionBluesheetSerializer
 
     @extend_schema(
         operation_id="meeting_session_upload_bluesheet",
@@ -204,8 +206,9 @@ class SessionBluesheetView(SessionDataView):
         request=SessionBluesheetSerializer,
         responses={200: SessionUpdatedSerializer},
     )
-    def post(self, request, session_id):
-        session = self.get_session(session_id)
+    @action(detail=True, methods=["post"])
+    def bluesheet(self, request, pk=None):
+        session = self.get_object()
         data = self.validated(request)
         text = render_to_string(
             "meeting/bluesheet.txt",
@@ -220,11 +223,6 @@ class SessionBluesheetView(SessionDataView):
                 Person.objects.get(name="(System)"),
             ),
         )
-
-
-class SessionAttendeesView(SessionDataView):
-    api_key_endpoint = "ietf.api.meeting.session.attendees"
-    request_serializer_class = SessionAttendeesSerializer
 
     @extend_schema(
         operation_id="meeting_session_add_attendees",
@@ -241,8 +239,9 @@ class SessionAttendeesView(SessionDataView):
         request=SessionAttendeesSerializer,
         responses={200: SessionUpdatedSerializer},
     )
-    def post(self, request, session_id):
-        session = self.get_session(session_id)
+    @action(detail=True, methods=["post"])
+    def attendees(self, request, pk=None):
+        session = self.get_object()
         attendees = self.validated(request)["attendees"]
 
         person_by_uuid = {
@@ -287,11 +286,6 @@ class SessionAttendeesView(SessionDataView):
                 )
             return self.applied(session, save_error)
 
-
-class SessionChatlogView(SessionDataView):
-    api_key_endpoint = "ietf.api.meeting.session.chatlog"
-    request_serializer_class = SessionChatlogSerializer
-
     @extend_schema(
         operation_id="meeting_session_upload_chatlog",
         summary="Upload a session's chat log",
@@ -303,8 +297,9 @@ class SessionChatlogView(SessionDataView):
         request=SessionChatlogSerializer,
         responses={200: SessionUpdatedSerializer},
     )
-    def post(self, request, session_id):
-        session = self.get_session(session_id)
+    @action(detail=True, methods=["post"])
+    def chatlog(self, request, pk=None):
+        session = self.get_object()
         data = self.validated(request)
         return self.applied(
             session,
@@ -316,11 +311,6 @@ class SessionChatlogView(SessionDataView):
             ),
         )
 
-
-class SessionPollsView(SessionDataView):
-    api_key_endpoint = "ietf.api.meeting.session.polls"
-    request_serializer_class = SessionPollsSerializer
-
     @extend_schema(
         operation_id="meeting_session_upload_polls",
         summary="Upload a session's polls",
@@ -331,8 +321,9 @@ class SessionPollsView(SessionDataView):
         request=SessionPollsSerializer,
         responses={200: SessionUpdatedSerializer},
     )
-    def post(self, request, session_id):
-        session = self.get_session(session_id)
+    @action(detail=True, methods=["post"])
+    def polls(self, request, pk=None):
+        session = self.get_object()
         data = self.validated(request)
         return self.applied(
             session,

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -235,7 +235,7 @@ class SessionAttendeesView(SessionDataView):
             "Each attendee is identified by any UUID the datatracker has issued them, so "
             "a UUID superseded by a merge still resolves. If any UUID fails to resolve "
             "the whole request is rejected and nothing is recorded.\n\n"
-            "join_time must carry an explicit UTC offset.\n\n"
+            "A join_time with no UTC offset is read as UTC.\n\n"
             "For an interim meeting this also regenerates the session's bluesheet."
         ),
         request=SessionAttendeesSerializer,

--- a/ietf/meeting/serializers.py
+++ b/ietf/meeting/serializers.py
@@ -26,3 +26,53 @@ class AttendedMeetingSerializer(serializers.ModelSerializer):
 
 class PersonAttendedMeetingsSerializer(serializers.Serializer):
     attended = AttendedMeetingSerializer(source="attended_registrations", many=True)
+
+
+class SessionVideoUrlSerializer(serializers.Serializer):
+    """A session's video recording URL"""
+
+    # max_length matches Document.external_url
+    url = serializers.URLField(max_length=200)
+
+
+class SessionRecordingNameSerializer(serializers.Serializer):
+    """The name the recording is served under by the player"""
+
+    # max_length matches Session.meetecho_recording_name
+    name = serializers.CharField(max_length=64)
+
+
+class BluesheetEntrySerializer(serializers.Serializer):
+    """One line of a bluesheet
+
+    Free text, not a person reference: the uploader cannot always resolve an attendee
+    to a datatracker Person.
+    """
+
+    name = serializers.CharField()
+    affiliation = serializers.CharField(allow_blank=True, default="")
+
+
+class SessionBluesheetSerializer(serializers.Serializer):
+    bluesheet = BluesheetEntrySerializer(many=True, allow_empty=True)
+
+
+class SessionChatlogSerializer(serializers.Serializer):
+    """A session's chat log
+
+    Entries are stored as sent. `author` is a display name, not a person reference.
+    """
+
+    chatlog = serializers.ListField(child=serializers.DictField(), allow_empty=True)
+
+
+class SessionPollsSerializer(serializers.Serializer):
+    """A session's polls, as aggregate counts"""
+
+    polls = serializers.ListField(child=serializers.DictField(), allow_empty=True)
+
+
+class SessionUpdatedSerializer(serializers.Serializer):
+    """Confirmation that a session data push was applied"""
+
+    session_id = serializers.IntegerField()

--- a/ietf/meeting/serializers.py
+++ b/ietf/meeting/serializers.py
@@ -1,5 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
 
+from django.utils import timezone
 from rest_framework import serializers
 
 from ietf.meeting.models import Registration
@@ -55,6 +56,34 @@ class BluesheetEntrySerializer(serializers.Serializer):
 
 class SessionBluesheetSerializer(serializers.Serializer):
     bluesheet = BluesheetEntrySerializer(many=True, allow_empty=True)
+
+
+class AwareDateTimeField(serializers.DateTimeField):
+    """DateTimeField that requires an explicit UTC offset
+
+    DateTimeField makes a naive value aware in the process timezone, which silently
+    shifts a timestamp the caller meant as UTC.
+    """
+
+    default_error_messages = {  # noqa: RUF012
+        "naive": "Datetime must include a UTC offset.",
+    }
+
+    def enforce_timezone(self, value):
+        if timezone.is_naive(value):
+            self.fail("naive")
+        return super().enforce_timezone(value)
+
+
+class SessionAttendeeSerializer(serializers.Serializer):
+    """One session attendee, identified by any UUID the datatracker issued them"""
+
+    person_uuid = serializers.UUIDField()
+    join_time = AwareDateTimeField()
+
+
+class SessionAttendeesSerializer(serializers.Serializer):
+    attendees = SessionAttendeeSerializer(many=True, allow_empty=True)
 
 
 class SessionChatlogSerializer(serializers.Serializer):

--- a/ietf/meeting/serializers.py
+++ b/ietf/meeting/serializers.py
@@ -1,6 +1,6 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+import datetime
 
-from django.utils import timezone
 from rest_framework import serializers
 
 from ietf.meeting.models import Registration
@@ -58,28 +58,13 @@ class SessionBluesheetSerializer(serializers.Serializer):
     bluesheet = BluesheetEntrySerializer(many=True, allow_empty=True)
 
 
-class AwareDateTimeField(serializers.DateTimeField):
-    """DateTimeField that requires an explicit UTC offset
-
-    DateTimeField makes a naive value aware in the process timezone, which silently
-    shifts a timestamp the caller meant as UTC.
-    """
-
-    default_error_messages = {  # noqa: RUF012
-        "naive": "Datetime must include a UTC offset.",
-    }
-
-    def enforce_timezone(self, value):
-        if timezone.is_naive(value):
-            self.fail("naive")
-        return super().enforce_timezone(value)
-
-
 class SessionAttendeeSerializer(serializers.Serializer):
     """One session attendee, identified by any UUID the datatracker issued them"""
 
     person_uuid = serializers.UUIDField()
-    join_time = AwareDateTimeField()
+    # default_timezone so a value with no offset is read as UTC rather than in the
+    # process timezone, matching the other DRF datetime fields in the API
+    join_time = serializers.DateTimeField(default_timezone=datetime.UTC)
 
 
 class SessionAttendeesSerializer(serializers.Serializer):

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -188,6 +188,64 @@ SESSION_DATA_TOKENS = {
 }
 
 
+@override_settings(
+    APP_API_TOKENS={"ietf.api.meeting.registration.attended_by_uuid": TOKEN}
+)
+class MeetingsAttendedByUuidTests(TestCase):
+    VIEWNAME = "ietf.api.meeting.registration.attended_by_uuid"
+
+    def setUp(self):
+        super().setUp()
+        self.person = PersonFactory()
+
+    def get(self, uuid, token=TOKEN):
+        url = urlreverse(self.VIEWNAME, kwargs={"uuid": str(uuid)})
+        return self.client.get(url, headers={"X-Api-Key": token})
+
+    def test_endpoint_is_plumbed(self):
+        url = urlreverse(self.VIEWNAME, kwargs={"uuid": str(self.person.primary_uuid)})
+        self.assertEqual(self.client.get(url).status_code, 403, "should require api key")
+        r = self.client.get(url, headers={"X-Api-Key": "invalid-token"})
+        self.assertEqual(r.status_code, 403, "should require valid api key")
+
+        r = self.get(self.person.primary_uuid)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"attended": []})
+
+    def test_unknown_uuid_is_404(self):
+        self.assertEqual(
+            self.get("6f9a1c30-6c7e-4f0a-9a3f-2f1d0b8a4e11").status_code, 404
+        )
+
+    def test_matches_the_email_keyed_endpoint(self):
+        meeting = MeetingFactory(type_id="ietf", number="118", populate_schedule=False)
+        RegistrationFactory(meeting=meeting, person=self.person, attended=True)
+
+        by_uuid = self.get(self.person.primary_uuid).json()
+        with override_settings(
+            APP_API_TOKENS={"ietf.api.meeting.registration.attended": TOKEN}
+        ):
+            by_email = self.client.get(
+                urlreverse(
+                    "ietf.api.meeting.registration.attended",
+                    kwargs={"email": self.person.email_address()},
+                ),
+                headers={"X-Api-Key": TOKEN},
+            )
+        self.assertEqual([e["meeting"] for e in by_uuid["attended"]], ["118"])
+        self.assertEqual(by_uuid, by_email.json())
+
+    def test_superseded_uuid_resolves(self):
+        """A UUID that stopped being primary because of a merge still resolves"""
+        meeting = MeetingFactory(type_id="ietf", number="118", populate_schedule=False)
+        RegistrationFactory(meeting=meeting, person=self.person, attended=True)
+        prior = PersonUUIDFactory(person=self.person, primary=False)
+
+        r = self.get(prior.uuid)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual([e["meeting"] for e in r.json()["attended"]], ["118"])
+
+
 @override_settings(APP_API_TOKENS=SESSION_DATA_TOKENS)
 class SessionDataApiTests(TestCase):
     settings_temp_path_overrides = TestCase.settings_temp_path_overrides + [

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -1,4 +1,5 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+import datetime
 import json
 from pathlib import Path
 from unittest.mock import PropertyMock, patch
@@ -14,8 +15,8 @@ from ietf.meeting.factories import (
     RegistrationFactory,
     SessionFactory,
 )
-from ietf.meeting.models import Registration, Session
-from ietf.person.factories import EmailFactory, PersonFactory
+from ietf.meeting.models import Attended, Registration, Session
+from ietf.person.factories import EmailFactory, PersonFactory, PersonUUIDFactory
 from ietf.person.models import Person
 from ietf.utils.test_utils import TestCase
 
@@ -176,7 +177,14 @@ TOKEN = "valid-token"
 
 SESSION_DATA_TOKENS = {
     f"ietf.api.meeting.session.{name}": TOKEN
-    for name in ["video_url", "recording_name", "bluesheet", "chatlog", "polls"]
+    for name in [
+        "video_url",
+        "recording_name",
+        "bluesheet",
+        "attendees",
+        "chatlog",
+        "polls",
+    ]
 }
 
 
@@ -224,6 +232,7 @@ class SessionDataApiTests(TestCase):
             "video_url": {"url": "https://example.com/v"},
             "recording_name": {"name": "a-name"},
             "bluesheet": {"bluesheet": []},
+            "attendees": {"attendees": []},
             "chatlog": {"chatlog": []},
             "polls": {"polls": []},
         }
@@ -268,6 +277,7 @@ class SessionDataApiTests(TestCase):
         for name, payload in [
             ("recording_name", {}),
             ("video_url", {"url": "not a url"}),
+            ("attendees", {"attendees": [{"person_uuid": "not-a-uuid"}]}),
             ("chatlog", {"chatlog": "not a list"}),
             ("polls", {"polls": [1, 2, 3]}),
         ]:
@@ -427,3 +437,117 @@ class SessionDataApiTests(TestCase):
             session=self.unscheduled_session(),
         )
         self.assertEqual(r.status_code, 400)
+
+    # --- attendees ---
+
+    def attend(self, entries, session=None):
+        return self.post("attendees", {"attendees": entries}, session=session)
+
+    @staticmethod
+    def attendee(person_uuid, join_time="2024-02-21T18:00:00Z"):
+        return {"person_uuid": str(person_uuid), "join_time": join_time}
+
+    def test_records_attendees_by_uuid(self):
+        people = PersonFactory.create_batch(2)
+        r = self.attend(
+            [
+                self.attendee(people[0].primary_uuid, "2024-02-21T18:00:00Z"),
+                self.attendee(people[1].primary_uuid, "2024-02-21T18:00:01Z"),
+            ]
+        )
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertCountEqual(
+            self.session.attended_set.values_list("person", flat=True),
+            [p.pk for p in people],
+        )
+        self.assertEqual(
+            self.session.attended_set.get(person=people[0]).time,
+            datetime.datetime(2024, 2, 21, 18, 0, 0, tzinfo=datetime.UTC),
+        )
+
+    def test_records_attendee_by_superseded_uuid(self):
+        person = PersonFactory()
+        prior = PersonUUIDFactory(person=person, primary=False)
+        r = self.attend([self.attendee(prior.uuid)])
+        self.assertEqual(r.status_code, 200, r.content)
+        self.assertTrue(self.session.attended_set.filter(person=person).exists())
+
+    def test_unknown_attendee_uuid_records_nothing(self):
+        """An unresolvable UUID rejects the whole request"""
+        person = PersonFactory()
+        unknown = "6f9a1c30-6c7e-4f0a-9a3f-2f1d0b8a4e11"
+        r = self.attend(
+            [
+                self.attendee(person.primary_uuid),
+                self.attendee(unknown, "2024-02-21T18:00:01Z"),
+            ]
+        )
+        self.assertEqual(r.status_code, 400)
+        errors = r.json()["errors"]
+        self.assertEqual([e["attr"] for e in errors], ["person_uuid"])
+        self.assertEqual([e["detail"] for e in errors], [unknown])
+        self.assertFalse(self.session.attended_set.exists())
+
+    def test_reports_each_unknown_uuid_once(self):
+        unknown = "6f9a1c30-6c7e-4f0a-9a3f-2f1d0b8a4e11"
+        r = self.attend(
+            [
+                self.attendee(unknown),
+                self.attendee(unknown, "2024-02-21T18:00:01Z"),
+            ]
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual([e["detail"] for e in r.json()["errors"]], [unknown])
+
+    def test_rejects_join_time_without_an_offset(self):
+        """A naive join_time is refused rather than read in the server's timezone"""
+        person = PersonFactory()
+        r = self.attend([self.attendee(person.primary_uuid, "2024-02-21T18:00:00")])
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(
+            [e["attr"] for e in r.json()["errors"]], ["attendees.0.join_time"]
+        )
+        self.assertFalse(self.session.attended_set.exists())
+
+    def test_repeated_attendee_push_keeps_first_join_time(self):
+        person = PersonFactory()
+        for join_time in ["2024-02-21T18:00:00Z", "2024-02-21T19:00:00Z"]:
+            r = self.attend([self.attendee(person.primary_uuid, join_time)])
+            self.assertEqual(r.status_code, 200, r.content)
+        self.assertEqual(Attended.objects.filter(session=self.session).count(), 1)
+        self.assertEqual(
+            self.session.attended_set.get(person=person).time,
+            datetime.datetime(2024, 2, 21, 18, 0, 0, tzinfo=datetime.UTC),
+        )
+
+    def test_interim_attendees_generate_bluesheet(self):
+        interim = MeetingFactory(type_id="interim")
+        session = SessionFactory(group__type_id="wg", meeting=interim)
+        person = PersonFactory()
+        r = self.attend([self.attendee(person.primary_uuid)], session=session)
+        self.assertEqual(r.status_code, 200, r.content)
+        doc = session.presentations.get(document__type_id="bluesheets").document
+        self.assertEqual(doc.docevent_set.first().by, self.system)
+        self.assertIn(
+            person.plain_name(),
+            get_unicode_document_content(
+                doc.name,
+                Path(interim.get_materials_path()) / "bluesheets" / doc.uploaded_filename,
+            ),
+        )
+
+    def test_failed_bluesheet_leaves_no_attendees(self):
+        """The Attended rows and the interim bluesheet succeed or fail together"""
+        session = self.unscheduled_session(MeetingFactory(type_id="interim"))
+        person = PersonFactory()
+        r = self.attend([self.attendee(person.primary_uuid)], session=session)
+        self.assertEqual(r.status_code, 400)
+        self.assertFalse(session.attended_set.exists())
+
+    def test_ietf_attendees_do_not_generate_bluesheet(self):
+        person = PersonFactory()
+        self.attend([self.attendee(person.primary_uuid)])
+        self.assertFalse(
+            Document.objects.filter(type_id="bluesheets").exists(),
+            "bluesheets for an IETF meeting are generated at finalization",
+        )

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -1,16 +1,22 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
+import json
+from pathlib import Path
 from unittest.mock import PropertyMock, patch
 
 from django.test import override_settings
 from django.urls import reverse as urlreverse
 
+from ietf.doc.models import Document
+from ietf.doc.utils import get_unicode_document_content
 from ietf.meeting.factories import (
     AttendedFactory,
     MeetingFactory,
     RegistrationFactory,
+    SessionFactory,
 )
-from ietf.meeting.models import Registration
+from ietf.meeting.models import Registration, Session
 from ietf.person.factories import EmailFactory, PersonFactory
+from ietf.person.models import Person
 from ietf.utils.test_utils import TestCase
 
 
@@ -164,3 +170,260 @@ class MeetingsAttendedByEmailTests(TestCase):
         attended = self.attended_for()
         self.assertEqual([entry["meeting"] for entry in attended], ["118"])
         self.assertEqual({entry["attendance_type"] for entry in attended}, {"onsite"})
+
+
+TOKEN = "valid-token"
+
+SESSION_DATA_TOKENS = {
+    f"ietf.api.meeting.session.{name}": TOKEN
+    for name in ["video_url", "recording_name", "bluesheet", "chatlog", "polls"]
+}
+
+
+@override_settings(APP_API_TOKENS=SESSION_DATA_TOKENS)
+class SessionDataApiTests(TestCase):
+    settings_temp_path_overrides = TestCase.settings_temp_path_overrides + [
+        "AGENDA_PATH"
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.meeting = MeetingFactory(type_id="ietf")
+        self.session = SessionFactory(group__type_id="wg", meeting=self.meeting)
+        self.system = Person.objects.get(name="(System)")
+
+    def url(self, name, session=None):
+        return urlreverse(
+            f"ietf.api.meeting.session.{name}",
+            kwargs={"session_id": (session or self.session).pk},
+        )
+
+    def post(self, name, payload, token=TOKEN, session=None):
+        return self.client.post(
+            self.url(name, session=session),
+            data=json.dumps(payload),
+            content_type="application/json",
+            headers={"X-Api-Key": token},
+        )
+
+    def unscheduled_session(self, meeting=None):
+        return SessionFactory(
+            group__type_id="wg",
+            meeting=meeting or self.meeting,
+            add_to_schedule=False,
+        )
+
+    def materials(self, type_id, doc):
+        path = Path(self.meeting.get_materials_path()) / type_id / doc.uploaded_filename
+        return get_unicode_document_content(doc.name, path)
+
+    # --- plumbing, shared by every endpoint in this group ---
+
+    def test_endpoints_are_plumbed(self):
+        payloads = {
+            "video_url": {"url": "https://example.com/v"},
+            "recording_name": {"name": "a-name"},
+            "bluesheet": {"bluesheet": []},
+            "chatlog": {"chatlog": []},
+            "polls": {"polls": []},
+        }
+        for name, payload in payloads.items():
+            with self.subTest(endpoint=name):
+                r = self.client.post(
+                    self.url(name),
+                    data=json.dumps(payload),
+                    content_type="application/json",
+                )
+                self.assertEqual(r.status_code, 403, "should require api key")
+
+                r = self.post(name, payload, token="invalid-token")
+                self.assertEqual(r.status_code, 403, "should require valid api key")
+
+                r = self.post(name, payload)
+                self.assertEqual(r.status_code, 200, r.content)
+                self.assertEqual(r.json(), {"session_id": self.session.pk})
+
+                self.assertEqual(
+                    self.client.get(
+                        self.url(name), headers={"X-Api-Key": TOKEN}
+                    ).status_code,
+                    405,
+                    "should not accept GET",
+                )
+
+    def test_unknown_session_is_404(self):
+        missing = Session.objects.order_by("-pk").first().pk + 1
+        r = self.client.post(
+            urlreverse(
+                "ietf.api.meeting.session.recording_name",
+                kwargs={"session_id": missing},
+            ),
+            data=json.dumps({"name": "a-name"}),
+            content_type="application/json",
+            headers={"X-Api-Key": TOKEN},
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_malformed_payload_is_400(self):
+        for name, payload in [
+            ("recording_name", {}),
+            ("video_url", {"url": "not a url"}),
+            ("chatlog", {"chatlog": "not a list"}),
+            ("polls", {"polls": [1, 2, 3]}),
+        ]:
+            with self.subTest(endpoint=name):
+                self.assertEqual(self.post(name, payload).status_code, 400)
+
+    # --- recording name ---
+
+    def test_sets_recording_name(self):
+        self.post("recording_name", {"name": "the-recording"})
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.meetecho_recording_name, "the-recording")
+
+    def test_rejects_recording_name_the_column_cannot_hold(self):
+        r = self.post("recording_name", {"name": "x" * 65})
+        self.assertEqual(r.status_code, 400)
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.meetecho_recording_name, "")
+
+    # --- video url ---
+
+    def test_creates_video_recording(self):
+        self.post("video_url", {"url": "https://example.com/first"})
+        recordings = [
+            d for d in self.session.recordings() if "video" in d.title.lower()
+        ]
+        self.assertEqual(len(recordings), 1)
+        self.assertEqual(recordings[0].external_url, "https://example.com/first")
+        self.assertEqual(
+            recordings[0].docevent_set.first().by,
+            self.system,
+            "events are attributed to the (System) person",
+        )
+
+    def test_updates_existing_video_recording(self):
+        self.post("video_url", {"url": "https://example.com/first"})
+        self.post("video_url", {"url": "https://example.com/second"})
+        recordings = [
+            d for d in self.session.recordings() if "video" in d.title.lower()
+        ]
+        self.assertEqual(len(recordings), 1, "no second recording document")
+        self.assertEqual(recordings[0].external_url, "https://example.com/second")
+        self.assertTrue(
+            recordings[0]
+            .docevent_set.filter(type="added_comment", by=self.system)
+            .exists()
+        )
+
+    def test_rejects_video_url_the_column_cannot_hold(self):
+        """An over-long URL is refused before any document or event is written"""
+        r = self.post("video_url", {"url": "https://example.com/" + "a" * 250})
+        self.assertEqual(r.status_code, 400)
+        self.assertFalse(self.session.recordings())
+
+    def test_rejects_video_url_update_the_column_cannot_hold(self):
+        """The update path refuses it too, leaving the recording and its history alone"""
+        self.post("video_url", {"url": "https://example.com/first"})
+        doc = self.session.recordings()[0]
+        events_before = doc.docevent_set.count()
+
+        r = self.post("video_url", {"url": "https://example.com/" + "a" * 250})
+        self.assertEqual(r.status_code, 400)
+        doc.refresh_from_db()
+        self.assertEqual(doc.external_url, "https://example.com/first")
+        self.assertEqual(doc.docevent_set.count(), events_before)
+
+    def test_video_url_without_official_timeslot_is_400(self):
+        r = self.post(
+            "video_url",
+            {"url": "https://example.com/v"},
+            session=self.unscheduled_session(),
+        )
+        self.assertEqual(r.status_code, 400)
+
+    # --- bluesheet ---
+
+    def test_uploads_bluesheet(self):
+        r = self.post(
+            "bluesheet",
+            {
+                "bluesheet": [
+                    {"name": "Some Body", "affiliation": "Some Organization"},
+                    {"name": "Another Body", "affiliation": ""},
+                ]
+            },
+        )
+        self.assertEqual(r.status_code, 200, r.content)
+        doc = self.session.presentations.get(document__type_id="bluesheets").document
+        self.assertEqual(doc.rev, "00")
+        content = self.materials("bluesheets", doc)
+        self.assertIn("Some Body", content)
+        self.assertIn("Some Organization", content)
+        self.assertIn("Another Body", content)
+        self.assertEqual(doc.docevent_set.first().by, self.system)
+
+    def test_bluesheet_upload_bumps_revision(self):
+        self.post("bluesheet", {"bluesheet": [{"name": "Some Body"}]})
+        self.post("bluesheet", {"bluesheet": [{"name": "Another Body"}]})
+        doc = self.session.presentations.get(document__type_id="bluesheets").document
+        self.assertEqual(doc.rev, "01")
+        self.assertIn("Another Body", self.materials("bluesheets", doc))
+
+    def test_bluesheet_without_official_timeslot_is_400(self):
+        r = self.post(
+            "bluesheet",
+            {"bluesheet": [{"name": "Some Body"}]},
+            session=self.unscheduled_session(),
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertFalse(Document.objects.filter(type_id="bluesheets").exists())
+
+    # --- chatlog and polls ---
+
+    def test_uploads_chatlog(self):
+        chatlog = [
+            {
+                "author": "Some Body",
+                "text": "<p>a remark</p>",
+                "time": "2022-07-28T19:26:16Z",
+            }
+        ]
+        r = self.post("chatlog", {"chatlog": chatlog})
+        self.assertEqual(r.status_code, 200, r.content)
+        doc = self.session.presentations.get(document__type_id="chatlog").document
+        self.assertEqual(json.loads(self.materials("chatlog", doc)), chatlog)
+        self.assertEqual(doc.docevent_set.first().by, self.system)
+
+    def test_uploads_polls(self):
+        polls = [
+            {
+                "start_time": "2022-07-28T19:19:54Z",
+                "end_time": "2022-07-28T19:20:23Z",
+                "text": "Are you willing to review the documents?",
+                "raise_hand": 57,
+                "do_not_raise_hand": 11,
+            }
+        ]
+        r = self.post("polls", {"polls": polls})
+        self.assertEqual(r.status_code, 200, r.content)
+        doc = self.session.presentations.get(document__type_id="polls").document
+        self.assertEqual(json.loads(self.materials("polls", doc)), polls)
+
+    def test_chatlog_upload_bumps_revision(self):
+        self.post("chatlog", {"chatlog": [{"author": "A", "text": "one"}]})
+        self.post("chatlog", {"chatlog": [{"author": "A", "text": "two"}]})
+        doc = self.session.presentations.get(document__type_id="chatlog").document
+        self.assertEqual(doc.rev, "01")
+        self.assertEqual(
+            json.loads(self.materials("chatlog", doc)),
+            [{"author": "A", "text": "two"}],
+        )
+
+    def test_chatlog_without_official_timeslot_is_400(self):
+        r = self.post(
+            "chatlog",
+            {"chatlog": []},
+            session=self.unscheduled_session(),
+        )
+        self.assertEqual(r.status_code, 400)

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -557,15 +557,15 @@ class SessionDataApiTests(TestCase):
         self.assertEqual(r.status_code, 400)
         self.assertEqual([e["detail"] for e in r.json()["errors"]], [unknown])
 
-    def test_rejects_join_time_without_an_offset(self):
-        """A naive join_time is refused rather than read in the server's timezone"""
+    def test_join_time_without_an_offset_is_read_as_utc(self):
+        """A naive join_time is UTC, not the server's timezone"""
         person = PersonFactory()
         r = self.attend([self.attendee(person.primary_uuid, "2024-02-21T18:00:00")])
-        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.status_code, 200, r.content)
         self.assertEqual(
-            [e["attr"] for e in r.json()["errors"]], ["attendees.0.join_time"]
+            self.session.attended_set.get(person=person).time,
+            datetime.datetime(2024, 2, 21, 18, 0, 0, tzinfo=datetime.UTC),
         )
-        self.assertFalse(self.session.attended_set.exists())
 
     def test_repeated_attendee_push_keeps_first_join_time(self):
         person = PersonFactory()

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -259,9 +259,10 @@ class SessionDataApiTests(TestCase):
         self.system = Person.objects.get(name="(System)")
 
     def url(self, name, session=None):
+        # action names are underscored; the router's route names are hyphenated
         return urlreverse(
-            f"ietf.api.meeting.session.{name}",
-            kwargs={"session_id": (session or self.session).pk},
+            f"ietf.api.meeting.session-{name.replace('_', '-')}",
+            kwargs={"pk": (session or self.session).pk},
         )
 
     def post(self, name, payload, token=TOKEN, session=None):
@@ -310,11 +311,13 @@ class SessionDataApiTests(TestCase):
                 self.assertEqual(r.status_code, 200, r.content)
                 self.assertEqual(r.json(), {"session_id": self.session.pk})
 
+                # 403, not 405: the router maps only POST, so an unmapped method
+                # leaves self.action None and the per-action token check fails first
                 self.assertEqual(
                     self.client.get(
                         self.url(name), headers={"X-Api-Key": TOKEN}
                     ).status_code,
-                    405,
+                    403,
                     "should not accept GET",
                 )
 
@@ -322,8 +325,8 @@ class SessionDataApiTests(TestCase):
         missing = Session.objects.order_by("-pk").first().pk + 1
         r = self.client.post(
             urlreverse(
-                "ietf.api.meeting.session.recording_name",
-                kwargs={"session_id": missing},
+                "ietf.api.meeting.session-recording-name",
+                kwargs={"pk": missing},
             ),
             data=json.dumps({"name": "a-name"}),
             content_type="application/json",

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -5,6 +5,7 @@ import itertools
 from contextlib import suppress
 from dataclasses import dataclass
 
+import json
 import jsonschema
 import os
 import requests
@@ -854,6 +855,37 @@ def new_doc_for_session(type_id, session):
     session.presentations.create(document=doc,rev='00')
     return doc
 
+
+def save_session_json_doc(session, type_id, data, by):
+    """Store a chatlog or polls upload as a new revision of the session's document
+
+    Returns an error message, or None on success.
+    """
+    presentation = session.presentations.filter(document__type=type_id).first()
+    if presentation:
+        doc = presentation.document
+        doc.rev = f"{(int(doc.rev)+1):02d}"
+        presentation.rev = doc.rev
+        presentation.save()
+    else:
+        doc = new_doc_for_session(type_id, session)
+        if doc is None:
+            return "Could not find official timeslot for session"
+    filename = f"{doc.name}-{doc.rev}.json"
+    doc.uploaded_filename = filename
+    write_doc_for_session(session, type_id, filename, json.dumps(data))
+    e = NewRevisionDocEvent.objects.create(
+        doc=doc,
+        rev=doc.rev,
+        by=by,
+        type="new_revision",
+        desc="New revision available: %s" % doc.rev,
+    )
+    doc.save_with_history([e])
+    resolve_uploaded_material(meeting=session.meeting, doc=doc)
+    return None
+
+
 # TODO-BLOBSTORE - consider adding doc to this signature and factoring away type_id
 def write_doc_for_session(session, type_id, filename, contents):
     filename = Path(filename)
@@ -1198,6 +1230,39 @@ def store_blobs_for_one_meeting(meeting: Meeting):
 
     for doc in meeting_documents:
         store_blobs_for_one_material_doc(doc)
+
+
+def save_session_video_url(session, url, by):
+    """Point the session's video recording at url
+
+    Updates the newest existing video recording, or creates one. Returns an error
+    message, or None on success.
+    """
+    recordings = [r for r in session.recordings() if "video" in r.title.lower()]
+    if recordings:
+        doc = recordings[-1]
+        if doc.external_url != url:
+            e = DocEvent.objects.create(
+                doc=doc,
+                rev=doc.rev,
+                type="added_comment",
+                by=by,
+                desc="External url changed from %s to %s" % (doc.external_url, url),
+            )
+            doc.external_url = url
+            doc.save_with_history([e])
+        return None
+    ota = session.official_timeslotassignment()
+    if ota is None:
+        return "Could not find official timeslot for session"
+    time = ota.timeslot.time
+    title = "Video recording for %s on %s at %s" % (
+        session.group.acronym,
+        time.date(),
+        time.time(),
+    )
+    create_recording(session, url, title=title, user=by)
+    return None
 
 
 def create_recording(session, url, title=None, user=None):

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -215,6 +215,8 @@ def save_bluesheet(request, session, file, by, encoding='utf-8'):
     else:
         ota = session.official_timeslotassignment()
         sess_time = ota and ota.timeslot.time
+        if sess_time is None:
+            return "Could not find official timeslot for session"
 
         if session.meeting.type_id=='ietf':
             name = 'bluesheets-%s-%s-%s' % (session.meeting.number, 

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -202,7 +202,7 @@ def bluesheet_data(session):
     ]
 
 
-def save_bluesheet(request, session, file, encoding='utf-8'):
+def save_bluesheet(request, session, file, by, encoding='utf-8'):
     bluesheet_sp = session.presentations.filter(document__type='bluesheets').first()
     _, ext = os.path.splitext(file.name)
 
@@ -236,7 +236,7 @@ def save_bluesheet(request, session, file, encoding='utf-8'):
         session.presentations.create(document=doc,rev='00')
     filename = '%s-%s%s'% ( doc.name, doc.rev, ext)
     doc.uploaded_filename = filename
-    e = NewRevisionDocEvent.objects.create(doc=doc, rev=doc.rev, by=request.user.person, type='new_revision', desc='New revision available: %s'%doc.rev)
+    e = NewRevisionDocEvent.objects.create(doc=doc, rev=doc.rev, by=by, type='new_revision', desc='New revision available: %s'%doc.rev)
     save_error = handle_upload_file(file, filename, session.meeting, 'bluesheets', request=request, encoding=encoding)
     if not save_error:
         doc.save_with_history([e])
@@ -244,7 +244,7 @@ def save_bluesheet(request, session, file, encoding='utf-8'):
     return save_error
 
 
-def generate_bluesheet(request, session):
+def generate_bluesheet(request, session, by):
     data = bluesheet_data(session)
     if not data:
         return
@@ -252,7 +252,7 @@ def generate_bluesheet(request, session):
             'session': session,
             'data': data,
         })
-    return save_bluesheet(request, session, ContentFile(text.encode("utf-8"), name="unusednamepartsothereisanextension.txt"))
+    return save_bluesheet(request, session, ContentFile(text.encode("utf-8"), name="unusednamepartsothereisanextension.txt"), by)
 
 
 def finalize(request, meeting):
@@ -274,7 +274,7 @@ def finalize(request, meeting):
 
         # Don't try to generate a bluesheet if it's before we had Attended records.
         if int(meeting.number) >= 108:
-            save_error = generate_bluesheet(request, session)
+            save_error = generate_bluesheet(request, session, request.user.person)
             if save_error:
                 messages.error(request, save_error)
     

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3323,7 +3323,7 @@ def upload_session_bluesheets(request, session_id, num):
                 )
 
 
-            save_error = save_bluesheet(request, session, file, encoding=form.file_encoding[file.name])
+            save_error = save_bluesheet(request, session, file, request.user.person, encoding=form.file_encoding[file.name])
             if save_error:
                 form.add_error(None, save_error)
             else:
@@ -5296,7 +5296,7 @@ def api_add_session_attendees(request):
             Attended.objects.bulk_create(to_create, ignore_conflicts=True)
 
     if session.meeting.type_id == "interim":
-        save_error = generate_bluesheet(request, session)
+        save_error = generate_bluesheet(request, session, request.user.person)
         if save_error:
             return err(400, save_error)
 
@@ -5460,7 +5460,7 @@ def api_upload_bluesheet(request):
     with open(name, "w") as file:
         file.write(text)
     with open(name, "br") as file:
-        save_err = save_bluesheet(request, session, file)
+        save_err = save_bluesheet(request, session, file, request.user.person)
     if save_err:
         return err(400, save_err)
     return HttpResponse(

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -177,8 +177,6 @@ from ietf.meeting.utils import (
     swap_meeting_schedule_timeslot_assignments,
     bulk_create_timeslots,
     preprocess_meeting_important_dates,
-    new_doc_for_session,
-    write_doc_for_session,
     get_activity_stats,
     post_process,
     create_recording,
@@ -186,6 +184,8 @@ from ietf.meeting.utils import (
     generate_bluesheet,
     bluesheet_data,
     save_bluesheet,
+    save_session_json_doc,
+    save_session_video_url,
 )
 from ietf.message.utils import infer_message
 from ietf.name.models import (
@@ -5104,18 +5104,9 @@ def api_set_session_video_url(request):
     except ValidationError:
         return err(400, f"Invalid url value: '{incoming_url}'")
 
-    recordings = [(r.name, r.title, r) for r in session.recordings() if 'video' in r.title.lower()]
-    if recordings:
-        r = recordings[-1][-1]
-        if r.external_url != incoming_url:
-            e = DocEvent.objects.create(doc=r, rev=r.rev, type="added_comment", by=request.user.person,
-                                        desc="External url changed from %s to %s" % (r.external_url, incoming_url))
-            r.external_url = incoming_url
-            r.save_with_history([e])
-    else:
-        time = session.official_timeslotassignment().timeslot.time
-        title = 'Video recording for %s on %s at %s' % (session.group.acronym, time.date(), time.time())
-        create_recording(session, incoming_url, title=title, user=request.user.person)
+    save_error = save_session_video_url(session, incoming_url, request.user.person)
+    if save_error:
+        return err(400, save_error)
     return HttpResponse(
         "Done",
         status=200,
@@ -5334,22 +5325,11 @@ def api_upload_chatlog(request):
     session = Session.objects.filter(pk=session_id).first()
     if not session:
         return err(400, "Invalid session")
-    chatlog_sp = session.presentations.filter(document__type='chatlog').first()
-    if chatlog_sp:
-        doc = chatlog_sp.document
-        doc.rev = f"{(int(doc.rev)+1):02d}"
-        chatlog_sp.rev = doc.rev
-        chatlog_sp.save()
-    else:
-        doc = new_doc_for_session('chatlog', session)
-        if doc is None:
-            return err(400, "Could not find official timeslot for session")
-    filename = f"{doc.name}-{doc.rev}.json"
-    doc.uploaded_filename = filename
-    write_doc_for_session(session, 'chatlog', filename, json.dumps(apidata['chatlog']))
-    e = NewRevisionDocEvent.objects.create(doc=doc, rev=doc.rev, by=request.user.person, type='new_revision', desc='New revision available: %s'%doc.rev)
-    doc.save_with_history([e])
-    resolve_uploaded_material(meeting=session.meeting, doc=doc)
+    save_error = save_session_json_doc(
+        session, 'chatlog', apidata['chatlog'], request.user.person
+    )
+    if save_error:
+        return err(400, save_error)
     return HttpResponse(
         "Done",
         status=200,
@@ -5383,22 +5363,11 @@ def api_upload_polls(request):
     session = Session.objects.filter(pk=session_id).first()
     if not session:
         return err(400, "Invalid session")
-    polls_sp = session.presentations.filter(document__type='polls').first()
-    if polls_sp:
-        doc = polls_sp.document
-        doc.rev = f"{(int(doc.rev)+1):02d}"
-        polls_sp.rev = doc.rev
-        polls_sp.save()
-    else:
-        doc = new_doc_for_session('polls', session)
-        if doc is None:
-            return err(400, "Could not find official timeslot for session")
-    filename = f"{doc.name}-{doc.rev}.json"
-    doc.uploaded_filename = filename
-    write_doc_for_session(session, 'polls', filename, json.dumps(apidata['polls']))
-    e = NewRevisionDocEvent.objects.create(doc=doc, rev=doc.rev, by=request.user.person, type='new_revision', desc='New revision available: %s'%doc.rev)
-    doc.save_with_history([e])
-    resolve_uploaded_material(meeting=session.meeting, doc=doc)
+    save_error = save_session_json_doc(
+        session, 'polls', apidata['polls'], request.user.person
+    )
+    if save_error:
+        return err(400, save_error)
     return HttpResponse(
         "Done",
         status=200,


### PR DESCRIPTION
Adds a parallel set of DRF endpoints for the session data Meetecho pushes, keyed by
Person UUID and authenticated by service token. The six existing personal-API-key
endpoints keep working, so Meetecho migrates on its own schedule with no coordinated
cutover.

## New endpoints

| Endpoint | Body |
| --- | --- |
| `POST /api/meeting/session/{id}/video-url/` | `{"url": ...}` |
| `POST /api/meeting/session/{id}/recording-name/` | `{"name": ...}` |
| `POST /api/meeting/session/{id}/bluesheet/` | `{"bluesheet": [{"name", "affiliation"}]}` |
| `POST /api/meeting/session/{id}/attendees/` | `{"attendees": [{"person_uuid", "join_time"}]}` |
| `POST /api/meeting/session/{id}/chatlog/` | `{"chatlog": [...]}` |
| `POST /api/meeting/session/{id}/polls/` | `{"polls": [...]}` |
| `GET /api/meeting/registration/attended/by-uuid/{uuid}/` | — |

JSON in, JSON out, `X-Api-Key` via `api_key_endpoint`. Errors use the project's
standardized error envelope.

## Decisions

- **Identifiers.** Only the attendees endpoint carried a person identifier
  (`user_id`, a `User` pk — the OIDC `sub`); it becomes `person_uuid`. Any UUID the
  datatracker issued resolves, including one superseded by a merge. Meetecho already
  gets these from the `datatracker_uuid` OIDC claim. Sessions stay addressed by pk.
- **Free text stays free text.** Bluesheet names and chatlog authors are what the
  uploader observed, not person references — Meetecho can't always resolve a room
  attendee or chat participant to a Person.
- **Authorship.** A token identifies an application, so `request.user` is
  `AnonymousUser` and document events are authored by the `(System)` Person. This also
  drops the Recording Manager role check: authorization is possession of the token.
- **All-or-nothing attendees.** Matching the existing api, one unresolvable UUID rejects the 
  request; the rows and an interim meeting's bluesheet are written in one transaction. A version 
  that allows partial success is left as a future exercise.

## Deploying

Needs seven `APP_API_TOKENS` keys: `ietf.api.meeting.session.{video_url,
recording_name,bluesheet,attendees,chatlog,polls}` and
`ietf.api.meeting.registration.attended_by_uuid`. Separate keys so any one capability
can be withdrawn independently; the same token *value* can serve all seven.

## Changes to existing behavior

Commits 1–3 touch code the existing endpoints share. Five of the six are
behavior-identical. The exceptions, both on a session with no official timeslot:

- `api_set_session_video_url` and `api_upload_bluesheet` already answered 400 for that
  input, because `require_api_key` catches `AttributeError`. Only the message changes.
- `upload_session_bluesheets` and `finalize` have no such catch, so they change from a
  500 to a form error and a user message.

## Notes

Reviewed adversarially before merge; the findings are folded into the commits they
belong to. Known and deliberately not fixed here: the legacy recording-name endpoint
still does no length validation against its 64-character column.
