### PR TITLE
refactor: require an explicit UTC offset on API datetime fields

### DIFF
--- a/ietf/api/serializers_rpc.py
+++ b/ietf/api/serializers_rpc.py
@@ -31,6 +31,7 @@ from ietf.group.models import Group, Role
 from ietf.group.serializers import AreaSerializer
 from ietf.name.models import StreamName, StdLevelName
 from ietf.person.models import Person
+from ietf.utils.rest_framework.fields import AwareDateTimeField
 from ietf.utils import log
 
 
@@ -286,7 +287,7 @@ class RfcGroupRelatedField(serializers.SlugRelatedField):
 class RfcPubSerializer(serializers.ModelSerializer):
     """Write-only serializer for RFC publication"""
     # publication-related fields
-    published = serializers.DateTimeField(default_timezone=datetime.timezone.utc)
+    published = AwareDateTimeField()
     draft_name = serializers.RegexField(
         required=False, regex=r"^draft-[a-zA-Z0-9-]+$"
     )
@@ -562,10 +563,7 @@ class EditableRfcSerializer(serializers.ModelSerializer):
     # Treats published and subseries fields as write-only. This isn't quite correct,
     # but makes it easier and we don't currently use the serialized value except for
     # debugging.
-    published = serializers.DateTimeField(
-        default_timezone=datetime.timezone.utc,
-        write_only=True,
-    )
+    published = AwareDateTimeField(write_only=True)
     authors = RfcAuthorSerializer(many=True, min_length=1, source="rfcauthor_set")
     subseries = serializers.ListField(
         child=SubseriesNameField(required=False),
@@ -827,10 +825,9 @@ class RfcFileSerializer(serializers.Serializer):
             "file types, but filenames are otherwise ignored."
         ),
     )
