### PR TITLE
refactor: raise SaveMaterialsError instead of returning an error message

### DIFF
--- a/ietf/api/tests.py
+++ b/ietf/api/tests.py
@@ -563,6 +563,62 @@ class CustomApiTests(TestCase):
                 json.loads(content)
             )
 
+    def test_legacy_session_data_endpoints_report_a_missing_timeslot(self):
+        """A session with no official timeslot is a 400 with the reason, not a 500
+
+        Pins the responses of the personal-API-key endpoints so the internal error
+        convention can change underneath them without changing what callers see.
+        """
+        recmanrole = RoleFactory(group__type_id="ietf", name_id="recman")
+        recmanrole.person.user.last_login = timezone.now()
+        recmanrole.person.user.save()
+        session = SessionFactory(
+            group__type_id="wg",
+            meeting=MeetingFactory(type_id="ietf"),
+            add_to_schedule=False,
+        )
+
+        cases = [
+            (
+                "ietf.meeting.views.api_set_session_video_url",
+                lambda key: {
+                    "apikey": key,
+                    "session_id": session.pk,
+                    "url": "https://example.com/v",
+                },
+            ),
+            (
+                "ietf.meeting.views.api_upload_bluesheet",
+                lambda key: {
+                    "apikey": key,
+                    "session_id": session.pk,
+                    "bluesheet": json.dumps([{"name": "A", "affiliation": "B"}]),
+                },
+            ),
+            (
+                "ietf.meeting.views.api_upload_chatlog",
+                lambda key: {
+                    "apikey": key,
+                    "apidata": json.dumps({"session_id": session.pk, "chatlog": []}),
+                },
+            ),
+            (
+                "ietf.meeting.views.api_upload_polls",
+                lambda key: {
+                    "apikey": key,
+                    "apidata": json.dumps({"session_id": session.pk, "polls": []}),
+                },
+            ),
+        ]
+        for viewname, payload in cases:
+            with self.subTest(view=viewname):
+                url = urlreverse(viewname)
+                apikey = PersonalApiKeyFactory(endpoint=url, person=recmanrole.person)
+                r = self.client.post(url, payload(apikey.hash()))
+                self.assertContains(
+                    r, "Could not find official timeslot for session", status_code=400
+                )
+
     def test_api_upload_bluesheet(self):
         url = urlreverse("ietf.meeting.views.api_upload_bluesheet")
         recmanrole = RoleFactory(group__type_id="ietf", name_id="recman")