-    mtime = serializers.DateTimeField(
+    mtime = AwareDateTimeField(
         required=False,
         default=timezone.now,
-        default_timezone=datetime.UTC,
         help_text="Modification timestamp to apply to uploaded files",
     )
     replace = serializers.BooleanField(

--- a/ietf/api/tests_serializers_rpc.py
+++ b/ietf/api/tests_serializers_rpc.py
@@ -11,6 +11,15 @@ from .serializers_rpc import EditableRfcSerializer
 
 
 class EditableRfcSerializerTests(TestCase):
+    def test_published_requires_an_offset(self):
+        """published is an AwareDateTimeField, so a naive value is refused"""
+        serializer = EditableRfcSerializer(data={"published": "2025-06-01T00:00:00"})
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            [str(e) for e in serializer.errors["published"]],
+            ["Datetime must include a UTC offset."],
+        )
+
     def test_create(self):
         serializer = EditableRfcSerializer(
             data={

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -233,7 +233,7 @@ class SessionDataViewSet(viewsets.GenericViewSet):
             "Each attendee is identified by any UUID the datatracker has issued them, so "
             "a UUID superseded by a merge still resolves. If any UUID fails to resolve "
             "the whole request is rejected and nothing is recorded.\n\n"
-            "A join_time with no UTC offset is read as UTC.\n\n"
+            "join_time must carry an explicit UTC offset.\n\n"
             "For an interim meeting this also regenerates the session's bluesheet."
         ),
         request=SessionAttendeesSerializer,

--- a/ietf/meeting/serializers.py
+++ b/ietf/meeting/serializers.py
@@ -1,9 +1,9 @@
 # Copyright The IETF Trust 2026, All Rights Reserved
-import datetime
 
 from rest_framework import serializers
 
 from ietf.meeting.models import Registration
+from ietf.utils.rest_framework.fields import AwareDateTimeField
 
 
 class AttendedMeetingSerializer(serializers.ModelSerializer):
@@ -62,9 +62,7 @@ class SessionAttendeeSerializer(serializers.Serializer):
     """One session attendee, identified by any UUID the datatracker issued them"""
 
     person_uuid = serializers.UUIDField()
-    # default_timezone so a value with no offset is read as UTC rather than in the
-    # process timezone, matching the other DRF datetime fields in the API
-    join_time = serializers.DateTimeField(default_timezone=datetime.UTC)
+    join_time = AwareDateTimeField()
 
 
 class SessionAttendeesSerializer(serializers.Serializer):

--- a/ietf/meeting/tests_api.py
+++ b/ietf/meeting/tests_api.py
@@ -560,15 +560,15 @@ class SessionDataApiTests(TestCase):
         self.assertEqual(r.status_code, 400)
         self.assertEqual([e["detail"] for e in r.json()["errors"]], [unknown])
 
-    def test_join_time_without_an_offset_is_read_as_utc(self):
-        """A naive join_time is UTC, not the server's timezone"""
+    def test_rejects_join_time_without_an_offset(self):
+        """A naive join_time is refused rather than assigned a zone"""
         person = PersonFactory()
         r = self.attend([self.attendee(person.primary_uuid, "2024-02-21T18:00:00")])
-        self.assertEqual(r.status_code, 200, r.content)
+        self.assertEqual(r.status_code, 400)
         self.assertEqual(
-            self.session.attended_set.get(person=person).time,
-            datetime.datetime(2024, 2, 21, 18, 0, 0, tzinfo=datetime.UTC),
+            [e["attr"] for e in r.json()["errors"]], ["attendees.0.join_time"]
         )
+        self.assertFalse(self.session.attended_set.exists())
 
     def test_repeated_attendee_push_keeps_first_join_time(self):
         person = PersonFactory()

--- a/ietf/utils/rest_framework/__init__.py
+++ b/ietf/utils/rest_framework/__init__.py
@@ -1,0 +1,1 @@
+# Copyright The IETF Trust 2026, All Rights Reserved

--- a/ietf/utils/rest_framework/fields.py
+++ b/ietf/utils/rest_framework/fields.py
@@ -1,0 +1,25 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+"""Serializer fields shared across the datatracker's DRF APIs"""
+
+from django.utils import timezone
+from rest_framework import serializers
+
+
+class AwareDateTimeField(serializers.DateTimeField):
+    """DateTimeField that requires the value to carry a UTC offset
+
+    DateTimeField applies default_timezone to a value that has none, so an offsetless
+    timestamp is silently assigned a zone the caller did not choose. Require the offset
+    instead of guessing at it.
+    """
+
+    default_error_messages = {  # noqa: RUF012
+        "naive": "Datetime must include a UTC offset.",
+    }
+
+    def enforce_timezone(self, value):
+        # The hook that receives the parsed value while it is still naive; checking
+        # after to_internal_value() would be too late, the zone is already applied.
+        if timezone.is_naive(value):
+            self.fail("naive")
+        return super().enforce_timezone(value)

--- a/ietf/utils/tests_rest_framework.py
+++ b/ietf/utils/tests_rest_framework.py
@@ -1,0 +1,44 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+import datetime
+
+from rest_framework import serializers
+
+from ietf.utils.rest_framework.fields import AwareDateTimeField
+from ietf.utils.test_utils import TestCase
+
+
+class AwareDateTimeFieldTests(TestCase):
+    class Serializer(serializers.Serializer):
+        when = AwareDateTimeField()
+
+    def validated(self, value):
+        serializer = self.Serializer(data={"when": value})
+        return serializer, serializer.is_valid()
+
+    def test_accepts_utc(self):
+        serializer, valid = self.validated("2024-02-21T18:00:00Z")
+        self.assertTrue(valid, serializer.errors)
+        self.assertEqual(
+            serializer.validated_data["when"],
+            datetime.datetime(2024, 2, 21, 18, 0, tzinfo=datetime.UTC),
+        )
+
+    def test_accepts_other_offsets_as_the_same_instant(self):
+        serializer, valid = self.validated("2024-02-21T13:00:00-05:00")
+        self.assertTrue(valid, serializer.errors)
+        self.assertEqual(
+            serializer.validated_data["when"],
+            datetime.datetime(2024, 2, 21, 18, 0, tzinfo=datetime.UTC),
+        )
+
+    def test_rejects_a_value_with_no_offset(self):
+        serializer, valid = self.validated("2024-02-21T18:00:00")
+        self.assertFalse(valid, "a naive value must not be accepted")
+        self.assertEqual(
+            [str(e) for e in serializer.errors["when"]],
+            ["Datetime must include a UTC offset."],
+        )
+
+    def test_rejects_a_value_that_is_not_a_datetime(self):
+        _, valid = self.validated("not a datetime")
+        self.assertFalse(valid)


### PR DESCRIPTION
Adds `AwareDateTimeField` in a new `ietf.utils.rest_framework.fields` module and uses
it for every DRF datetime field in the API.

Addresses the review comment on #11719 about not having two conventions for datetime
fields, taking the refactor-existing-code option rather than the minimal one.

## Why

`DateTimeField(default_timezone=...)` assigns a zone to a value that carries none, so
an offsetless timestamp is accepted and stored as a different instant than the caller
meant. The field requires the offset instead of guessing at it. It overrides
`enforce_timezone`, which is the hook that sees the parsed value while it is still
naive -- checking after `to_internal_value` is too late, the zone has already been
applied.

## Fields changed

- `SessionAttendeeSerializer.join_time` (`ietf/meeting/serializers.py`)
- `RfcPubSerializer.published` (`ietf/api/serializers_rpc.py`)
- `EditableRfcSerializer.published` (`ietf/api/serializers_rpc.py`)
- `RfcPubFilesView`'s `mtime` (`ietf/api/serializers_rpc.py`)

The last three previously used `default_timezone=UTC`.

## Breaking change, needs confirmation before merge

This rejects offsetless timestamps that `POST /api/purple/rfc/publish/` and
`POST /api/purple/rfc/publish/files/` used to accept. Every existing test sends an
offset, so a green suite is **not** evidence that Purple does. Someone should confirm
what Purple actually sends before this merges.

## Follows

#11719, where this was raised in review. One commit, rebased onto main.