--- a/ietf/meeting/api.py
+++ b/ietf/meeting/api.py
@@ -22,6 +22,7 @@ from ietf.meeting.serializers import (
     SessionVideoUrlSerializer,
 )
 from ietf.meeting.utils import (
+    SaveMaterialsError,
     generate_bluesheet,
     save_bluesheet,
     save_session_json_doc,
@@ -151,9 +152,13 @@ class SessionDataViewSet(viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
 
-    def applied(self, session, save_error=None):
-        if save_error:
-            raise serializers.ValidationError({"detail": save_error})
+    def handle_exception(self, exc):
+        # A helper that could not store what was pushed is a bad request, not a 500
+        if isinstance(exc, SaveMaterialsError):
+            exc = serializers.ValidationError({"detail": str(exc)})
+        return super().handle_exception(exc)
+
+    def applied(self, session):
         return Response(
             SessionUpdatedSerializer({"session_id": session.pk}).data,
             status=status.HTTP_200_OK,
@@ -173,12 +178,10 @@ class SessionDataViewSet(viewsets.GenericViewSet):
     def video_url(self, request, pk=None):
         session = self.get_object()
         data = self.validated(request)
-        return self.applied(
-            session,
-            save_session_video_url(
-                session, data["url"], Person.objects.get(name="(System)")
-            ),
+        save_session_video_url(
+            session, data["url"], Person.objects.get(name="(System)")
         )
+        return self.applied(session)
 
     @extend_schema(
         operation_id="meeting_session_set_recording_name",
@@ -214,15 +217,13 @@ class SessionDataViewSet(viewsets.GenericViewSet):
             "meeting/bluesheet.txt",
             {"data": data["bluesheet"], "session": session},
         )
-        return self.applied(
+        save_bluesheet(
+            request,
             session,
-            save_bluesheet(
-                request,
-                session,
-                ContentFile(text.encode("utf-8"), name="bluesheet.txt"),
-                Person.objects.get(name="(System)"),
-            ),
+            ContentFile(text.encode("utf-8"), name="bluesheet.txt"),
+            Person.objects.get(name="(System)"),
         )
+        return self.applied(session)
 
     @extend_schema(
         operation_id="meeting_session_add_attendees",
@@ -279,12 +280,11 @@ class SessionDataViewSet(viewsets.GenericViewSet):
                 ignore_conflicts=True,
             )
 
-            save_error = None
             if session.meeting.type_id == "interim":
-                save_error = generate_bluesheet(
+                generate_bluesheet(
                     request, session, Person.objects.get(name="(System)")
                 )
-            return self.applied(session, save_error)
+            return self.applied(session)
 
     @extend_schema(
         operation_id="meeting_session_upload_chatlog",
@@ -301,15 +301,10 @@ class SessionDataViewSet(viewsets.GenericViewSet):
     def chatlog(self, request, pk=None):
         session = self.get_object()
         data = self.validated(request)
-        return self.applied(
-            session,
-            save_session_json_doc(
-                session,
-                "chatlog",
-                data["chatlog"],
-                Person.objects.get(name="(System)"),
-            ),
+        save_session_json_doc(
+            session, "chatlog", data["chatlog"], Person.objects.get(name="(System)")
         )
+        return self.applied(session)
 
     @extend_schema(
         operation_id="meeting_session_upload_polls",
@@ -325,9 +320,7 @@ class SessionDataViewSet(viewsets.GenericViewSet):
     def polls(self, request, pk=None):
         session = self.get_object()
         data = self.validated(request)
-        return self.applied(
-            session,
-            save_session_json_doc(
-                session, "polls", data["polls"], Person.objects.get(name="(System)")
-            ),
+        save_session_json_doc(
+            session, "polls", data["polls"], Person.objects.get(name="(System)")
         )
+        return self.applied(session)

--- a/ietf/meeting/utils.py
+++ b/ietf/meeting/utils.py
@@ -62,6 +62,11 @@ from ietf.utils.log import log
 from ietf.utils.timezone import date_today
 
 
+class SaveMaterialsError(Exception):
+    """Indicates failure saving session materials"""
+    pass
+
+
 def session_time_for_sorting(session, use_meeting_date):
     if hasattr(session, "_otsa"):
         official_timeslot=session._otsa.timeslot
@@ -204,6 +209,10 @@ def bluesheet_data(session):
 
 
 def save_bluesheet(request, session, file, by, encoding='utf-8'):
+    """Store a bluesheet upload as a new revision of the session's document
+
+    Raises SaveMaterialsError if it cannot be saved.
+    """
     bluesheet_sp = session.presentations.filter(document__type='bluesheets').first()
     _, ext = os.path.splitext(file.name)
 
@@ -216,7 +225,7 @@ def save_bluesheet(request, session, file, by, encoding='utf-8'):
         ota = session.official_timeslotassignment()
         sess_time = ota and ota.timeslot.time
         if sess_time is None:
-            return "Could not find official timeslot for session"
+            raise SaveMaterialsError("Could not find official timeslot for session")
 
         if session.meeting.type_id=='ietf':
             name = 'bluesheets-%s-%s-%s' % (session.meeting.number, 
@@ -240,14 +249,17 @@ def save_bluesheet(request, session, file, by, encoding='utf-8'):
     filename = '%s-%s%s'% ( doc.name, doc.rev, ext)
     doc.uploaded_filename = filename
     e = NewRevisionDocEvent.objects.create(doc=doc, rev=doc.rev, by=by, type='new_revision', desc='New revision available: %s'%doc.rev)
-    save_error = handle_upload_file(file, filename, session.meeting, 'bluesheets', request=request, encoding=encoding)
-    if not save_error:
-        doc.save_with_history([e])
-        resolve_uploaded_material(meeting=session.meeting, doc=doc)
-    return save_error
+    handle_upload_file(file, filename, session.meeting, 'bluesheets', request=request, encoding=encoding)
+    doc.save_with_history([e])
+    resolve_uploaded_material(meeting=session.meeting, doc=doc)
 
 
 def generate_bluesheet(request, session, by):
+    """Render the session's attendance into a new bluesheet revision
+
+    Does nothing if the session has no attendance recorded. Raises
+    SaveMaterialsError if the bluesheet cannot be saved.
+    """
     data = bluesheet_data(session)
     if not data:
         return
@@ -255,7 +267,7 @@ def generate_bluesheet(request, session, by):
             'session': session,
             'data': data,
         })
-    return save_bluesheet(request, session, ContentFile(text.encode("utf-8"), name="unusednamepartsothereisanextension.txt"), by)
+    save_bluesheet(request, session, ContentFile(text.encode("utf-8"), name="unusednamepartsothereisanextension.txt"), by)
 
 
 def finalize(request, meeting):
@@ -277,9 +289,10 @@ def finalize(request, meeting):
 
         # Don't try to generate a bluesheet if it's before we had Attended records.
         if int(meeting.number) >= 108:
-            save_error = generate_bluesheet(request, session, request.user.person)
-            if save_error:
-                messages.error(request, save_error)
+            try:
+                generate_bluesheet(request, session, request.user.person)
+            except SaveMaterialsError as err:
+                messages.error(request, str(err))
     
     create_proceedings_templates(meeting)
     meeting.proceedings_final = True
@@ -682,11 +695,6 @@ class SessionNotScheduledError(Exception):
     pass
 
 
-class SaveMaterialsError(Exception):
-    """Indicates failure saving session materials"""
-    pass
-
-
 def save_session_minutes_revision(session, file, ext, request, encoding=None, apply_to_all=False, narrative=False):
     """Creates or updates session minutes records
 
@@ -755,7 +763,7 @@ def save_session_minutes_revision(session, file, ext, request, encoding=None, ap
     )
 
     # The way this function builds the filename it will never trigger the file delete in handle_file_upload.
-    save_error = handle_upload_file(
+    handle_upload_file(
         file=file,
         filename=doc.uploaded_filename,
         meeting=session.meeting,
@@ -763,10 +771,7 @@ def save_session_minutes_revision(session, file, ext, request, encoding=None, ap
         request=request,
         encoding=encoding,
     )
-    if save_error:
-        raise SaveMaterialsError(save_error)
-    else:
-        doc.save_with_history([e])
+    doc.save_with_history([e])
 
 
 def handle_upload_file(file, filename, meeting, subdir, request=None, encoding=None):
@@ -774,6 +779,8 @@ def handle_upload_file(file, filename, meeting, subdir, request=None, encoding=N
 
     This function takes a _binary mode_ file object, a filename and a meeting object and subdir as string.
     It saves the file to the appropriate directory, get_materials_path() + subdir.
+
+    Raises SaveMaterialsError if the file cannot be saved.
     """
     filename = Path(filename)
 
@@ -797,7 +804,7 @@ def handle_upload_file(file, filename, meeting, subdir, request=None, encoding=N
                 try:
                     text = text.decode(encoding)
                 except LookupError as e:
-                    return (
+                    raise SaveMaterialsError(
                         f"Failure trying to save '{filename}': "
                         f"Could not identify the file encoding, got '{str(e)[:120]}'. "
                         f"Hint: Try to upload as UTF-8."
@@ -806,7 +813,10 @@ def handle_upload_file(file, filename, meeting, subdir, request=None, encoding=N
                 try:
                     text = smart_str(text)
                 except UnicodeDecodeError as e:
-                    return "Failure trying to save '%s'. Hint: Try to upload as UTF-8: %s..." % (filename, str(e)[:120])
+                    raise SaveMaterialsError(
+                        "Failure trying to save '%s'. Hint: Try to upload as UTF-8: %s..."
+                        % (filename, str(e)[:120])
+                    )
             # Whole file sanitization; add back what's missing from a complete
             # document (sanitize will remove these).
             clean = clean_html(text)
@@ -832,7 +842,6 @@ def handle_upload_file(file, filename, meeting, subdir, request=None, encoding=N
             # TODO-BLOBSTORE: See above question about refactoring
             store_bytes(subdir, filename.name, b"".join(chunks))
 
-    return None
 
 def new_doc_for_session(type_id, session):
     typename = DocTypeName.objects.get(slug=type_id)
@@ -861,7 +870,7 @@ def new_doc_for_session(type_id, session):
 def save_session_json_doc(session, type_id, data, by):
     """Store a chatlog or polls upload as a new revision of the session's document
 
-    Returns an error message, or None on success.
+    Raises SaveMaterialsError if it cannot be stored.
     """
     presentation = session.presentations.filter(document__type=type_id).first()
     if presentation:
@@ -872,7 +881,7 @@ def save_session_json_doc(session, type_id, data, by):
     else:
         doc = new_doc_for_session(type_id, session)
         if doc is None:
-            return "Could not find official timeslot for session"
+            raise SaveMaterialsError("Could not find official timeslot for session")
     filename = f"{doc.name}-{doc.rev}.json"
     doc.uploaded_filename = filename
     write_doc_for_session(session, type_id, filename, json.dumps(data))
@@ -885,7 +894,6 @@ def save_session_json_doc(session, type_id, data, by):
     )
     doc.save_with_history([e])
     resolve_uploaded_material(meeting=session.meeting, doc=doc)
-    return None
 
 
 # TODO-BLOBSTORE - consider adding doc to this signature and factoring away type_id
@@ -1237,8 +1245,8 @@ def store_blobs_for_one_meeting(meeting: Meeting):
 def save_session_video_url(session, url, by):
     """Point the session's video recording at url
 
-    Updates the newest existing video recording, or creates one. Returns an error
-    message, or None on success.
+    Updates the newest existing video recording, or creates one. Raises
+    SaveMaterialsError if there is no timeslot to name a new recording after.
     """
     recordings = [r for r in session.recordings() if "video" in r.title.lower()]
     if recordings:
@@ -1253,10 +1261,10 @@ def save_session_video_url(session, url, by):
             )
             doc.external_url = url
             doc.save_with_history([e])
-        return None
+        return
     ota = session.official_timeslotassignment()
     if ota is None:
-        return "Could not find official timeslot for session"
+        raise SaveMaterialsError("Could not find official timeslot for session")
     time = ota.timeslot.time
     title = "Video recording for %s on %s at %s" % (
         session.group.acronym,
@@ -1264,7 +1272,6 @@ def save_session_video_url(session, url, by):
         time.time(),
     )
     create_recording(session, url, title=title, user=by)
-    return None
 
 
 def create_recording(session, url, title=None, user=None):

--- a/ietf/meeting/views.py
+++ b/ietf/meeting/views.py
@@ -3323,9 +3323,10 @@ def upload_session_bluesheets(request, session_id, num):
                 )
 
 
-            save_error = save_bluesheet(request, session, file, request.user.person, encoding=form.file_encoding[file.name])
-            if save_error:
-                form.add_error(None, save_error)
+            try:
+                save_bluesheet(request, session, file, request.user.person, encoding=form.file_encoding[file.name])
+            except SaveMaterialsError as err:
+                form.add_error(None, str(err))
             else:
                 messages.success(request, 'Successfully uploaded bluesheets.')
                 return redirect('ietf.meeting.views.session_details',num=num,acronym=session.group.acronym)
@@ -3589,9 +3590,10 @@ def upload_session_agenda(request, session_id, num):
                 encoding=form.file_encoding[file.name]
             except AttributeError:
                 encoding=None
-            save_error = handle_upload_file(file, filename, session.meeting, 'agenda', request=request, encoding=encoding)
-            if save_error:
-                form.add_error(None, save_error)
+            try:
+                handle_upload_file(file, filename, session.meeting, 'agenda', request=request, encoding=encoding)
+            except SaveMaterialsError as err:
+                form.add_error(None, str(err))
             else:
                 doc.save_with_history([e])
                 resolve_uploaded_material(meeting=session.meeting, doc=doc)
@@ -3771,16 +3773,19 @@ def upload_session_slides(request, session_id, num, name=None):
                 rev=doc.rev,
             )
             # The way this function builds the filename it will never trigger the file delete in handle_file_upload.
-            save_error = handle_upload_file(
-                file,
-                filename,
-                session.meeting,
-                "slides",
-                request=request,
-                encoding=form.file_encoding[file.name],
-            )
-            if save_error:
-                form.add_error(None, save_error)
+            save_failed = False
+            try:
+                handle_upload_file(
+                    file,
+                    filename,
+                    session.meeting,
+                    "slides",
+                    request=request,
+                    encoding=form.file_encoding[file.name],
+                )
+            except SaveMaterialsError as err:
+                form.add_error(None, str(err))
+                save_failed = True
             else:
                 doc.save_with_history([e])
                 post_process(doc)
@@ -3801,7 +3806,7 @@ def upload_session_slides(request, session_id, num, name=None):
                     except MeetechoAPIError as err:
                         log(f"Error in SlidesManager.revise(): {err}")
 
-            if not save_error:
+            if not save_failed:
                 messages.success(
                     request,
                     f"Successfully uploaded slides as revision {doc.rev} of {doc.name}.",
@@ -5104,9 +5109,10 @@ def api_set_session_video_url(request):
     except ValidationError:
         return err(400, f"Invalid url value: '{incoming_url}'")
 
-    save_error = save_session_video_url(session, incoming_url, request.user.person)
-    if save_error:
-        return err(400, save_error)
+    try:
+        save_session_video_url(session, incoming_url, request.user.person)
+    except SaveMaterialsError as save_err:
+        return err(400, str(save_err))
     return HttpResponse(
         "Done",
         status=200,
@@ -5287,9 +5293,10 @@ def api_add_session_attendees(request):
             Attended.objects.bulk_create(to_create, ignore_conflicts=True)
 
     if session.meeting.type_id == "interim":
-        save_error = generate_bluesheet(request, session, request.user.person)
-        if save_error:
-            return err(400, save_error)
+        try:
+            generate_bluesheet(request, session, request.user.person)
+        except SaveMaterialsError as save_err:
+            return err(400, str(save_err))
 
     return HttpResponse(
         "Done",
@@ -5325,11 +5332,12 @@ def api_upload_chatlog(request):
     session = Session.objects.filter(pk=session_id).first()
     if not session:
         return err(400, "Invalid session")
-    save_error = save_session_json_doc(
-        session, 'chatlog', apidata['chatlog'], request.user.person
-    )
-    if save_error:
-        return err(400, save_error)
+    try:
+        save_session_json_doc(
+            session, 'chatlog', apidata['chatlog'], request.user.person
+        )
+    except SaveMaterialsError as save_err:
+        return err(400, str(save_err))
     return HttpResponse(
         "Done",
         status=200,
@@ -5363,11 +5371,12 @@ def api_upload_polls(request):
     session = Session.objects.filter(pk=session_id).first()
     if not session:
         return err(400, "Invalid session")
-    save_error = save_session_json_doc(
-        session, 'polls', apidata['polls'], request.user.person
-    )
-    if save_error:
-        return err(400, save_error)
+    try:
+        save_session_json_doc(
+            session, 'polls', apidata['polls'], request.user.person
+        )
+    except SaveMaterialsError as save_err:
+        return err(400, str(save_err))
     return HttpResponse(
         "Done",
         status=200,
@@ -5428,10 +5437,11 @@ def api_upload_bluesheet(request):
     os.close(fd)
     with open(name, "w") as file:
         file.write(text)
-    with open(name, "br") as file:
-        save_err = save_bluesheet(request, session, file, request.user.person)
-    if save_err:
-        return err(400, save_err)
+    try:
+        with open(name, "br") as file:
+            save_bluesheet(request, session, file, request.user.person)
+    except SaveMaterialsError as save_err:
+        return err(400, str(save_err))
     return HttpResponse(
         "Done",
         status=200,

--- a/ietf/meeting/views_proceedings.py
+++ b/ietf/meeting/views_proceedings.py
@@ -14,7 +14,11 @@ from ietf.meeting.forms import FileUploadForm
 from ietf.meeting.models import Meeting, MeetingHost
 from ietf.meeting.helpers import get_meeting
 from ietf.name.models import ProceedingsMaterialTypeName
-from ietf.meeting.utils import handle_upload_file, resolve_uploaded_material
+from ietf.meeting.utils import (
+    SaveMaterialsError,
+    handle_upload_file,
+    resolve_uploaded_material,
+)
 from ietf.utils.text import xslugify
 
 class UploadProceedingsMaterialForm(FileUploadForm):
@@ -102,9 +106,10 @@ def save_proceedings_material_doc(meeting, material_type, title, request, file=N
         if not created:
             doc.rev = '{:02}'.format(int(doc.rev) + 1)
         filename = f'{doc.name}-{doc.rev}{Path(file.name).suffix}'
-        save_error = handle_upload_file(file, filename, meeting, 'procmaterials', )
-        if save_error is not None:
-            raise RuntimeError(save_error)
+        try:
+            handle_upload_file(file, filename, meeting, 'procmaterials', )
+        except SaveMaterialsError as err:
+            raise RuntimeError(str(err))
 
         doc.uploaded_filename = filename
         doc.external_url = ''


### PR DESCRIPTION
Converts the material-saving helpers from "return an error message, or None on
success" to raising.

Addresses the two review comments on #11719 about that pattern.

## What changed

`handle_upload_file`, `save_bluesheet`, `generate_bluesheet`, `save_session_json_doc`
and `save_session_video_url` now raise.

They raise `SaveMaterialsError`, which **already existed** in
`ietf/meeting/utils.py` -- it was raised by `save_session_minutes_revision` and caught
in three views. So this consolidates onto the convention the module already had rather
than introducing one. `save_session_minutes_revision` no longer has to convert a
returned message into that exception, and `save_bluesheet` loses its `if not
save_error:` guard in favour of straight-line code.

## Internal only

Every caller reproduces the response it produced before: the same 400 and message text
from the API endpoints, the same form errors on the bluesheet, agenda and slides
uploads, the same `messages.error` from `finalize`, and the same `RuntimeError` out of
the proceedings material upload.

One caller needed care. The slides upload reads its error again *after* a Meetecho sync
that has to run whether or not saving succeeded, so a plain try/except would have
swallowed the gate on its success message. That view keeps a `save_failed` flag.

## Test evidence

Adds four subtests pinning the legacy endpoints' status and message text for a session
with no official timeslot. That same test file passes unchanged against `main`, where
the helpers still return strings -- so the endpoints answer identically either way.

Those tests also cover the three previously uncovered `return err(400, save_error)`
lines codecov flagged on #11719.

## Follows

#11719, where this was raised in review. One commit, rebased onto main.